### PR TITLE
Add cross-provider merge endpoints

### DIFF
--- a/src/main/java/io/kontur/eventapi/crossprovidermerge/client/EventApiClient.java
+++ b/src/main/java/io/kontur/eventapi/crossprovidermerge/client/EventApiClient.java
@@ -1,0 +1,15 @@
+package io.kontur.eventapi.crossprovidermerge.client;
+
+import io.kontur.eventapi.crossprovidermerge.dto.MergePairDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@FeignClient(value = "eventApiClient", url = "${eventApi.host}")
+public interface EventApiClient {
+
+    @GetMapping("/v1/merge_pair")
+    MergePairDto getMergePair(@RequestParam("pairID") List<String> pairID);
+}

--- a/src/main/java/io/kontur/eventapi/crossprovidermerge/dto/MergePairDecisionDto.java
+++ b/src/main/java/io/kontur/eventapi/crossprovidermerge/dto/MergePairDecisionDto.java
@@ -1,0 +1,11 @@
+package io.kontur.eventapi.crossprovidermerge.dto;
+
+import lombok.Data;
+
+@Data
+public class MergePairDecisionDto {
+    private Boolean approved;
+    private String decisionMadeBy;
+    private String eventId1;
+    private String eventId2;
+}

--- a/src/main/java/io/kontur/eventapi/crossprovidermerge/dto/MergePairDto.java
+++ b/src/main/java/io/kontur/eventapi/crossprovidermerge/dto/MergePairDto.java
@@ -1,0 +1,17 @@
+package io.kontur.eventapi.crossprovidermerge.dto;
+
+import lombok.Data;
+
+import java.time.OffsetDateTime;
+
+@Data
+public class MergePairDto {
+    private String eventId1;
+    private String eventId2;
+    private Double confidence;
+    private Boolean approved;
+    private String decisionMadeBy;
+    private OffsetDateTime decisionMadeAt;
+    private Object event1;
+    private Object event2;
+}

--- a/src/main/java/io/kontur/eventapi/crossprovidermerge/resource/CrossProviderMergeResource.java
+++ b/src/main/java/io/kontur/eventapi/crossprovidermerge/resource/CrossProviderMergeResource.java
@@ -1,0 +1,32 @@
+package io.kontur.eventapi.crossprovidermerge.resource;
+
+import io.kontur.eventapi.crossprovidermerge.dto.MergePairDecisionDto;
+import io.kontur.eventapi.crossprovidermerge.dto.MergePairDto;
+import io.kontur.eventapi.crossprovidermerge.service.CrossProviderMergeService;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/merge_pair")
+public class CrossProviderMergeResource {
+
+    private final CrossProviderMergeService service;
+
+    public CrossProviderMergeResource(CrossProviderMergeService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    @Operation(summary = "Select event pair")
+    public MergePairDto getMergePair(@RequestParam("pairID") List<String> pairID) {
+        return service.getMergePair(pairID);
+    }
+
+    @PostMapping
+    @Operation(summary = "Save decision on merge pair")
+    public void saveDecision(@RequestBody MergePairDecisionDto decision) {
+        service.saveDecision(decision);
+    }
+}

--- a/src/main/java/io/kontur/eventapi/crossprovidermerge/service/CrossProviderMergeService.java
+++ b/src/main/java/io/kontur/eventapi/crossprovidermerge/service/CrossProviderMergeService.java
@@ -1,0 +1,75 @@
+package io.kontur.eventapi.crossprovidermerge.service;
+
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import io.kontur.eventapi.crossprovidermerge.client.EventApiClient;
+import io.kontur.eventapi.crossprovidermerge.dto.MergePairDecisionDto;
+import io.kontur.eventapi.crossprovidermerge.dto.MergePairDto;
+import io.kontur.eventapi.util.JsonUtil;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+public class CrossProviderMergeService {
+
+    private final EventApiClient eventApiClient;
+    private final AmazonS3 s3;
+    private final String bucket;
+    private final String folder;
+    private final Environment environment;
+
+    public CrossProviderMergeService(EventApiClient eventApiClient,
+                                     @Value("${crossProviderMerge.s3Bucket:event-api-locker01}") String bucket,
+                                     @Value("${crossProviderMerge.s3Folder:cross-provider-merge}") String folder,
+                                     Environment environment) {
+        this.eventApiClient = eventApiClient;
+        this.bucket = bucket;
+        this.folder = folder;
+        this.environment = environment;
+        this.s3 = AmazonS3ClientBuilder.standard().withRegion(Regions.EU_CENTRAL_1).build();
+    }
+
+    public MergePairDto getMergePair(List<String> pairId) {
+        return eventApiClient.getMergePair(pairId);
+    }
+
+    public void saveDecision(MergePairDecisionDto decision) {
+        String id1 = decision.getEventId1();
+        String id2 = decision.getEventId2();
+        if (id1.compareTo(id2) > 0) {
+            decision.setEventId1(id2);
+            decision.setEventId2(id1);
+            id1 = decision.getEventId1();
+            id2 = decision.getEventId2();
+        }
+        String envFolder = getEnvironmentFolder();
+        String key = String.format("%s/%s/%s-%s-%s.json", folder, envFolder,
+                decision.getDecisionMadeBy(), id1, id2);
+        String json = JsonUtil.writeJson(decision);
+        byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(bytes.length);
+        metadata.setContentType("application/json");
+        s3.putObject(bucket, key, new ByteArrayInputStream(bytes), metadata);
+    }
+
+    private String getEnvironmentFolder() {
+        List<String> profiles = Arrays.asList(environment.getActiveProfiles());
+        if (profiles.contains("prod")) {
+            return "PROD";
+        } else if (profiles.contains("test")) {
+            return "TEST";
+        } else if (profiles.contains("dev")) {
+            return "DEV";
+        }
+        return "EXP";
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -9,6 +9,9 @@ spring:
 konturApi:
   host: 'https://test-api02.konturlabs.com/'
 
+eventApi:
+  host: 'http://localhost:8624/events'
+
 konturApps:
   host: 'https://test-apps02.konturlabs.com/'
 
@@ -18,6 +21,10 @@ pdc:
 
 humanitarianCrisis:
   s3Folder: 'kontur_events/TEST DEV/'
+
+crossProviderMerge:
+  s3Bucket: 'event-api-locker01'
+  s3Folder: 'cross-provider-merge'
 
 staticdata:
   s3Folder: 'TEST DEV/'

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -9,6 +9,9 @@ spring:
 konturApi:
   host: 'https://api.kontur.io/'
 
+eventApi:
+  host: 'https://api.kontur.io/events'
+
 konturApps:
   host: 'https://apps.kontur.io/'
 
@@ -21,6 +24,10 @@ staticdata:
 
 humanitarianCrisis:
   s3Folder: 'kontur_events/PROD/'
+
+crossProviderMerge:
+  s3Bucket: 'event-api-locker01'
+  s3Folder: 'cross-provider-merge'
 
 aws:
   sqs:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -9,6 +9,9 @@ spring:
 konturApi:
   host: 'https://test-api.konturlabs.com/'
 
+eventApi:
+  host: 'https://test-api.konturlabs.com/events'
+
 konturApps:
   host: 'https://test-apps.konturlabs.com/'
 
@@ -21,6 +24,10 @@ staticdata:
 
 humanitarianCrisis:
   s3Folder: 'kontur_events/TEST QA/'
+
+crossProviderMerge:
+  s3Bucket: 'event-api-locker01'
+  s3Folder: 'cross-provider-merge'
 
 aws:
   sqs:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,6 +48,9 @@ spring:
 konturApi:
   host: 'https://test-api02.konturlabs.com/'
 
+eventApi:
+  host: 'http://localhost:8624/events'
+
 konturApps:
   host: 'https://test-apps02.konturlabs.com/'
 
@@ -75,6 +78,10 @@ staticdata:
 humanitarianCrisis:
   s3Bucket: 'event-api-locker01'
   s3Folder: 'kontur_events/EXP/'
+
+crossProviderMerge:
+  s3Bucket: 'event-api-locker01'
+  s3Folder: 'cross-provider-merge'
 
 tornadoJapanMa:
   host: 'https://www.data.jma.go.jp/obd/stats/data/bosai/tornado/'


### PR DESCRIPTION
## Summary
- add GET/POST `/merge_pair` endpoints
- implement S3 saving and Event API client
- configure eventApi and crossProviderMerge properties

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850140d05c08324bdc50b8c89968696