### PR TITLE
14036 Implement 304 response for feed endpoints

### DIFF
--- a/src/main/java/io/kontur/eventapi/resource/EventResource.java
+++ b/src/main/java/io/kontur/eventapi/resource/EventResource.java
@@ -217,7 +217,7 @@ public class EventResource {
                 datetime != null && datetime.getTo() != null ? datetime.getTo() : null,
                 effectiveAfter, limit, severities, sortOrder, bbox, episodeFilterType);
         if (geoJsonOpt.isEmpty()) {
-            if (effectiveAfter != null) {
+            if (effectiveAfter != null && updatedAfter == null) {
                 return ResponseEntity.status(HttpStatus.NOT_MODIFIED).build();
             }
             return ResponseEntity.noContent().build();


### PR DESCRIPTION
## Summary
- support `If-Modified-Since` header on feed endpoints
- return HTTP 304 when no events were updated

## Testing
- `java -version`
- `mvn -q test` *(fails: command not found)*
- `./gradlew test` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6850145fb0f08324948d58759de79bc4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for the optional If-Modified-Since HTTP header to event search endpoints, enabling more efficient caching and conditional requests.
- **Behavior Changes**
	- Event search endpoints may now return a 304 Not Modified status when no new data is available since the specified timestamp, reducing unnecessary data transfer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->