### PR TITLE
Add JTWC cyclones import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 #### Added
+ - JTWC cyclones import job (disabled by default)
 
 #### Changed
 

--- a/src/main/java/io/kontur/eventapi/jtwc/client/JtwcClient.java
+++ b/src/main/java/io/kontur/eventapi/jtwc/client/JtwcClient.java
@@ -1,0 +1,15 @@
+package io.kontur.eventapi.jtwc.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(value = "jtwcClient", url = "${jtwc.host}")
+public interface JtwcClient {
+
+    @GetMapping("/jtwc/rss/jtwc.rss")
+    String getFeed();
+
+    @GetMapping("/jtwc/products/{fileName}")
+    String getProduct(@PathVariable("fileName") String fileName);
+}

--- a/src/main/java/io/kontur/eventapi/jtwc/job/JtwcImportJob.java
+++ b/src/main/java/io/kontur/eventapi/jtwc/job/JtwcImportJob.java
@@ -1,0 +1,93 @@
+package io.kontur.eventapi.jtwc.job;
+
+import io.kontur.eventapi.dao.DataLakeDao;
+import io.kontur.eventapi.entity.DataLake;
+import io.kontur.eventapi.job.AbstractJob;
+import io.kontur.eventapi.jtwc.service.JtwcService;
+import io.kontur.eventapi.util.DateTimeUtil;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.parser.Parser;
+import org.jsoup.select.Elements;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+public class JtwcImportJob extends AbstractJob {
+
+    public static final String JTWC_PROVIDER = "cyclones.jtwc";
+    private static final Logger LOG = LoggerFactory.getLogger(JtwcImportJob.class);
+
+    private final JtwcService service;
+    private final DataLakeDao dataLakeDao;
+
+    public JtwcImportJob(MeterRegistry registry, JtwcService service, DataLakeDao dataLakeDao) {
+        super(registry);
+        this.service = service;
+        this.dataLakeDao = dataLakeDao;
+    }
+
+    @Override
+    public String getName() {
+        return "jtwcImport";
+    }
+
+    @Override
+    public void execute() {
+        Optional<String> feedOpt = service.fetchFeed();
+        if (feedOpt.isEmpty()) {
+            return;
+        }
+        String feed = feedOpt.get();
+        Document doc = Jsoup.parse(feed, "", Parser.xmlParser());
+        Elements items = doc.select("item");
+        List<DataLake> dataLakes = new ArrayList<>();
+        for (Element item : items) {
+            String title = item.selectFirst("title").text();
+            if (isApplicableTitle(title)) {
+                String description = item.selectFirst("description").text();
+                if (!description.contains("No Current Tropical Cyclone Warnings.")) {
+                    String pubDateStr = item.selectFirst("pubDate").text();
+                    OffsetDateTime updatedAt = DateTimeUtil.parseDateTimeByPattern(pubDateStr, "EEE, dd MMM yy HH:mm:ss Z");
+                    Document descDoc = Jsoup.parse(description);
+                    Element link = descDoc.selectFirst("li a:contains(TC Warning Text)");
+                    if (link != null) {
+                        String href = link.attr("href");
+                        String fileName = href.substring(href.lastIndexOf('/') + 1);
+                        Optional<String> textOpt = service.fetchProduct(fileName);
+                        if (textOpt.isPresent()) {
+                            String data = textOpt.get();
+                            String externalId = DigestUtils.md5Hex(data);
+                            if (dataLakeDao.isNewEvent(externalId, JTWC_PROVIDER, updatedAt.format(DateTimeFormatter.ISO_INSTANT))) {
+                                DataLake dataLake = new DataLake(UUID.randomUUID(), externalId, updatedAt, DateTimeUtil.uniqueOffsetDateTime());
+                                dataLake.setProvider(JTWC_PROVIDER);
+                                dataLake.setData(data);
+                                dataLakes.add(dataLake);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if (!dataLakes.isEmpty()) {
+            dataLakeDao.storeDataLakes(dataLakes);
+        }
+    }
+
+    private boolean isApplicableTitle(String title) {
+        return "Current Northwest Pacific/North Indian Ocean* Tropical Systems".equals(title)
+                || "Current Central/Eastern Pacific Tropical Systems".equals(title)
+                || "Current Southern Hemisphere Tropical Systems".equals(title);
+    }
+}

--- a/src/main/java/io/kontur/eventapi/jtwc/service/JtwcService.java
+++ b/src/main/java/io/kontur/eventapi/jtwc/service/JtwcService.java
@@ -1,0 +1,39 @@
+package io.kontur.eventapi.jtwc.service;
+
+import feign.FeignException;
+import io.kontur.eventapi.jtwc.client.JtwcClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class JtwcService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JtwcService.class);
+
+    private final JtwcClient client;
+
+    public JtwcService(JtwcClient client) {
+        this.client = client;
+    }
+
+    public Optional<String> fetchFeed() {
+        try {
+            return Optional.of(client.getFeed());
+        } catch (FeignException e) {
+            LOG.warn("JTWC feed has not been received");
+        }
+        return Optional.empty();
+    }
+
+    public Optional<String> fetchProduct(String fileName) {
+        try {
+            return Optional.of(client.getProduct(fileName));
+        } catch (FeignException e) {
+            LOG.warn("JTWC product {} has not been received", fileName);
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -91,6 +91,9 @@ inciweb:
 nhc:
   host: 'https://www.nhc.noaa.gov'
 
+jtwc:
+  host: 'https://www.metoc.navy.mil'
+
 firms:
   host: 'https://firms.modaps.eosdis.nasa.gov/data/active_fire'
   modis: '/modis-c6.1/csv/MODIS_C6_1_Global_24h.csv'
@@ -168,6 +171,10 @@ scheduler:
     fixedDelay: 1800000
   nhcEpImport:
     enable: true
+    initialDelay: 1000
+    fixedDelay: 1800000
+  jtwcImport:
+    enable: false
     initialDelay: 1000
     fixedDelay: 1800000
   normalization:

--- a/src/test/java/io/kontur/eventapi/jtwc/job/JtwcImportJobTest.java
+++ b/src/test/java/io/kontur/eventapi/jtwc/job/JtwcImportJobTest.java
@@ -1,0 +1,72 @@
+package io.kontur.eventapi.jtwc.job;
+
+import io.kontur.eventapi.dao.DataLakeDao;
+import io.kontur.eventapi.entity.DataLake;
+import io.kontur.eventapi.jtwc.client.JtwcClient;
+import io.kontur.eventapi.jtwc.service.JtwcService;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+import static io.kontur.eventapi.jtwc.job.JtwcImportJob.JTWC_PROVIDER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class JtwcImportJobTest {
+
+    @Mock
+    private DataLakeDao dataLakeDao;
+
+    @Mock
+    private JtwcClient jtwcClient;
+
+    @Captor
+    private ArgumentCaptor<List<DataLake>> dataLakesCaptor;
+
+    @AfterEach
+    public void resetMocks() {
+        reset(dataLakeDao);
+        reset(jtwcClient);
+    }
+
+    @Test
+    public void testImportJob() throws IOException {
+        String feed = readResource("input_jtwc.xml");
+        String text = readResource("ep0425web.txt");
+        when(jtwcClient.getFeed()).thenReturn(feed);
+        when(jtwcClient.getProduct("ep0425web.txt")).thenReturn(text);
+        when(dataLakeDao.isNewEvent(anyString(), anyString(), anyString())).thenReturn(true);
+
+        JtwcService service = new JtwcService(jtwcClient);
+        JtwcImportJob job = new JtwcImportJob(new SimpleMeterRegistry(), service, dataLakeDao);
+
+        job.run();
+
+        verify(dataLakeDao, times(1)).storeDataLakes(dataLakesCaptor.capture());
+        List<DataLake> stored = dataLakesCaptor.getValue();
+        assertEquals(1, stored.size());
+        DataLake dl = stored.get(0);
+        assertEquals(JTWC_PROVIDER, dl.getProvider());
+        assertNotNull(dl.getExternalId());
+        assertNotNull(dl.getUpdatedAt());
+        assertEquals(text, dl.getData());
+    }
+
+    private String readResource(String name) throws IOException {
+        return IOUtils.toString(Objects.requireNonNull(getClass().getResourceAsStream(name)), "UTF-8");
+    }
+}

--- a/src/test/resources/io/kontur/eventapi/jtwc/job/ep0425web.txt
+++ b/src/test/resources/io/kontur/eventapi/jtwc/job/ep0425web.txt
@@ -1,0 +1,1 @@
+Some warning text here

--- a/src/test/resources/io/kontur/eventapi/jtwc/job/input_jtwc.xml
+++ b/src/test/resources/io/kontur/eventapi/jtwc/job/input_jtwc.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>JTWC TROPICAL CYCLONE INFORMATION FEED</title>
+    <item>
+      <title>Current Central/Eastern Pacific Tropical Systems</title>
+      <description><![CDATA[<ul><li><a href='https://www.metoc.navy.mil/jtwc/products/ep0425web.txt'>TC Warning Text </a></li></ul>]]></description>
+      <pubDate>Mon, 16 Jun 25 12:52:02 +0000</pubDate>
+    </item>
+    <item>
+      <title>Current Northwest Pacific/North Indian Ocean* Tropical Systems</title>
+      <description><![CDATA[<ul><li><font color='red'>No Current Tropical Cyclone Warnings.</font></li></ul>]]></description>
+      <pubDate>Mon, 16 Jun 25 12:52:02 +0000</pubDate>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
## Summary
- add JTWC client, service and import job
- configure scheduler and host settings
- test JTWC import job
- mention JTWC job in changelog

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685012e9adc48324a39583196b5e7b4d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for importing JTWC (Joint Typhoon Warning Center) cyclone data, with the import job disabled by default.
- **Configuration**
  - Introduced new configuration options for the JTWC service and scheduler.
- **Tests**
  - Added tests and sample data to verify the JTWC cyclone import functionality.
- **Documentation**
  - Updated changelog to reflect the addition of JTWC cyclone import support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->