### PR TITLE
Fix JSONB cast for large DataLake entries

### DIFF
--- a/src/main/resources/db/mappers/DataLakeMapper.xml
+++ b/src/main/resources/db/mappers/DataLakeMapper.xml
@@ -90,7 +90,7 @@
     </select>
 
     <select id="getPdcExposureGeohashes" resultMap="exposureGeohash">
-        SELECT external_id, jsonb_object_field_text((data::jsonb)->'properties', 'geohash') as geohash
+        SELECT external_id, (data::json -> 'properties' ->> 'geohash') as geohash
         FROM data_lake
         WHERE provider = 'pdcMapSrv' AND
         <foreach item="externalId" collection="externalIds" separator="," open="external_id in (" close=")">
@@ -106,7 +106,7 @@
         SELECT
             CASE WHEN EXISTS (
                 SELECT * FROM datalakes
-                WHERE jsonb_object_field_text((data::jsonb)->'properties', 'geohash') = #{geoHash}
+                WHERE (data::json -> 'properties' ->> 'geohash') = #{geoHash}
             ) THEN FALSE ELSE TRUE
             END
     </select>


### PR DESCRIPTION
## Summary
- avoid casting large `data` values to `jsonb` when fetching PDC exposure geohashes

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent from https://nexus.kontur.io)*

------
https://chatgpt.com/codex/tasks/task_e_685013e4caf48324b5c0fb7c4178b879