### PR TITLE
Add merge decisions import job

### DIFF
--- a/src/main/java/io/kontur/eventapi/config/WorkerScheduler.java
+++ b/src/main/java/io/kontur/eventapi/config/WorkerScheduler.java
@@ -26,6 +26,7 @@ import io.kontur.eventapi.pdc.job.HpSrvSearchJob;
 import io.kontur.eventapi.tornadojapanma.job.HistoricalTornadoJapanMaImportJob;
 import io.kontur.eventapi.tornadojapanma.job.TornadoJapanMaImportJob;
 import io.kontur.eventapi.uhc.job.HumanitarianCrisisImportJob;
+import io.kontur.eventapi.merge.job.MergeDecisionsImportJob;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -54,6 +55,7 @@ public class WorkerScheduler {
     private final NifcImportJob nifcImportJob;
     private final InciWebImportJob inciWebImportJob;
     private final HumanitarianCrisisImportJob humanitarianCrisisImportJob;
+    private final MergeDecisionsImportJob mergeDecisionsImportJob;
     private final MetricsJob metricsJob;
     private final ReEnrichmentJob reEnrichmentJob;
     private final NhcAtImportJob nhcAtImportJob;
@@ -101,6 +103,8 @@ public class WorkerScheduler {
     private String inciwebEnabled;
     @Value("${scheduler.humanitarianCrisisImport.enable}")
     private String humanitarianCrisisEnabled;
+    @Value("${scheduler.mergeDecisionsImport.enable}")
+    private String mergeDecisionsEnabled;
     @Value("${scheduler.nhcAtImport.enable}")
     private String nhcAtEnabled;
     @Value("${scheduler.nhcCpImport.enable}")
@@ -126,6 +130,7 @@ public class WorkerScheduler {
                            PdcMapSrvSearchJobs pdcMapSrvSearchJobs,
                            EnrichmentJob enrichmentJob, CalFireSearchJob calFireSearchJob, NifcImportJob nifcImportJob,
                            InciWebImportJob inciWebImportJob, HumanitarianCrisisImportJob humanitarianCrisisImportJob,
+                           MergeDecisionsImportJob mergeDecisionsImportJob,
                            NhcAtImportJob nhcAtImportJob, NhcCpImportJob nhcCpImportJob, NhcEpImportJob nhcEpImportJob,
                            MetricsJob metricsJob, ReEnrichmentJob reEnrichmentJob, EventExpirationJob eventExpirationJob) {
         this.hpSrvSearchJob = hpSrvSearchJob;
@@ -148,6 +153,7 @@ public class WorkerScheduler {
         this.calFireSearchJob = calFireSearchJob;
         this.nifcImportJob = nifcImportJob;
         this.inciWebImportJob = inciWebImportJob;
+        this.mergeDecisionsImportJob = mergeDecisionsImportJob;
         this.nhcAtImportJob = nhcAtImportJob;
         this.nhcCpImportJob = nhcCpImportJob;
         this.nhcEpImportJob = nhcEpImportJob;
@@ -273,6 +279,14 @@ public class WorkerScheduler {
     public void startHumanitarianCrisisImport() {
         if (Boolean.parseBoolean(humanitarianCrisisEnabled)) {
             humanitarianCrisisImportJob.run();
+        }
+    }
+
+    @Scheduled(initialDelayString = "${scheduler.mergeDecisionsImport.initialDelay}",
+            fixedDelayString = "${scheduler.mergeDecisionsImport.fixedDelay}")
+    public void startMergeDecisionsImport() {
+        if (Boolean.parseBoolean(mergeDecisionsEnabled)) {
+            mergeDecisionsImportJob.run();
         }
     }
 

--- a/src/main/java/io/kontur/eventapi/dao/MergeOperationsDao.java
+++ b/src/main/java/io/kontur/eventapi/dao/MergeOperationsDao.java
@@ -1,0 +1,28 @@
+package io.kontur.eventapi.dao;
+
+import io.kontur.eventapi.dao.mapper.MergeOperationsMapper;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Component
+public class MergeOperationsDao {
+
+    private final MergeOperationsMapper mapper;
+
+    public MergeOperationsDao(MergeOperationsMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    public OffsetDateTime getLastApprovedAt() {
+        return mapper.getLastApprovedAt();
+    }
+
+    @Transactional
+    public void updateMergeDecision(UUID eventId1, UUID eventId2, Boolean approved,
+                                    String decisionMadeBy, OffsetDateTime decisionMadeAt) {
+        mapper.updateMergeDecision(eventId1, eventId2, approved, decisionMadeBy, decisionMadeAt);
+    }
+}

--- a/src/main/java/io/kontur/eventapi/dao/mapper/MergeOperationsMapper.java
+++ b/src/main/java/io/kontur/eventapi/dao/mapper/MergeOperationsMapper.java
@@ -1,0 +1,19 @@
+package io.kontur.eventapi.dao.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Mapper
+public interface MergeOperationsMapper {
+
+    OffsetDateTime getLastApprovedAt();
+
+    void updateMergeDecision(@Param("eventId1") UUID eventId1,
+                             @Param("eventId2") UUID eventId2,
+                             @Param("approved") Boolean approved,
+                             @Param("decisionMadeBy") String decisionMadeBy,
+                             @Param("decisionMadeAt") OffsetDateTime decisionMadeAt);
+}

--- a/src/main/java/io/kontur/eventapi/merge/dto/MergeDecisionDTO.java
+++ b/src/main/java/io/kontur/eventapi/merge/dto/MergeDecisionDTO.java
@@ -1,0 +1,13 @@
+package io.kontur.eventapi.merge.dto;
+
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+public class MergeDecisionDTO {
+    private Boolean approved;
+    private String decisionMadeBy;
+    private UUID eventId1;
+    private UUID eventId2;
+}

--- a/src/main/java/io/kontur/eventapi/merge/job/MergeDecisionsImportJob.java
+++ b/src/main/java/io/kontur/eventapi/merge/job/MergeDecisionsImportJob.java
@@ -1,0 +1,73 @@
+package io.kontur.eventapi.merge.job;
+
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import io.kontur.eventapi.dao.MergeOperationsDao;
+import io.kontur.eventapi.job.AbstractJob;
+import io.kontur.eventapi.merge.dto.MergeDecisionDTO;
+import io.kontur.eventapi.merge.service.MergeDecisionsS3Service;
+import io.kontur.eventapi.util.JsonUtil;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+@Component
+public class MergeDecisionsImportJob extends AbstractJob {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MergeDecisionsImportJob.class);
+
+    private final MergeDecisionsS3Service s3Service;
+    private final MergeOperationsDao mergeOperationsDao;
+
+    public MergeDecisionsImportJob(MeterRegistry meterRegistry,
+                                   MergeDecisionsS3Service s3Service,
+                                   MergeOperationsDao mergeOperationsDao) {
+        super(meterRegistry);
+        this.s3Service = s3Service;
+        this.mergeOperationsDao = mergeOperationsDao;
+    }
+
+    @Override
+    public String getName() {
+        return "mergeDecisionsImport";
+    }
+
+    @Override
+    public void execute() throws Exception {
+        OffsetDateTime lastApprovedAt = mergeOperationsDao.getLastApprovedAt();
+        List<S3ObjectSummary> summaries = s3Service.listS3ObjectSummaries();
+        for (S3ObjectSummary summary : summaries) {
+            OffsetDateTime modifiedAt = OffsetDateTime.ofInstant(summary.getLastModified().toInstant(), ZoneOffset.UTC);
+            if (lastApprovedAt != null && !modifiedAt.isAfter(lastApprovedAt)) {
+                continue;
+            }
+            try (S3Object s3Object = s3Service.getS3Object(summary.getKey())) {
+                processFile(modifiedAt, s3Object.getObjectContent());
+            } catch (Exception e) {
+                LOG.warn("Error while processing merge decision file {}", summary.getKey(), e);
+            }
+        }
+    }
+
+    void processFile(OffsetDateTime modifiedAt, InputStream content) throws Exception {
+        String json = IOUtils.toString(content, StandardCharsets.UTF_8);
+        List<MergeDecisionDTO> decisions = JsonUtil.readJson(json,
+                new com.fasterxml.jackson.core.type.TypeReference<List<MergeDecisionDTO>>() {});
+        if (CollectionUtils.isEmpty(decisions)) {
+            return;
+        }
+        for (MergeDecisionDTO dto : decisions) {
+            mergeOperationsDao.updateMergeDecision(dto.getEventId1(), dto.getEventId2(),
+                    dto.getApproved(), dto.getDecisionMadeBy(), modifiedAt);
+        }
+    }
+}

--- a/src/main/java/io/kontur/eventapi/merge/service/MergeDecisionsS3Service.java
+++ b/src/main/java/io/kontur/eventapi/merge/service/MergeDecisionsS3Service.java
@@ -1,0 +1,43 @@
+package io.kontur.eventapi.merge.service;
+
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class MergeDecisionsS3Service {
+
+    @Value("${mergeDecisions.s3Bucket}")
+    private String bucket;
+
+    @Value("${mergeDecisions.s3Folder}")
+    private String folder;
+
+    private static final AmazonS3 s3 = AmazonS3ClientBuilder.standard()
+            .withRegion(Regions.EU_CENTRAL_1)
+            .build();
+
+    public List<S3ObjectSummary> listS3ObjectSummaries() {
+        ListObjectsV2Request request = new ListObjectsV2Request()
+                .withBucketName(bucket)
+                .withPrefix(folder);
+        ListObjectsV2Result result = s3.listObjectsV2(request);
+        return result.getObjectSummaries().stream()
+                .filter(summary -> summary.getSize() > 0)
+                .collect(Collectors.toList());
+    }
+
+    public S3Object getS3Object(String key) {
+        return s3.getObject(new GetObjectRequest(bucket, key));
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -19,6 +19,9 @@ pdc:
 humanitarianCrisis:
   s3Folder: 'kontur_events/TEST DEV/'
 
+mergeDecisions:
+  s3Folder: 'merge_decisions/TEST DEV/'
+
 staticdata:
   s3Folder: 'TEST DEV/'
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -22,6 +22,9 @@ staticdata:
 humanitarianCrisis:
   s3Folder: 'kontur_events/PROD/'
 
+mergeDecisions:
+  s3Folder: 'merge_decisions/PROD/'
+
 aws:
   sqs:
     enabled: true

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -22,6 +22,9 @@ staticdata:
 humanitarianCrisis:
   s3Folder: 'kontur_events/TEST QA/'
 
+mergeDecisions:
+  s3Folder: 'merge_decisions/TEST QA/'
+
 aws:
   sqs:
     enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -76,6 +76,10 @@ humanitarianCrisis:
   s3Bucket: 'event-api-locker01'
   s3Folder: 'kontur_events/EXP/'
 
+mergeDecisions:
+  s3Bucket: 'event-api-locker01'
+  s3Folder: 'merge_decisions/EXP/'
+
 tornadoJapanMa:
   host: 'https://www.data.jma.go.jp/obd/stats/data/bosai/tornado/'
 
@@ -158,6 +162,10 @@ scheduler:
     enable: false
     initialDelay: 1000
     fixedDelay: PT12H # every 12 hours
+  mergeDecisionsImport:
+    enable: false
+    initialDelay: 1000
+    fixedDelay: PT1H
   nhcAtImport:
     enable: true
     initialDelay: 1000

--- a/src/main/resources/db/mappers/MergeOperationsMapper.xml
+++ b/src/main/resources/db/mappers/MergeOperationsMapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.kontur.eventapi.dao.mapper.MergeOperationsMapper">
+
+    <select id="getLastApprovedAt" resultType="java.time.OffsetDateTime">
+        SELECT max(approved_at) FROM merge_operations
+    </select>
+
+    <update id="updateMergeDecision">
+        UPDATE merge_operations
+        SET approved = #{approved},
+            decision_made_by = #{decisionMadeBy},
+            decision_made_at = #{decisionMadeAt},
+            executed = false
+        WHERE event_id_1 = #{eventId1} AND event_id_2 = #{eventId2}
+    </update>
+</mapper>

--- a/src/test/java/io/kontur/eventapi/config/WorkerSchedulerTest.java
+++ b/src/test/java/io/kontur/eventapi/config/WorkerSchedulerTest.java
@@ -28,6 +28,7 @@ import io.kontur.eventapi.staticdata.job.StaticImportJob;
 import io.kontur.eventapi.tornadojapanma.job.HistoricalTornadoJapanMaImportJob;
 import io.kontur.eventapi.tornadojapanma.job.TornadoJapanMaImportJob;
 import io.kontur.eventapi.uhc.job.HumanitarianCrisisImportJob;
+import io.kontur.eventapi.merge.job.MergeDecisionsImportJob;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -64,6 +65,7 @@ class WorkerSchedulerTest {
     private final NifcImportJob nifcImportJob = mock(NifcImportJob.class);
     private final InciWebImportJob inciWebImportJob = mock(InciWebImportJob.class);
     private final HumanitarianCrisisImportJob humanitarianCrisisImportJob = mock(HumanitarianCrisisImportJob.class);
+    private final MergeDecisionsImportJob mergeDecisionsImportJob = mock(MergeDecisionsImportJob.class);
     private final NhcAtImportJob nhcAtImportJob = mock(NhcAtImportJob.class);
     private final NhcCpImportJob nhcCpImportJob = mock(NhcCpImportJob.class);
     private final NhcEpImportJob nhcEpImportJob = mock(NhcEpImportJob.class);
@@ -75,7 +77,8 @@ class WorkerSchedulerTest {
             eventCombinationJob, firmsEventCombinationJob, feedCompositionJob, firmsImportModisJob, firmsImportNoaaJob,
             firmsImportSuomiJob, emDatImportJob, staticImportJob, stormsNoaaImportJob, tornadoJapanMaImportJob,
             historicalTornadoJapanMaImportJob, pdcMapSrvSearchJobs, enrichmentJob, calFireSearchJob,
-            nifcImportJob, inciWebImportJob, humanitarianCrisisImportJob, nhcAtImportJob, nhcCpImportJob, nhcEpImportJob,
+            nifcImportJob, inciWebImportJob, humanitarianCrisisImportJob, mergeDecisionsImportJob,
+            nhcAtImportJob, nhcCpImportJob, nhcEpImportJob,
             metricsJob, reEnrichmentJob, eventExpirationJob);
 
     @AfterEach
@@ -96,6 +99,7 @@ class WorkerSchedulerTest {
         Mockito.reset(pdcMapSrvSearchJobs);
         Mockito.reset(calFireSearchJob);
         Mockito.reset(inciWebImportJob);
+        Mockito.reset(mergeDecisionsImportJob);
         Mockito.reset(reEnrichmentJob);
         Mockito.reset(eventExpirationJob);
     }
@@ -338,5 +342,21 @@ class WorkerSchedulerTest {
         scheduler.startInciWebImport();
 
         verify(inciWebImportJob, never()).run();
+    }
+
+    @Test
+    public void startMergeDecisionsImportJob() {
+        ReflectionTestUtils.setField(scheduler, "mergeDecisionsEnabled", "true");
+        scheduler.startMergeDecisionsImport();
+
+        verify(mergeDecisionsImportJob, times(1)).run();
+    }
+
+    @Test
+    public void skipMergeDecisionsImportJob() {
+        ReflectionTestUtils.setField(scheduler, "mergeDecisionsEnabled", "false");
+        scheduler.startMergeDecisionsImport();
+
+        verify(mergeDecisionsImportJob, never()).run();
     }
 }

--- a/src/test/java/io/kontur/eventapi/merge/job/MergeDecisionsImportJobIT.java
+++ b/src/test/java/io/kontur/eventapi/merge/job/MergeDecisionsImportJobIT.java
@@ -1,0 +1,81 @@
+package io.kontur.eventapi.merge.job;
+
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import io.kontur.eventapi.dao.MergeOperationsDao;
+import io.kontur.eventapi.merge.service.MergeDecisionsS3Service;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class MergeDecisionsImportJobIT {
+
+    @Mock
+    private MergeDecisionsS3Service s3Service;
+    @Mock
+    private MergeOperationsDao mergeOperationsDao;
+
+    @AfterEach
+    public void resetMocks() {
+        reset(s3Service);
+        reset(mergeOperationsDao);
+    }
+
+    @Test
+    public void testImportNewDecision() throws Exception {
+        S3ObjectSummary summary = new S3ObjectSummary();
+        summary.setKey("user-1-2.json");
+        summary.setLastModified(new Date());
+        when(s3Service.listS3ObjectSummaries()).thenReturn(List.of(summary));
+        when(mergeOperationsDao.getLastApprovedAt()).thenReturn(null);
+        S3Object s3Object = mock(S3Object.class);
+        when(s3Service.getS3Object(isA(String.class))).thenReturn(s3Object);
+        String json = "[{" +
+                "\"approved\":true,\"decisionMadeBy\":\"u\"," +
+                "\"eventId1\":\"11111111-1111-1111-1111-111111111111\"," +
+                "\"eventId2\":\"22222222-2222-2222-2222-222222222222\"}]";
+        when(s3Object.getObjectContent()).thenReturn(new S3ObjectInputStream(IOUtils.toInputStream(json, StandardCharsets.UTF_8), new HttpGet()));
+
+        MergeDecisionsImportJob job = new MergeDecisionsImportJob(new SimpleMeterRegistry(), s3Service, mergeOperationsDao);
+        job.run();
+
+        verify(mergeOperationsDao, times(1)).updateMergeDecision(
+                UUID.fromString("11111111-1111-1111-1111-111111111111"),
+                UUID.fromString("22222222-2222-2222-2222-222222222222"),
+                true,
+                "u",
+                any(OffsetDateTime.class));
+    }
+
+    @Test
+    public void testSkipOldDecision() throws Exception {
+        OffsetDateTime last = OffsetDateTime.now();
+        S3ObjectSummary summary = new S3ObjectSummary();
+        summary.setKey("user-1-2.json");
+        summary.setLastModified(Date.from(last.minusDays(1).toInstant()));
+        when(s3Service.listS3ObjectSummaries()).thenReturn(List.of(summary));
+        when(mergeOperationsDao.getLastApprovedAt()).thenReturn(last);
+
+        MergeDecisionsImportJob job = new MergeDecisionsImportJob(new SimpleMeterRegistry(), s3Service, mergeOperationsDao);
+        job.run();
+
+        verify(mergeOperationsDao, never()).updateMergeDecision(any(), any(), any(), any(), any());
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -29,6 +29,10 @@ humanitarianCrisis:
   s3Bucket: 'event-api-locker01'
   s3Folder: 'kontur_events/EXP/'
 
+mergeDecisions:
+  s3Bucket: 'event-api-locker01'
+  s3Folder: 'merge_decisions/EXP/'
+
 tornadoJapanMa:
   host: 'https://www.data.jma.go.jp/obd/stats/data/bosai/tornado/'
 
@@ -108,6 +112,10 @@ scheduler:
     initialDelay: 999999
     fixedDelay: 999999
   humanitarianCrisisImport:
+    enable: false
+    initialDelay: 999999
+    fixedDelay: 999999
+  mergeDecisionsImport:
     enable: false
     initialDelay: 999999
     fixedDelay: 999999


### PR DESCRIPTION
## Summary
- add MergeDecisionDTO and S3 service
- create MergeOperations DAO and mapper
- implement MergeDecisionsImportJob
- wire scheduler and tests
- configure S3 paths and scheduler properties

## Testing
- `mvn -q -Dtest=MergeDecisionsImportJobIT,WorkerSchedulerTest test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685013c0dbb88324b1443fc900dac65b