### PR TITLE
Add feed_id+updated_at index

### DIFF
--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -70,3 +70,6 @@ databaseChangeLog:
 - include:
     relativeToChangelogFile: true
     file: v1.21.0/v1.21.0.yaml
+- include:
+    relativeToChangelogFile: true
+    file: v1.22.0/v1.22.0.yaml

--- a/src/main/resources/db/changelog/v1.22.0/create-feed-data-feed-id-updated-at-index.sql
+++ b/src/main/resources/db/changelog/v1.22.0/create-feed-data-feed-id-updated-at-index.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset event-api-migrations:v1.22.0/create-feed-data-feed-id-updated-at-index.sql runOnChange:true
+
+create index feed_data_feed_id_updated_at_idx on feed_data using btree (feed_id, updated_at)
+    where is_latest_version and enriched;

--- a/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
+++ b/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
@@ -1,0 +1,4 @@
+databaseChangeLog:
+  - include:
+      relativeToChangelogFile: true
+      file: create-feed-data-feed-id-updated-at-index.sql


### PR DESCRIPTION
## Summary
- add `feed_data_feed_id_updated_at_idx` btree index to improve lookups by feed and updated timestamp
- register v1.22.0 migration in changelog

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_6850135e31ec83249af59bc610c8db1b