### PR TITLE
Add metrics for observations to process

### DIFF
--- a/src/main/java/io/kontur/eventapi/calfire/job/CalFireSearchJob.java
+++ b/src/main/java/io/kontur/eventapi/calfire/job/CalFireSearchJob.java
@@ -66,6 +66,7 @@ public class CalFireSearchJob extends AbstractJob {
                     LOG.error("Error while processing calfire feature. {}", e1.getMessage());
                 }
             }
+            updateObservationsMetric(dataLakes.size());
             if (!CollectionUtils.isEmpty(dataLakes)) {
                 dataLakeDao.storeDataLakes(dataLakes);
             }

--- a/src/main/java/io/kontur/eventapi/firms/eventcombination/FirmsEventCombinationJob.java
+++ b/src/main/java/io/kontur/eventapi/firms/eventcombination/FirmsEventCombinationJob.java
@@ -37,6 +37,7 @@ public class FirmsEventCombinationJob extends EventCombinationJob {
     public void execute() {
         List<NormalizedObservation> observations = observationsDao
                 .getFirmsObservationsNotLinkedToEventFor24Hours();
+        updateObservationsMetric(observations.size());
 
         if (!CollectionUtils.isEmpty(observations)) {
             LOG.info("Firms Combination processing: {} events", observations.size());

--- a/src/main/java/io/kontur/eventapi/firms/jobs/FirmsImportJob.java
+++ b/src/main/java/io/kontur/eventapi/firms/jobs/FirmsImportJob.java
@@ -55,6 +55,7 @@ public abstract class FirmsImportJob extends AbstractJob {
     public void execute() {
         try {
             List<DataLake> dataLakes = loadData();
+            updateObservationsMetric(dataLakes.size());
             List<DataLake> sortedDataLakes = dataLakes.stream()
                     .sorted(Comparator.comparing(DataLake::getUpdatedAt, Comparator.nullsFirst(Comparator.naturalOrder())))
                     .peek(dataLake -> dataLake.setLoadedAt(DateTimeUtil.uniqueOffsetDateTime()))

--- a/src/main/java/io/kontur/eventapi/job/EventCombinationJob.java
+++ b/src/main/java/io/kontur/eventapi/job/EventCombinationJob.java
@@ -41,6 +41,7 @@ public class EventCombinationJob extends AbstractJob  {
     public void execute() {
         List<NormalizedObservation> observations = observationsDao
                 .getObservationsNotLinkedToEvent(Arrays.asList(sequentialProviders));
+        updateObservationsMetric(observations.size());
 
         if (!CollectionUtils.isEmpty(observations)) {
             LOG.info("Combination processing: {} events", observations.size());

--- a/src/main/java/io/kontur/eventapi/job/NormalizationJob.java
+++ b/src/main/java/io/kontur/eventapi/job/NormalizationJob.java
@@ -42,6 +42,7 @@ public class NormalizationJob extends AbstractJob {
     @Override
     public void execute() {
         List<DataLake> dataLakes = dataLakeDao.getDenormalizedEvents(Arrays.asList(providers));
+        updateObservationsMetric(dataLakes.size());
         if (!CollectionUtils.isEmpty(dataLakes)) {
             LOG.info("Normalization processing: {} data lakes", dataLakes.size());
 

--- a/src/main/java/io/kontur/eventapi/pdc/job/PdcMapSrvSearchJob.java
+++ b/src/main/java/io/kontur/eventapi/pdc/job/PdcMapSrvSearchJob.java
@@ -114,6 +114,7 @@ public class PdcMapSrvSearchJob extends AbstractJob {
                         dataLakes.add(pdcDataLakeConverter.convertExposure(features.get(id), id));
                     }
                 }
+                updateObservationsMetric(dataLakes.size());
                 if (!CollectionUtils.isEmpty(dataLakes)) {
                     dataLakeDao.storeDataLakes(dataLakes);
                 }


### PR DESCRIPTION
## Summary
- track number of observations pending for each job
- update import and pipeline jobs to publish new metric `job.observations.to.process`

## Testing
- `mvn -q -DskipTests=true package` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685013075efc8324a136e83ce208218a