### PR TITLE
Implement basic rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,3 +141,7 @@ For debugging could be used levels ERROR, WARN, INFO, DEBUG, TRACE
         </encoder>
     </appender>
 ```
+
+### Rate limiting
+
+The API applies a simple concurrency limit. Configure the limit via `ratelimit.concurrent` in `application.yml`. When the number of parallel requests exceeds this value the service responds with `429 Too Many Requests`.

--- a/src/main/java/io/kontur/eventapi/filter/RateLimitingFilter.java
+++ b/src/main/java/io/kontur/eventapi/filter/RateLimitingFilter.java
@@ -1,0 +1,35 @@
+package io.kontur.eventapi.filter;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.concurrent.Semaphore;
+
+@Component
+public class RateLimitingFilter extends OncePerRequestFilter {
+
+    private final Semaphore semaphore;
+
+    public RateLimitingFilter(@Value("${ratelimit.concurrent:1000}") int concurrentLimit) {
+        this.semaphore = new Semaphore(concurrentLimit);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        if (semaphore.tryAcquire()) {
+            try {
+                filterChain.doFilter(request, response);
+            } finally {
+                semaphore.release();
+            }
+        } else {
+            response.sendError(HttpServletResponse.SC_TOO_MANY_REQUESTS, "Too Many Requests");
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,8 @@ server:
   shutdown: graceful
   jetty:
     connection-idle-timeout: 3600000
+ratelimit:
+  concurrent: 1000
 
 spring:
   lifecycle:


### PR DESCRIPTION
## Summary
- add simple concurrency-based rate limiting filter
- expose `ratelimit.concurrent` property in `application.yml`
- document the rate limit property in README

## Testing
- `mvn test` *(fails: Could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685014bc20e8832498260e7b0075ef71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced concurrency-based rate limiting for incoming API requests. If the number of simultaneous requests exceeds the configured limit, the API will respond with a 429 Too Many Requests error.

* **Documentation**
  * Added a "Rate limiting" section to the README to describe the new concurrency limit feature and its configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->