### PR TITLE
Fix InciWeb normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Added
 
 #### Changed
+- fix InciWeb provider import to set proper name and episode description
 
 #### Removed
 

--- a/src/main/java/io/kontur/eventapi/inciweb/normalization/InciWebNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/inciweb/normalization/InciWebNormalizer.java
@@ -43,7 +43,9 @@ public class InciWebNormalizer extends Normalizer {
             normalizedObservation.setProvider(dataLakeDto.getProvider());
             normalizedObservation.setEventSeverity(Severity.UNKNOWN);
             normalizedObservation.setName(parsedItem.get().getTitle());
+            normalizedObservation.setProperName(parsedItem.get().getTitle());
             normalizedObservation.setDescription(parsedItem.get().getDescription());
+            normalizedObservation.setEpisodeDescription(parsedItem.get().getDescription());
             normalizedObservation.setType(EventType.WILDFIRE);
             normalizedObservation.setLoadedAt(dataLakeDto.getLoadedAt());
             normalizedObservation.setStartedAt(dataLakeDto.getUpdatedAt());

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -70,3 +70,6 @@ databaseChangeLog:
 - include:
     relativeToChangelogFile: true
     file: v1.21.0/v1.21.0.yaml
+- include:
+    relativeToChangelogFile: true
+    file: v1.22.0/v1.22.0.yaml

--- a/src/main/resources/db/changelog/v1.22.0/recalculate-inciweb.sql
+++ b/src/main/resources/db/changelog/v1.22.0/recalculate-inciweb.sql
@@ -1,0 +1,31 @@
+--liquibase formatted sql
+
+--changeset event-api-migrations:v1.22.0/recalculate-inciweb.sql runOnChange:true
+
+with inciweb_event_ids as (
+    select distinct event_id
+    from kontur_events
+    where provider = 'wildfire.inciweb'
+)
+delete from feed_data fd
+using inciweb_event_ids iei
+where fd.event_id = iei.event_id;
+
+with inciweb_event_ids as (
+    select distinct event_id
+    from kontur_events
+    where provider = 'wildfire.inciweb'
+)
+delete from feed_event_status fes
+using inciweb_event_ids iei
+where fes.event_id = iei.event_id;
+
+delete from kontur_events
+where provider = 'wildfire.inciweb';
+
+delete from normalized_observations
+where provider = 'wildfire.inciweb';
+
+update data_lake
+set normalized = false
+where provider = 'wildfire.inciweb';

--- a/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
+++ b/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
@@ -1,0 +1,4 @@
+databaseChangeLog:
+  - include:
+      relativeToChangelogFile: true
+      file: recalculate-inciweb.sql

--- a/src/test/java/io/kontur/eventapi/inciweb/normalization/InciWebNormalizationTest.java
+++ b/src/test/java/io/kontur/eventapi/inciweb/normalization/InciWebNormalizationTest.java
@@ -48,7 +48,9 @@ class InciWebNormalizationTest {
         assertNull(observation.getExternalEpisodeId());
         assertEquals(Severity.UNKNOWN, observation.getEventSeverity());
         assertEquals("Title 1", observation.getName());
+        assertEquals("Title 1", observation.getProperName());
         assertEquals("Description 1", observation.getDescription());
+        assertEquals("Description 1", observation.getEpisodeDescription());
         assertEquals(EventType.WILDFIRE, observation.getType());
         assertEquals(dataLake.getUpdatedAt(), observation.getStartedAt());
         assertEquals(dataLake.getUpdatedAt(), observation.getEndedAt());


### PR DESCRIPTION
## Summary
- set `properName` and `episodeDescription` when normalizing InciWeb events
- document InciWeb fix in changelog
- add database migration to remove old InciWeb records and reprocess
- update unit test to check new fields

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6850138f5b048324849cf549b1aed282