### PR TITLE
Handle malformed RSS XML

### DIFF
--- a/src/main/java/io/kontur/eventapi/cap/converter/CapBaseXmlParser.java
+++ b/src/main/java/io/kontur/eventapi/cap/converter/CapBaseXmlParser.java
@@ -97,6 +97,10 @@ public abstract class CapBaseXmlParser {
     public abstract Optional<CapParsedEvent> getParsedItemForDataLake(String xml, String provider);
 
     protected Document getXmlDocument(String xml) throws ParserConfigurationException, IOException, SAXException {
+        if (StringUtils.isBlank(xml) || !xml.contains("</rss>")) {
+            throw new SAXException("Malformed XML: closing </rss> tag not found");
+        }
+
         DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
         builderFactory.setNamespaceAware(true);
         DocumentBuilder builder = builderFactory.newDocumentBuilder();


### PR DESCRIPTION
## Summary
- detect missing closing `</rss>` tag before parsing

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685014985308832498f455986f4c9ac0