### PR TITLE
Add revoked field to FeedData

### DIFF
--- a/src/main/java/io/kontur/eventapi/dao/FeedDao.java
+++ b/src/main/java/io/kontur/eventapi/dao/FeedDao.java
@@ -43,7 +43,7 @@ public class FeedDao {
                 feedData.getSeverity(), feedData.getActive(), feedData.getStartedAt(), feedData.getEndedAt(),
                 feedData.getUpdatedAt(), feedData.getLocation(), feedData.getUrls(), feedData.getLoss(),
                 feedData.getSeverityData(), feedData.getObservations(), episodesJson, feedData.getEnriched(),
-                feedData.getAutoExpire(), feedData.getGeomFuncType());
+                feedData.getAutoExpire(), feedData.getGeomFuncType(), feedData.getRevoked());
 
         if (count > 0) {
             mapper.markOutdatedEventsVersions(feedData.getEventId(), feedData.getFeedId(), feedData.getVersion());

--- a/src/main/java/io/kontur/eventapi/dao/mapper/FeedMapper.java
+++ b/src/main/java/io/kontur/eventapi/dao/mapper/FeedMapper.java
@@ -35,7 +35,8 @@ public interface FeedMapper {
                        @Param("episodes") String episodes,
                        @Param("enriched") Boolean enriched,
                        @Param("autoExpire") Boolean autoExpire,
-                       @Param("geomFuncType") Integer geomFuncType);
+                       @Param("geomFuncType") Integer geomFuncType,
+                       @Param("revoked") Boolean revoked);
 
     /**
      * Mark events below specified version outdated

--- a/src/main/java/io/kontur/eventapi/entity/FeedData.java
+++ b/src/main/java/io/kontur/eventapi/entity/FeedData.java
@@ -36,6 +36,7 @@ public class FeedData {
     private OffsetDateTime enrichedAt;
     private Boolean autoExpire;
     private Integer geomFuncType;
+    private Boolean revoked;
 
     public FeedData(UUID eventId, UUID feedId, Long version) {
         this.eventId = eventId;

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -70,3 +70,6 @@ databaseChangeLog:
 - include:
     relativeToChangelogFile: true
     file: v1.21.0/v1.21.0.yaml
+- include:
+    relativeToChangelogFile: true
+    file: v1.22.0/v1.22.0.yaml

--- a/src/main/resources/db/changelog/v1.22.0/add-revoked-column.sql
+++ b/src/main/resources/db/changelog/v1.22.0/add-revoked-column.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset event-api-migrations:v1.22.0/add-revoked-column.sql runOnChange:true
+
+alter table feed_data
+    add column if not exists revoked boolean default false;

--- a/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
+++ b/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
@@ -1,0 +1,4 @@
+databaseChangeLog:
+  - include:
+      relativeToChangelogFile: true
+      file: add-revoked-column.sql

--- a/src/main/resources/db/mappers/FeedMapper.xml
+++ b/src/main/resources/db/mappers/FeedMapper.xml
@@ -20,7 +20,7 @@
                                active, started_at, ended_at, updated_at, location, urls,
                                <if test='loss != null'>loss,</if>
                                <if test='severityData != null'>severity_data,</if>
-                               observations, geometries, episodes, enriched, auto_expire)
+                               observations, geometries, episodes, enriched, auto_expire, revoked)
         values (#{eventId}, #{feedId}, #{version}, #{name}, #{properName}, #{description}, #{type},
                 (select severity_id from severities where severity = #{severity}),
                 #{active}, #{startedAt}, #{endedAt}, #{updatedAt}, #{location},
@@ -36,7 +36,7 @@
                         collectEventGeometries(#{episodes}::jsonb),
                     </otherwise>
                 </choose>
-                #{episodes}::jsonb, #{enriched}, #{autoExpire})
+                #{episodes}::jsonb, #{enriched}, #{autoExpire}, #{revoked})
     </insert>
 
     <update id="markOutdatedEventsVersions">
@@ -157,5 +157,6 @@
         <result property="composedAt" column="composed_at"/>
         <result property="enrichedAt" column="enriched_at"/>
         <result property="autoExpire" column="auto_expire"/>
+        <result property="revoked" column="revoked"/>
     </resultMap>
 </mapper>


### PR DESCRIPTION
## Summary
- add new boolean field `revoked` to `FeedData`
- extend `FeedMapper` to handle `revoked`
- pass `revoked` when inserting feed data
- create SQL migration adding `revoked` column
- include new migration in master changelog

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685013b288c0832497938121c1b89e59