### PR TITLE
Fix EofException logs

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -278,3 +278,6 @@ sentry:
   # Set traces-sample-rate to 1.0 to capture 100% of transactions for performance monitoring.
   # We recommend adjusting this value in production.
   traces-sample-rate: 1.0
+  # Ignore Jetty EOFException caused by client disconnects
+  ignored-exceptions-for-type:
+    - org.eclipse.jetty.io.EofException


### PR DESCRIPTION
## Summary
- ignore `org.eclipse.jetty.io.EofException` in Sentry

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration to ignore specific server disconnect exceptions in Sentry error tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->