### PR TITLE
Refactor cost field to JSON

### DIFF
--- a/src/main/java/io/kontur/eventapi/dao/mapper/NormalizedObservationsMapper.java
+++ b/src/main/java/io/kontur/eventapi/dao/mapper/NormalizedObservationsMapper.java
@@ -6,7 +6,6 @@ import io.kontur.eventapi.entity.Severity;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
-import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.*;
@@ -32,7 +31,7 @@ public interface NormalizedObservationsMapper {
                @Param("sourceUpdatedAt") OffsetDateTime sourceUpdatedAt,
                @Param("region") String region,
                @Param("urls") List<String> urls,
-               @Param("cost") BigDecimal cost,
+               @Param("cost") Map<String, Object> cost,
                @Param("loss") Map<String, Object> loss,
                @Param("severityData") Map<String, Object> severityData,
                @Param("point") String point,

--- a/src/main/java/io/kontur/eventapi/entity/NormalizedObservation.java
+++ b/src/main/java/io/kontur/eventapi/entity/NormalizedObservation.java
@@ -3,7 +3,6 @@ package io.kontur.eventapi.entity;
 import lombok.Data;
 import org.wololo.geojson.FeatureCollection;
 
-import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.*;
 
@@ -28,7 +27,7 @@ public class NormalizedObservation {
     private OffsetDateTime sourceUpdatedAt;
     private String region;
     private List<String> urls = new ArrayList<>();
-    private BigDecimal cost;
+    private Map<String, Object> cost = new HashMap<>();
     private Map<String, Object> loss = new HashMap<>();
     private Map<String, Object> severityData = new HashMap<>();
     private String point;

--- a/src/main/java/io/kontur/eventapi/nifc/normalization/LocationsNifcNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/nifc/normalization/LocationsNifcNormalizer.java
@@ -5,6 +5,8 @@ import io.kontur.eventapi.entity.NormalizedObservation;
 import org.springframework.stereotype.Component;
 import org.wololo.geojson.Feature;
 
+import java.math.BigDecimal;
+import java.util.HashMap;
 import java.util.Map;
 
 import static io.kontur.eventapi.nifc.converter.NifcDataLakeConverter.NIFC_LOCATIONS_PROVIDER;
@@ -44,6 +46,13 @@ public class LocationsNifcNormalizer extends NifcNormalizer {
         Double lon = readDouble(props, "InitialLongitude");
         Double lat = readDouble(props, "InitialLatitude");
         observation.setPoint(makeWktPoint(lon, lat));
+
+        Map<String, Object> cost = new HashMap<>();
+        Double supCost = readDouble(props, "EstimatedCostToDate");
+        if (supCost != null) {
+            cost.put("suppression_cost", BigDecimal.valueOf(supCost));
+        }
+        observation.setCost(cost);
 
         Double calculatedAcres = readDouble(props, "CalculatedAcres");
         Double incidentSize = readDouble(props, "IncidentSize");

--- a/src/main/java/io/kontur/eventapi/nifc/normalization/PerimetersNifcNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/nifc/normalization/PerimetersNifcNormalizer.java
@@ -4,6 +4,8 @@ import io.kontur.eventapi.entity.DataLake;
 import io.kontur.eventapi.entity.NormalizedObservation;
 import org.springframework.stereotype.Component;
 import org.wololo.geojson.Feature;
+import java.math.BigDecimal;
+import java.util.HashMap;
 import java.util.Map;
 
 import static io.kontur.eventapi.nifc.converter.NifcDataLakeConverter.NIFC_PERIMETERS_PROVIDER;
@@ -48,6 +50,14 @@ public class PerimetersNifcNormalizer extends NifcNormalizer {
         Double lon = selectFirstNotNull(readDouble(props, "attr_InitialLongitude"), readDouble(props, "irwin_InitialLongitude"));
         Double lat = selectFirstNotNull(readDouble(props, "attr_InitialLatitude"), readDouble(props, "irwin_InitialLatitude"));
         observation.setPoint(makeWktPoint(lon, lat));
+
+        Map<String, Object> cost = new HashMap<>();
+        Double supCost = selectFirstNotNull(readDouble(props, "attr_EstimatedCostToDate"),
+                readDouble(props, "irwin_EstimatedCostToDate"));
+        if (supCost != null) {
+            cost.put("suppression_cost", BigDecimal.valueOf(supCost));
+        }
+        observation.setCost(cost);
 
         double areaSqKm2 = convertAcresToSqKm(readDouble(props, "poly_GISAcres"));
         long durationHours = between(observation.getStartedAt(), observation.getEndedAt()).toHours();

--- a/src/main/java/io/kontur/eventapi/stormsnoaa/normalization/StormsNoaaNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/stormsnoaa/normalization/StormsNoaaNormalizer.java
@@ -131,7 +131,17 @@ public class StormsNoaaNormalizer extends Normalizer {
         normalizedObservation.setExternalEpisodeId(parseString(data, "EVENT_ID"));
         normalizedObservation.setDescription(parseString(data, "EPISODE_NARRATIVE"));
         normalizedObservation.setEpisodeDescription(parseString(data, "EVENT_NARRATIVE"));
-        normalizedObservation.setCost(getCost(parseString(data, "DAMAGE_PROPERTY")));
+
+        Map<String, Object> cost = new HashMap<>();
+        BigDecimal damageCrops = getCost(parseString(data, "DAMAGE_CROPS"));
+        if (damageCrops != null) {
+            cost.put("damage_crops_cost", damageCrops);
+        }
+        BigDecimal damageProperty = getCost(parseString(data, "DAMAGE_PROPERTY"));
+        if (damageProperty != null) {
+            cost.put("damage_property_cost", damageProperty);
+        }
+        normalizedObservation.setCost(cost);
         normalizedObservation.setEventSeverity(convertFujitaScale(parseString(data, "TOR_F_SCALE")));
 
         setGeometry(data, normalizedObservation);

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -70,3 +70,6 @@ databaseChangeLog:
 - include:
     relativeToChangelogFile: true
     file: v1.21.0/v1.21.0.yaml
+- include:
+    relativeToChangelogFile: true
+    file: v1.22.0/v1.22.0.yaml

--- a/src/main/resources/db/changelog/v1.22.0/alter-cost-column.sql
+++ b/src/main/resources/db/changelog/v1.22.0/alter-cost-column.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset event-api-migrations:v1.22.0/alter-cost-column.sql runOnChange:true
+alter table normalized_observations
+    alter column cost type jsonb using case when cost is null then null else jsonb_build_object('legacy_cost', cost) end;

--- a/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
+++ b/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
@@ -1,0 +1,4 @@
+databaseChangeLog:
+  - include:
+      relativeToChangelogFile: true
+      file: alter-cost-column.sql

--- a/src/main/resources/db/mappers/NormalizedObservationsMapper.xml
+++ b/src/main/resources/db/mappers/NormalizedObservationsMapper.xml
@@ -17,7 +17,7 @@
             #{observationId}, #{externalEventId}, #{externalEpisodeId}, #{provider}, #{origin}, #{name}, #{properName},
             #{description}, #{episodeDescription}, #{type}, #{eventSeverity}, #{active}, #{loadedAt}, #{startedAt},
             #{endedAt}, #{sourceUpdatedAt}, #{region}, #{urls, typeHandler=io.kontur.eventapi.typehandler.StringArrayTypeHandler},
-            #{cost},
+            #{cost,typeHandler=io.kontur.eventapi.typehandler.MapTypeHandler}::jsonb,
             <if test='loss != null'>#{loss,typeHandler=io.kontur.eventapi.typehandler.MapTypeHandler}::jsonb,</if>
             <if test='severityData != null'>#{severityData,typeHandler=io.kontur.eventapi.typehandler.MapTypeHandler}::jsonb,</if>
             <if test='point != null'>'SRID=4326;${point}'::geometry,</if>
@@ -30,7 +30,7 @@
             episode_description = #{episodeDescription}, type = #{type}, event_severity = #{eventSeverity},
             active = #{active}, loaded_at = #{loadedAt}, started_at = #{startedAt}, ended_at = #{endedAt},
             source_updated_at = #{sourceUpdatedAt}, region = #{region},
-            urls = #{urls, typeHandler=io.kontur.eventapi.typehandler.StringArrayTypeHandler}, cost = #{cost},
+            urls = #{urls, typeHandler=io.kontur.eventapi.typehandler.StringArrayTypeHandler}, cost = #{cost,typeHandler=io.kontur.eventapi.typehandler.MapTypeHandler}::jsonb,
             <if test='loss != null'>loss = #{loss,typeHandler=io.kontur.eventapi.typehandler.MapTypeHandler}::jsonb,</if>
             <if test='severityData != null'>severity_data = #{severityData,typeHandler=io.kontur.eventapi.typehandler.MapTypeHandler}::jsonb,</if>
             <if test='point != null'>point = 'SRID=4326;${point}'::geometry,</if>
@@ -133,7 +133,7 @@
         <result property="sourceUpdatedAt" column="source_updated_at"/>
         <result property="region" column="region"/>
         <result property="urls" column="urls" typeHandler="io.kontur.eventapi.typehandler.StringArrayTypeHandler"/>
-        <result property="cost" column="cost"/>
+        <result property="cost" column="cost" typeHandler="io.kontur.eventapi.typehandler.MapTypeHandler"/>
         <result property="loss" column="loss" typeHandler="io.kontur.eventapi.typehandler.MapTypeHandler"/>
         <result property="severityData" column="severity_data" typeHandler="io.kontur.eventapi.typehandler.MapTypeHandler"/>
         <result property="point" column="point"/>

--- a/src/test/java/io/kontur/eventapi/firms/normalization/FirmsNormalizerIT.java
+++ b/src/test/java/io/kontur/eventapi/firms/normalization/FirmsNormalizerIT.java
@@ -70,7 +70,7 @@ public class FirmsNormalizerIT extends AbstractCleanableIntegrationTest {
         assertNull(observation.getEndedAt());
         assertTrue(observation.getUrls().isEmpty());
         assertNull(observation.getActive());
-        assertNull(observation.getCost());
+        assertTrue(observation.getCost().isEmpty());
         assertNull(observation.getRegion());
 
     }

--- a/src/test/java/io/kontur/eventapi/gdacs/normalization/GdacsNormalizerIT.java
+++ b/src/test/java/io/kontur/eventapi/gdacs/normalization/GdacsNormalizerIT.java
@@ -120,7 +120,7 @@ public class GdacsNormalizerIT extends AbstractIntegrationTest {
 
         assertTrue(observation.getActive());
         assertNull(observation.getPoint());
-        assertNull(observation.getCost());
+        assertTrue(observation.getCost().isEmpty());
         assertNotNull(observation.getRegion());
 
         assertNull(observation.getGeometries());
@@ -151,7 +151,7 @@ public class GdacsNormalizerIT extends AbstractIntegrationTest {
         assertNull(observation.getDescription());
         assertNull(observation.getEpisodeDescription());
         assertNull(observation.getPoint());
-        assertNull(observation.getCost());
+        assertTrue(observation.getCost().isEmpty());
         assertNotNull(observation.getRegion());
     }
 

--- a/src/test/java/io/kontur/eventapi/job/EventExpirationJobIT.java
+++ b/src/test/java/io/kontur/eventapi/job/EventExpirationJobIT.java
@@ -125,8 +125,8 @@ public class EventExpirationJobIT extends AbstractCleanableIntegrationTest {
 		assertEquals(pastEvent ? pastDate : futureDate, observation.getEndedAt());
 		assertEquals(pastEvent ? pastDate : futureDate, observation.getSourceUpdatedAt());
 		assertEquals(region, observation.getRegion());
-		assertEquals(urls, observation.getUrls());
-		assertNull(observation.getCost());
+                assertEquals(urls, observation.getUrls());
+                assertTrue(observation.getCost().isEmpty());
 		assertEquals(loss, observation.getLoss().get(INFRASTRUCTURE_REPLACEMENT_VALUE));
 		assertEquals(autoExpire, observation.getAutoExpire());
 		assertEquals(1, observation.getGeometries().getFeatures().length);

--- a/src/test/java/io/kontur/eventapi/nifc/normalization/LocationsNifcNormalizerTest.java
+++ b/src/test/java/io/kontur/eventapi/nifc/normalization/LocationsNifcNormalizerTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.UUID;
+import java.math.BigDecimal;
 
 import static io.kontur.eventapi.TestUtil.readFile;
 import static io.kontur.eventapi.nifc.converter.NifcDataLakeConverter.NIFC_LOCATIONS_PROVIDER;
@@ -43,7 +44,7 @@ class LocationsNifcNormalizerTest {
         assertEquals(getDateTimeFromMilli(1626488389000L), observation.getStartedAt());
         assertNull(observation.getEpisodeDescription());
         assertNull(observation.getActive());
-        assertNull(observation.getCost());
+        assertEquals(BigDecimal.valueOf(23000000), observation.getCost().get("suppression_cost"));
         assertNull(observation.getRegion());
         assertTrue(observation.getUrls().isEmpty());
         assertNull(observation.getExternalEpisodeId());

--- a/src/test/java/io/kontur/eventapi/nifc/normalization/PerimetersNifcNormalizerTest.java
+++ b/src/test/java/io/kontur/eventapi/nifc/normalization/PerimetersNifcNormalizerTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.UUID;
+import java.math.BigDecimal;
 
 import static io.kontur.eventapi.TestUtil.readFile;
 import static io.kontur.eventapi.nifc.converter.NifcDataLakeConverter.NIFC_PERIMETERS_PROVIDER;
@@ -43,7 +44,7 @@ class PerimetersNifcNormalizerTest {
         assertEquals(getDateTimeFromMilli(1637450954000L), observation.getStartedAt());
         assertNull(observation.getEpisodeDescription());
         assertNull(observation.getActive());
-        assertNull(observation.getCost());
+        assertEquals(BigDecimal.valueOf(35000), observation.getCost().get("suppression_cost"));
         assertNull(observation.getRegion());
         assertTrue(observation.getUrls().isEmpty());
         assertNull(observation.getExternalEpisodeId());

--- a/src/test/java/io/kontur/eventapi/pdc/normalization/PdcMapSrvNormalizerTest.java
+++ b/src/test/java/io/kontur/eventapi/pdc/normalization/PdcMapSrvNormalizerTest.java
@@ -42,7 +42,7 @@ class PdcMapSrvNormalizerTest {
         assertNull(observation.getEpisodeDescription());
         assertEquals(EventType.CYCLONE, observation.getType());
         assertNull(observation.getActive());
-        assertNull(observation.getCost());
+        assertTrue(observation.getCost().isEmpty());
         assertNull(observation.getRegion());
         assertEquals(dataLake.getLoadedAt(), observation.getLoadedAt());
         assertNull(observation.getStartedAt());

--- a/src/test/java/io/kontur/eventapi/pdc/normalization/PdcSqsMessageNormalizerTest.java
+++ b/src/test/java/io/kontur/eventapi/pdc/normalization/PdcSqsMessageNormalizerTest.java
@@ -58,7 +58,7 @@ class PdcSqsMessageNormalizerTest {
 
         assertNull(observation.getActive());
         assertTrue(observation.getUrls().isEmpty());
-        assertNull(observation.getCost());
+        assertTrue(observation.getCost().isEmpty());
         assertNull(observation.getRegion());
         assertNull(observation.getProperName());
         assertNull(observation.getNormalizedAt());
@@ -96,7 +96,7 @@ class PdcSqsMessageNormalizerTest {
 
         assertNull(observation.getActive());
         assertTrue(observation.getUrls().isEmpty());
-        assertNull(observation.getCost());
+        assertTrue(observation.getCost().isEmpty());
         assertNull(observation.getRegion());
         assertNull(observation.getProperName());
         assertNull(observation.getNormalizedAt());
@@ -134,7 +134,7 @@ class PdcSqsMessageNormalizerTest {
         assertEquals(observation.getUrls(), List.of("snc url"));
         assertTrue(observation.getActive());
 
-        assertNull(observation.getCost());
+        assertTrue(observation.getCost().isEmpty());
         assertNull(observation.getRegion());
         assertNull(observation.getProperName());
         assertNull(observation.getNormalizedAt());

--- a/src/test/java/io/kontur/eventapi/staticdata/normalization/AustraliaWildfireNormalizerTest.java
+++ b/src/test/java/io/kontur/eventapi/staticdata/normalization/AustraliaWildfireNormalizerTest.java
@@ -81,7 +81,7 @@ class AustraliaWildfireNormalizerTest {
 
         assertNull(observation.getDescription());
         assertNull(observation.getEpisodeDescription());
-        assertNull(observation.getCost());
+        assertTrue(observation.getCost().isEmpty());
         assertNull(observation.getRegion());
         assertNull(observation.getUrls());
         assertNull(observation.getExternalEpisodeId());

--- a/src/test/java/io/kontur/eventapi/staticdata/normalization/CommonStaticNormalizerIT.java
+++ b/src/test/java/io/kontur/eventapi/staticdata/normalization/CommonStaticNormalizerIT.java
@@ -48,7 +48,7 @@ class CommonStaticNormalizerIT extends AbstractCleanableIntegrationTest {
         assertEquals(dataLake.getProvider(), normalizedObservation.getProvider());
         assertFalse(normalizedObservation.getActive());
         assertEquals("Tornado - Stratford, Canada", normalizedObservation.getName());
-        assertEquals(BigDecimal.valueOf(100), normalizedObservation.getCost());
+        assertEquals(BigDecimal.valueOf(100), normalizedObservation.getCost().get("damage_property_cost"));
         assertEquals(Severity.MINOR, normalizedObservation.getEventSeverity());
         assertEquals("tornado", normalizedObservation.getDescription());
         assertEquals(EventType.TORNADO, normalizedObservation.getType());

--- a/src/test/java/io/kontur/eventapi/stormsnoaa/normalization/StormsNoaaNormalizerIT.java
+++ b/src/test/java/io/kontur/eventapi/stormsnoaa/normalization/StormsNoaaNormalizerIT.java
@@ -50,7 +50,7 @@ class StormsNoaaNormalizerIT extends AbstractCleanableIntegrationTest {
         assertNull(normalizedObservation.getExternalEventId());
         assertNull(normalizedObservation.getEpisodeDescription());
         assertNull(normalizedObservation.getDescription());
-        assertEquals(BigDecimal.valueOf(250000), normalizedObservation.getCost());
+        assertEquals(BigDecimal.valueOf(250000), normalizedObservation.getCost().get("damage_property_cost"));
         assertEquals(OffsetDateTime.parse("1950-04-28T13:20:00Z"), normalizedObservation.getStartedAt());
         assertEquals(OffsetDateTime.parse("1950-04-29T14:45:00Z"), normalizedObservation.getEndedAt());
         assertEquals(Severity.SEVERE, normalizedObservation.getEventSeverity());

--- a/src/test/java/io/kontur/eventapi/tornadojapanma/normalizer/TornadoJapanMaNormalizerIT.java
+++ b/src/test/java/io/kontur/eventapi/tornadojapanma/normalizer/TornadoJapanMaNormalizerIT.java
@@ -47,7 +47,7 @@ class TornadoJapanMaNormalizerIT extends AbstractCleanableIntegrationTest {
         assertNull(normalizedObservation.getGeometries());
         assertNull(normalizedObservation.getDescription());
         assertNull(normalizedObservation.getEpisodeDescription());
-        assertNull(normalizedObservation.getCost());
+        assertTrue(normalizedObservation.getCost().isEmpty());
         assertNull(normalizedObservation.getRegion());
         assertNull(normalizedObservation.getSourceUpdatedAt());
         assertNull(normalizedObservation.getExternalEpisodeId());


### PR DESCRIPTION
## Summary
- store different cost types in NormalizedObservation as JSON data
- parse cost values in EM-DAT, NOAA Storms and NIFC normalizers
- change DB column type for cost to jsonb
- adjust MyBatis mappings
- update unit tests

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.6.1)*

------
https://chatgpt.com/codex/tasks/task_e_685012c167e88324b72cf277c4022e0a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced cost information for observations by supporting multiple cost components (e.g., reconstruction, insured, suppression, and property damages) instead of a single value.

- **Database**
  - Updated the database to store cost data as a JSON object, allowing for richer and more flexible cost details.

- **Bug Fixes**
  - Adjusted normalization logic to ensure all relevant cost fields are captured and stored in the new format.

- **Tests**
  - Updated tests to reflect the new cost structure, ensuring correctness of the new multi-component cost handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->