### PR TITLE
Add merge recalculation job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## UNRELEASED
 
 #### Added
+- `merged_groups` table for storing merged event groups
+- background job `mergeRecalculationJob` for processing merge operations
 
 #### Changed
 

--- a/src/main/java/io/kontur/eventapi/config/WorkerScheduler.java
+++ b/src/main/java/io/kontur/eventapi/config/WorkerScheduler.java
@@ -60,6 +60,7 @@ public class WorkerScheduler {
     private final NhcCpImportJob nhcCpImportJob;
     private final NhcEpImportJob nhcEpImportJob;
     private final EventExpirationJob eventExpirationJob;
+    private final MergeRecalculationJob mergeRecalculationJob;
 
     @Value("${scheduler.hpSrvImport.enable}")
     private String hpSrvImportEnabled;
@@ -113,6 +114,8 @@ public class WorkerScheduler {
     private String reEnrichmentEnabled;
     @Value("${scheduler.eventExpiration.enable}")
     private String eventExpirationEnabled;
+    @Value("${scheduler.mergeRecalculation.enable}")
+    private String mergeRecalculationEnabled;
 
 
     public WorkerScheduler(HpSrvSearchJob hpSrvSearchJob, HpSrvMagsJob hpSrvMagsJob,
@@ -127,7 +130,8 @@ public class WorkerScheduler {
                            EnrichmentJob enrichmentJob, CalFireSearchJob calFireSearchJob, NifcImportJob nifcImportJob,
                            InciWebImportJob inciWebImportJob, HumanitarianCrisisImportJob humanitarianCrisisImportJob,
                            NhcAtImportJob nhcAtImportJob, NhcCpImportJob nhcCpImportJob, NhcEpImportJob nhcEpImportJob,
-                           MetricsJob metricsJob, ReEnrichmentJob reEnrichmentJob, EventExpirationJob eventExpirationJob) {
+                           MetricsJob metricsJob, ReEnrichmentJob reEnrichmentJob,
+                           EventExpirationJob eventExpirationJob, MergeRecalculationJob mergeRecalculationJob) {
         this.hpSrvSearchJob = hpSrvSearchJob;
         this.hpSrvMagsJob = hpSrvMagsJob;
         this.gdacsSearchJob = gdacsSearchJob;
@@ -155,6 +159,7 @@ public class WorkerScheduler {
         this.reEnrichmentJob = reEnrichmentJob;
         this.humanitarianCrisisImportJob = humanitarianCrisisImportJob;
         this.eventExpirationJob = eventExpirationJob;
+        this.mergeRecalculationJob = mergeRecalculationJob;
     }
 
     @Scheduled(initialDelayString = "${scheduler.hpSrvImport.initialDelay}", fixedDelay = Integer.MAX_VALUE)
@@ -350,6 +355,14 @@ public class WorkerScheduler {
     public void startExpirationJob() {
         if (Boolean.parseBoolean(eventExpirationEnabled)) {
             eventExpirationJob.run();
+        }
+    }
+
+    @Scheduled(initialDelayString = "${scheduler.mergeRecalculation.initialDelay}",
+            fixedDelayString = "${scheduler.mergeRecalculation.fixedDelay}")
+    public void startMergeRecalculationJob() {
+        if (Boolean.parseBoolean(mergeRecalculationEnabled)) {
+            mergeRecalculationJob.run();
         }
     }
 }

--- a/src/main/java/io/kontur/eventapi/dao/MergeOperationsDao.java
+++ b/src/main/java/io/kontur/eventapi/dao/MergeOperationsDao.java
@@ -1,0 +1,25 @@
+package io.kontur.eventapi.dao;
+
+import io.kontur.eventapi.dao.mapper.MergeOperationsMapper;
+import io.kontur.eventapi.entity.MergeOperation;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class MergeOperationsDao {
+    private final MergeOperationsMapper mapper;
+
+    public MergeOperationsDao(MergeOperationsMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    public List<MergeOperation> getPendingOperations() {
+        return mapper.getPendingOperations();
+    }
+
+    public void markExecuted(UUID operationId) {
+        mapper.markExecuted(operationId);
+    }
+}

--- a/src/main/java/io/kontur/eventapi/dao/MergedGroupsDao.java
+++ b/src/main/java/io/kontur/eventapi/dao/MergedGroupsDao.java
@@ -1,0 +1,42 @@
+package io.kontur.eventapi.dao;
+
+import io.kontur.eventapi.dao.mapper.MergedGroupsMapper;
+import io.kontur.eventapi.entity.MergedGroup;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class MergedGroupsDao {
+    private final MergedGroupsMapper mapper;
+
+    public MergedGroupsDao(MergedGroupsMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    public UUID findGroupIdByEvent(UUID eventId) {
+        return mapper.findGroupIdByEvent(eventId);
+    }
+
+    public BigDecimal getMinPrimaryIdx(UUID mergeGroupId) {
+        return mapper.getMinPrimaryIdx(mergeGroupId);
+    }
+
+    public List<MergedGroup> getGroup(UUID mergeGroupId) {
+        return mapper.getGroup(mergeGroupId);
+    }
+
+    public void insert(MergedGroup group) {
+        mapper.insert(group);
+    }
+
+    public void updateGroupId(UUID fromGroup, UUID toGroup) {
+        mapper.updateGroupId(fromGroup, toGroup);
+    }
+
+    public void updatePrimaryIdx(UUID mergeGroupId, UUID eventId, BigDecimal idx) {
+        mapper.updatePrimaryIdx(mergeGroupId, eventId, idx);
+    }
+}

--- a/src/main/java/io/kontur/eventapi/dao/mapper/MergeOperationsMapper.java
+++ b/src/main/java/io/kontur/eventapi/dao/mapper/MergeOperationsMapper.java
@@ -1,0 +1,15 @@
+package io.kontur.eventapi.dao.mapper;
+
+import io.kontur.eventapi.entity.MergeOperation;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+import java.util.UUID;
+
+@Mapper
+public interface MergeOperationsMapper {
+    List<MergeOperation> getPendingOperations();
+
+    void markExecuted(@Param("operationId") UUID operationId);
+}

--- a/src/main/java/io/kontur/eventapi/dao/mapper/MergedGroupsMapper.java
+++ b/src/main/java/io/kontur/eventapi/dao/mapper/MergedGroupsMapper.java
@@ -1,0 +1,27 @@
+package io.kontur.eventapi.dao.mapper;
+
+import io.kontur.eventapi.entity.MergedGroup;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+@Mapper
+public interface MergedGroupsMapper {
+    UUID findGroupIdByEvent(@Param("eventId") UUID eventId);
+
+    BigDecimal getMinPrimaryIdx(@Param("mergeGroupId") UUID mergeGroupId);
+
+    List<MergedGroup> getGroup(@Param("mergeGroupId") UUID mergeGroupId);
+
+    void insert(MergedGroup group);
+
+    void updateGroupId(@Param("fromGroup") UUID fromGroup,
+                       @Param("toGroup") UUID toGroup);
+
+    void updatePrimaryIdx(@Param("mergeGroupId") UUID mergeGroupId,
+                          @Param("eventId") UUID eventId,
+                          @Param("idx") BigDecimal idx);
+}

--- a/src/main/java/io/kontur/eventapi/entity/MergeOperation.java
+++ b/src/main/java/io/kontur/eventapi/entity/MergeOperation.java
@@ -1,0 +1,14 @@
+package io.kontur.eventapi.entity;
+
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+public class MergeOperation {
+    private UUID operationId;
+    private UUID eventId1;
+    private UUID eventId2;
+    private Boolean approved;
+    private Boolean executed;
+}

--- a/src/main/java/io/kontur/eventapi/entity/MergedGroup.java
+++ b/src/main/java/io/kontur/eventapi/entity/MergedGroup.java
@@ -1,0 +1,13 @@
+package io.kontur.eventapi.entity;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Data
+public class MergedGroup {
+    private UUID mergeGroupId;
+    private UUID eventId;
+    private BigDecimal primaryIdx;
+}

--- a/src/main/java/io/kontur/eventapi/job/MergeRecalculationJob.java
+++ b/src/main/java/io/kontur/eventapi/job/MergeRecalculationJob.java
@@ -1,0 +1,123 @@
+package io.kontur.eventapi.job;
+
+import io.kontur.eventapi.dao.FeedEventStatusDao;
+import io.kontur.eventapi.dao.MergeOperationsDao;
+import io.kontur.eventapi.dao.MergedGroupsDao;
+import io.kontur.eventapi.entity.MergeOperation;
+import io.kontur.eventapi.entity.MergedGroup;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class MergeRecalculationJob extends AbstractJob {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MergeRecalculationJob.class);
+
+    private final MergeOperationsDao operationsDao;
+    private final MergedGroupsDao groupsDao;
+    private final FeedEventStatusDao feedEventStatusDao;
+
+    public MergeRecalculationJob(MeterRegistry meterRegistry,
+                                 MergeOperationsDao operationsDao,
+                                 MergedGroupsDao groupsDao,
+                                 FeedEventStatusDao feedEventStatusDao) {
+        super(meterRegistry);
+        this.operationsDao = operationsDao;
+        this.groupsDao = groupsDao;
+        this.feedEventStatusDao = feedEventStatusDao;
+    }
+
+    @Override
+    public void execute() {
+        List<MergeOperation> operations = operationsDao.getPendingOperations();
+        for (MergeOperation operation : operations) {
+            processOperation(operation);
+            operationsDao.markExecuted(operation.getOperationId());
+        }
+    }
+
+    private void processOperation(MergeOperation operation) {
+        UUID group1 = groupsDao.findGroupIdByEvent(operation.getEventId1());
+        UUID group2 = groupsDao.findGroupIdByEvent(operation.getEventId2());
+
+        if (Boolean.TRUE.equals(operation.getApproved())) {
+            mergeApproved(operation, group1, group2);
+        } else if (Boolean.FALSE.equals(operation.getApproved())) {
+            mergeRejected(operation, group1, group2);
+        }
+    }
+
+    private void mergeApproved(MergeOperation op, UUID g1, UUID g2) {
+        if (g1 != null && g2 != null && !g1.equals(g2)) {
+            groupsDao.updateGroupId(g2, g1);
+        } else if (g1 != null) {
+            BigDecimal min = groupsDao.getMinPrimaryIdx(g1);
+            MergedGroup mg = new MergedGroup();
+            mg.setMergeGroupId(g1);
+            mg.setEventId(op.getEventId2());
+            mg.setPrimaryIdx(min.subtract(BigDecimal.ONE));
+            groupsDao.insert(mg);
+        } else if (g2 != null) {
+            BigDecimal min = groupsDao.getMinPrimaryIdx(g2);
+            MergedGroup mg = new MergedGroup();
+            mg.setMergeGroupId(g2);
+            mg.setEventId(op.getEventId1());
+            mg.setPrimaryIdx(min.subtract(BigDecimal.ONE));
+            groupsDao.insert(mg);
+        } else {
+            UUID groupId = UUID.randomUUID();
+            MergedGroup mg1 = new MergedGroup();
+            MergedGroup mg2 = new MergedGroup();
+            mg1.setMergeGroupId(groupId);
+            mg2.setMergeGroupId(groupId);
+            if (Math.random() > 0.5) {
+                mg1.setEventId(op.getEventId1());
+                mg1.setPrimaryIdx(BigDecimal.ONE);
+                mg2.setEventId(op.getEventId2());
+                mg2.setPrimaryIdx(BigDecimal.ZERO);
+            } else {
+                mg1.setEventId(op.getEventId1());
+                mg1.setPrimaryIdx(BigDecimal.ZERO);
+                mg2.setEventId(op.getEventId2());
+                mg2.setPrimaryIdx(BigDecimal.ONE);
+            }
+            groupsDao.insert(mg1);
+            groupsDao.insert(mg2);
+        }
+        markNonActual(g1 != null ? g1 : (g2 != null ? g2 : null));
+    }
+
+    private void mergeRejected(MergeOperation op, UUID g1, UUID g2) {
+        if (g1 != null && g1.equals(g2)) {
+            UUID newGroup = UUID.randomUUID();
+            groupsDao.updateGroupId(g1, newGroup);
+        }
+        markNonActual(g1);
+        markNonActual(g2);
+    }
+
+    private void markNonActual(UUID groupId) {
+        if (groupId == null) {
+            return;
+        }
+        List<MergedGroup> groups = groupsDao.getGroup(groupId);
+        for (MergedGroup g : groups) {
+            try {
+                feedEventStatusDao.markAsNonActual("merge", g.getEventId());
+            } catch (Exception e) {
+                LOG.warn("Failed to mark event {} non actual", g.getEventId(), e);
+            }
+        }
+    }
+
+    @Override
+    public String getName() {
+        return "mergeRecalculationJob";
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -209,6 +209,10 @@ scheduler:
     enable: true
     initialDelay: 1000
     fixedDelay: PT3H
+  mergeRecalculation:
+    enable: false
+    initialDelay: 1000
+    fixedDelay: 10000
 
 
 feign:

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -70,3 +70,6 @@ databaseChangeLog:
 - include:
     relativeToChangelogFile: true
     file: v1.21.0/v1.21.0.yaml
+- include:
+    relativeToChangelogFile: true
+    file: v1.22.0/v1.22.0.yaml

--- a/src/main/resources/db/changelog/v1.22.0/create-merged-groups-table.sql
+++ b/src/main/resources/db/changelog/v1.22.0/create-merged-groups-table.sql
@@ -1,0 +1,12 @@
+--liquibase formatted sql
+
+--changeset event-api-migrations:v1.22.0/create-merged-groups-table.sql runOnChange:false
+
+create table if not exists merged_groups (
+    merge_group_id uuid not null,
+    event_id uuid not null,
+    primary_idx numeric,
+    unique(event_id)
+);
+
+create index if not exists merged_groups_merge_group_id_idx on merged_groups (merge_group_id);

--- a/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
+++ b/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
@@ -1,0 +1,4 @@
+databaseChangeLog:
+  - include:
+      relativeToChangelogFile: true
+      file: create-merged-groups-table.sql

--- a/src/main/resources/db/mappers/MergeOperationsMapper.xml
+++ b/src/main/resources/db/mappers/MergeOperationsMapper.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.kontur.eventapi.dao.mapper.MergeOperationsMapper">
+
+    <select id="getPendingOperations" resultMap="mergeOperationMap">
+        select operation_id,
+               event_id_1,
+               event_id_2,
+               approved,
+               executed
+        from merge_operations
+        where approved is not null
+          and executed = false
+    </select>
+
+    <update id="markExecuted">
+        update merge_operations
+        set executed = true
+        where operation_id = #{operationId}
+    </update>
+
+    <resultMap id="mergeOperationMap" type="io.kontur.eventapi.entity.MergeOperation">
+        <result property="operationId" column="operation_id" />
+        <result property="eventId1" column="event_id_1" />
+        <result property="eventId2" column="event_id_2" />
+        <result property="approved" column="approved" />
+        <result property="executed" column="executed" />
+    </resultMap>
+</mapper>

--- a/src/main/resources/db/mappers/MergedGroupsMapper.xml
+++ b/src/main/resources/db/mappers/MergedGroupsMapper.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.kontur.eventapi.dao.mapper.MergedGroupsMapper">
+
+    <select id="findGroupIdByEvent" resultType="java.util.UUID">
+        select merge_group_id from merged_groups where event_id = #{eventId}
+    </select>
+
+    <select id="getMinPrimaryIdx" resultType="java.math.BigDecimal">
+        select min(primary_idx) from merged_groups where merge_group_id = #{mergeGroupId}
+    </select>
+
+    <select id="getGroup" resultMap="mergedGroupMap">
+        select merge_group_id, event_id, primary_idx
+        from merged_groups
+        where merge_group_id = #{mergeGroupId}
+        order by primary_idx
+    </select>
+
+    <insert id="insert">
+        insert into merged_groups(merge_group_id, event_id, primary_idx)
+        values(#{mergeGroupId}, #{eventId}, #{primaryIdx})
+        on conflict (event_id) do nothing
+    </insert>
+
+    <update id="updateGroupId">
+        update merged_groups set merge_group_id = #{toGroup} where merge_group_id = #{fromGroup}
+    </update>
+
+    <update id="updatePrimaryIdx">
+        update merged_groups set primary_idx = #{idx}
+        where merge_group_id = #{mergeGroupId} and event_id = #{eventId}
+    </update>
+
+    <resultMap id="mergedGroupMap" type="io.kontur.eventapi.entity.MergedGroup">
+        <result property="mergeGroupId" column="merge_group_id" />
+        <result property="eventId" column="event_id" />
+        <result property="primaryIdx" column="primary_idx" />
+    </resultMap>
+</mapper>


### PR DESCRIPTION
## Summary
- add `merged_groups` table and changelog
- create DAO and mappers for merge operations and groups
- implement `MergeRecalculationJob`
- wire job into scheduler configuration
- document in CHANGELOG

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685013d99cb88324bcddd2d18250b850