### PR TITLE
Sort observations uuid arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Added
 
 #### Changed
+ - Sorted `observations` arrays in `feed_data` table and inside episodes
 
 #### Removed
 

--- a/src/main/java/io/kontur/eventapi/typehandler/FeedEpisodeTypeHandler.java
+++ b/src/main/java/io/kontur/eventapi/typehandler/FeedEpisodeTypeHandler.java
@@ -10,8 +10,8 @@ import java.sql.CallableStatement;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import static io.kontur.eventapi.util.JsonUtil.readJson;
 import static io.kontur.eventapi.util.JsonUtil.writeJson;
@@ -21,6 +21,15 @@ public class FeedEpisodeTypeHandler extends BaseTypeHandler<List<FeedEpisode>> {
     @Override
     public void setNonNullParameter(PreparedStatement ps, int i, List<FeedEpisode> parameter,
                                     JdbcType jdbcType) throws SQLException {
+        parameter.forEach(ep -> {
+            if (ep.getObservations() != null && !ep.getObservations().isEmpty()) {
+                Set<UUID> sorted = ep.getObservations().stream()
+                        .filter(Objects::nonNull)
+                        .sorted()
+                        .collect(Collectors.toCollection(LinkedHashSet::new));
+                ep.setObservations(sorted);
+            }
+        });
         ps.setObject(i, writeJson(parameter));
     }
 
@@ -30,7 +39,17 @@ public class FeedEpisodeTypeHandler extends BaseTypeHandler<List<FeedEpisode>> {
         if (StringUtils.isEmpty(value)) {
             return Collections.emptyList();
         }
-        return readJson(value, new TypeReference<>() {});
+        List<FeedEpisode> episodes = readJson(value, new TypeReference<>() {});
+        episodes.forEach(ep -> {
+            if (ep.getObservations() != null && !ep.getObservations().isEmpty()) {
+                Set<UUID> sorted = ep.getObservations().stream()
+                        .filter(Objects::nonNull)
+                        .sorted()
+                        .collect(Collectors.toCollection(LinkedHashSet::new));
+                ep.setObservations(sorted);
+            }
+        });
+        return episodes;
     }
 
     @Override
@@ -39,7 +58,17 @@ public class FeedEpisodeTypeHandler extends BaseTypeHandler<List<FeedEpisode>> {
         if (StringUtils.isEmpty(value)) {
             return Collections.emptyList();
         }
-        return readJson(value, new TypeReference<>() {});
+        List<FeedEpisode> episodes = readJson(value, new TypeReference<>() {});
+        episodes.forEach(ep -> {
+            if (ep.getObservations() != null && !ep.getObservations().isEmpty()) {
+                Set<UUID> sorted = ep.getObservations().stream()
+                        .filter(Objects::nonNull)
+                        .sorted()
+                        .collect(Collectors.toCollection(LinkedHashSet::new));
+                ep.setObservations(sorted);
+            }
+        });
+        return episodes;
     }
 
     @Override
@@ -48,6 +77,16 @@ public class FeedEpisodeTypeHandler extends BaseTypeHandler<List<FeedEpisode>> {
         if (StringUtils.isEmpty(value)) {
             return Collections.emptyList();
         }
-        return readJson(value, new TypeReference<>() {});
+        List<FeedEpisode> episodes = readJson(value, new TypeReference<>() {});
+        episodes.forEach(ep -> {
+            if (ep.getObservations() != null && !ep.getObservations().isEmpty()) {
+                Set<UUID> sorted = ep.getObservations().stream()
+                        .filter(Objects::nonNull)
+                        .sorted()
+                        .collect(Collectors.toCollection(LinkedHashSet::new));
+                ep.setObservations(sorted);
+            }
+        });
+        return episodes;
     }
 }

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -70,3 +70,6 @@ databaseChangeLog:
 - include:
     relativeToChangelogFile: true
     file: v1.21.0/v1.21.0.yaml
+- include:
+    relativeToChangelogFile: true
+    file: v1.22.0/v1.22.0.yaml

--- a/src/main/resources/db/changelog/v1.22.0/sort-feed-data-observations.sql
+++ b/src/main/resources/db/changelog/v1.22.0/sort-feed-data-observations.sql
@@ -1,0 +1,22 @@
+--changeset event-api-migrations:v1.22.0/sort-feed-data-observations.sql runOnChange:false
+
+-- sort observations array in feed_data table
+update feed_data
+set observations = (
+    select array_agg(o order by o)
+    from unnest(observations) o
+)
+where observations is not null;
+
+-- sort observations arrays inside episodes jsonb
+update feed_data
+set episodes = (
+    select jsonb_agg(
+               jsonb_set(ep, '{observations}',
+                          coalesce((select jsonb_agg(val order by val)
+                                   from jsonb_array_elements_text(ep->'observations') val), '[]'::jsonb),
+                          false)
+               order by ord)
+    from jsonb_array_elements(episodes) with ordinality as e(ep, ord)
+)
+where episodes is not null;

--- a/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
+++ b/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
@@ -1,0 +1,4 @@
+databaseChangeLog:
+  - include:
+      relativeToChangelogFile: true
+      file: sort-feed-data-observations.sql


### PR DESCRIPTION
## Summary
- sort observation UUIDs before storing them
- keep episode observation lists ordered in type handler
- add migration to sort existing observations arrays
- document database change

## Testing
- `mvn -q -DskipTests=false test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_6850129b8e248324952d2fee25ff0355

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated documentation to reflect that observation arrays are now sorted in relevant data tables and episode records.
  - Improved consistency of observation data by ensuring arrays are sorted and free of null values in both the application and database.
  - Added a new database migration to sort observation arrays in existing records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->