### PR TITLE
Add merge pair internal API

### DIFF
--- a/src/main/java/io/kontur/eventapi/dao/MergePairDao.java
+++ b/src/main/java/io/kontur/eventapi/dao/MergePairDao.java
@@ -1,0 +1,29 @@
+package io.kontur.eventapi.dao;
+
+import io.kontur.eventapi.dao.mapper.MergePairMapper;
+import io.kontur.eventapi.resource.dto.MergeCandidatePairDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MergePairDao {
+
+    private final MergePairMapper mapper;
+
+    @Autowired
+    public MergePairDao(MergePairMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    public MergeCandidatePairDTO takeNextPair() {
+        return mapper.takeNextPair();
+    }
+
+    public MergeCandidatePairDTO getPairByIds(String eventId1, String eventId2) {
+        return mapper.getPairByIds(eventId1, eventId2);
+    }
+
+    public void markAsTaken(String eventId1, String eventId2) {
+        mapper.markAsTaken(eventId1, eventId2);
+    }
+}

--- a/src/main/java/io/kontur/eventapi/dao/mapper/MergePairMapper.java
+++ b/src/main/java/io/kontur/eventapi/dao/mapper/MergePairMapper.java
@@ -1,0 +1,17 @@
+package io.kontur.eventapi.dao.mapper;
+
+import io.kontur.eventapi.resource.dto.MergeCandidatePairDTO;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface MergePairMapper {
+
+    MergeCandidatePairDTO takeNextPair();
+
+    MergeCandidatePairDTO getPairByIds(@Param("eventId1") String eventId1,
+                                       @Param("eventId2") String eventId2);
+
+    void markAsTaken(@Param("eventId1") String eventId1,
+                     @Param("eventId2") String eventId2);
+}

--- a/src/main/java/io/kontur/eventapi/resource/dto/MergeCandidatePairDTO.java
+++ b/src/main/java/io/kontur/eventapi/resource/dto/MergeCandidatePairDTO.java
@@ -1,0 +1,18 @@
+package io.kontur.eventapi.resource.dto;
+
+import lombok.Data;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+@Data
+public class MergeCandidatePairDTO {
+    private String eventId1;
+    private String eventId2;
+    private Double confidence;
+    private Boolean approved;
+    private String decisionMadeBy;
+    private OffsetDateTime decisionMadeAt;
+    private Map<String, Object> event1;
+    private Map<String, Object> event2;
+}

--- a/src/main/java/io/kontur/eventapi/resource/internal/MergePairResource.java
+++ b/src/main/java/io/kontur/eventapi/resource/internal/MergePairResource.java
@@ -1,0 +1,34 @@
+package io.kontur.eventapi.resource.internal;
+
+import io.kontur.eventapi.resource.dto.MergeCandidatePairDTO;
+import io.kontur.eventapi.service.MergePairService;
+import io.swagger.v3.oas.annotations.Hidden;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1")
+@Hidden
+public class MergePairResource {
+
+    private final MergePairService service;
+
+    public MergePairResource(MergePairService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/merge_pair")
+    public ResponseEntity<List<MergeCandidatePairDTO>> getMergePair(
+            @RequestParam(value = "pairID", required = false) List<String> pairId) {
+        List<MergeCandidatePairDTO> result = service.getMergePairs(pairId);
+        if (result.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/io/kontur/eventapi/service/MergePairService.java
+++ b/src/main/java/io/kontur/eventapi/service/MergePairService.java
@@ -1,0 +1,32 @@
+package io.kontur.eventapi.service;
+
+import io.kontur.eventapi.dao.MergePairDao;
+import io.kontur.eventapi.resource.dto.MergeCandidatePairDTO;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+public class MergePairService {
+
+    private final MergePairDao dao;
+
+    public MergePairService(MergePairDao dao) {
+        this.dao = dao;
+    }
+
+    public List<MergeCandidatePairDTO> getMergePairs(List<String> pairIds) {
+        MergeCandidatePairDTO pair;
+        if (pairIds != null && pairIds.size() == 2) {
+            pair = dao.getPairByIds(pairIds.get(0), pairIds.get(1));
+        } else {
+            pair = dao.takeNextPair();
+        }
+        if (pair == null) {
+            return Collections.emptyList();
+        }
+        dao.markAsTaken(pair.getEventId1(), pair.getEventId2());
+        return List.of(pair);
+    }
+}

--- a/src/main/resources/db/mappers/MergePairMapper.xml
+++ b/src/main/resources/db/mappers/MergePairMapper.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.kontur.eventapi.dao.mapper.MergePairMapper">
+
+    <resultMap id="mergePairMap" type="io.kontur.eventapi.resource.dto.MergeCandidatePairDTO">
+        <result property="eventId1" column="event_id1"/>
+        <result property="eventId2" column="event_id2"/>
+        <result property="confidence" column="confidence"/>
+        <result property="approved" column="approved"/>
+        <result property="decisionMadeBy" column="decision_made_by"/>
+        <result property="decisionMadeAt" column="decision_made_at"/>
+        <result property="event1" column="event1" typeHandler="io.kontur.eventapi.typehandler.MapTypeHandler"/>
+        <result property="event2" column="event2" typeHandler="io.kontur.eventapi.typehandler.MapTypeHandler"/>
+    </resultMap>
+
+    <select id="takeNextPair" resultMap="mergePairMap">
+        SELECT * FROM merge_operations
+        ORDER BY taken_to_merge_at NULLS FIRST
+        LIMIT 1
+        FOR UPDATE SKIP LOCKED
+    </select>
+
+    <select id="getPairByIds" resultMap="mergePairMap">
+        SELECT * FROM merge_operations
+        WHERE event_id1 = #{eventId1} AND event_id2 = #{eventId2}
+    </select>
+
+    <update id="markAsTaken">
+        UPDATE merge_operations SET taken_to_merge_at = now()
+        WHERE event_id1 = #{eventId1} AND event_id2 = #{eventId2}
+    </update>
+</mapper>


### PR DESCRIPTION
## Summary
- implement `/v1/merge_pair` internal endpoint
- add service and DAO layer to fetch merge pairs
- include MyBatis mapper for merge pair operations
- expose MergeCandidatePairDTO

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685013cd92648324aa4c7af578158515