### PR TITLE
Group metrics modules under new package

### DIFF
--- a/src/main/java/io/kontur/eventapi/config/WorkerScheduler.java
+++ b/src/main/java/io/kontur/eventapi/config/WorkerScheduler.java
@@ -12,6 +12,7 @@ import io.kontur.eventapi.firms.jobs.FirmsImportNoaaJob;
 import io.kontur.eventapi.firms.jobs.FirmsImportSuomiJob;
 import io.kontur.eventapi.inciweb.job.InciWebImportJob;
 import io.kontur.eventapi.job.*;
+import io.kontur.eventapi.metrics.job.MetricsJob;
 import io.kontur.eventapi.nhc.job.NhcAtImportJob;
 import io.kontur.eventapi.nhc.job.NhcCpImportJob;
 import io.kontur.eventapi.nhc.job.NhcEpImportJob;

--- a/src/main/java/io/kontur/eventapi/metrics/config/MetricsAnnotationConfiguration.java
+++ b/src/main/java/io/kontur/eventapi/metrics/config/MetricsAnnotationConfiguration.java
@@ -1,4 +1,4 @@
-package io.kontur.eventapi.config;
+package io.kontur.eventapi.metrics.config;
 
 import io.micrometer.core.aop.CountedAspect;
 import io.micrometer.core.aop.TimedAspect;

--- a/src/main/java/io/kontur/eventapi/metrics/job/MetricsJob.java
+++ b/src/main/java/io/kontur/eventapi/metrics/job/MetricsJob.java
@@ -1,6 +1,7 @@
-package io.kontur.eventapi.job;
+package io.kontur.eventapi.metrics.job;
 
 import io.kontur.eventapi.metrics.MetricCollector;
+import io.kontur.eventapi.job.AbstractJob;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/test/java/io/kontur/eventapi/config/WorkerSchedulerTest.java
+++ b/src/test/java/io/kontur/eventapi/config/WorkerSchedulerTest.java
@@ -15,7 +15,7 @@ import io.kontur.eventapi.job.EventCombinationJob;
 import io.kontur.eventapi.job.FeedCompositionJob;
 import io.kontur.eventapi.job.NormalizationJob;
 import io.kontur.eventapi.job.EventExpirationJob;
-import io.kontur.eventapi.job.MetricsJob;
+import io.kontur.eventapi.metrics.job.MetricsJob;
 import io.kontur.eventapi.nhc.job.NhcAtImportJob;
 import io.kontur.eventapi.nhc.job.NhcCpImportJob;
 import io.kontur.eventapi.nhc.job.NhcEpImportJob;


### PR DESCRIPTION
## Summary
- regroup MetricsJob and configuration in `metrics` package
- update WorkerScheduler and tests

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68501488ca148324bf8380f96f253d21