### PR TITLE
Fix job array length

### DIFF
--- a/src/main/java/io/kontur/eventapi/config/WorkerScheduler.java
+++ b/src/main/java/io/kontur/eventapi/config/WorkerScheduler.java
@@ -174,7 +174,7 @@ public class WorkerScheduler {
     @Scheduled(initialDelayString = "${scheduler.pdcMapSrvSearch.initialDelay}", fixedDelayString = "${scheduler.pdcMapSrvSearch.fixedDelay}")
     public void startPdcMapSrvSearch() {
         if (Boolean.parseBoolean(pdcMapSrvSearchEnabled)) {
-            PdcMapSrvSearchJob[] jobs = new PdcMapSrvSearchJob[26];
+            PdcMapSrvSearchJob[] jobs = new PdcMapSrvSearchJob[PDC_MAP_SRV_IDS.length];
             jobs = pdcMapSrvSearchJobs.getJobs().toArray(jobs);
             for (int i = 0; i < PDC_MAP_SRV_IDS.length; i++) {
                 PdcMapSrvSearchJob job = jobs[i];


### PR DESCRIPTION
## Summary
- make PdcMapSrvSearchJob array size dynamic

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability by ensuring background jobs are initialized dynamically based on the current number of job identifiers, preventing potential issues when the number of jobs changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->