### PR TITLE
Add Codecov integration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,3 +64,9 @@ jobs:
         with:
           report_paths: target/*-reports/*.xml
           retention-days: 10
+
+      - name: Uploading coverage to Codecov
+        uses: codecov/codecov-action@v3
+        if: always()
+        with:
+          files: target/site/jacoco/jacoco.xml

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![codecov](https://codecov.io/gh/konturio/event-api/branch/main/graph/badge.svg)](https://app.codecov.io/gh/konturio/event-api)
 ## Profiles
 
 Available profiles:

--- a/pom.xml
+++ b/pom.xml
@@ -485,6 +485,25 @@
 					</execution>
 				</executions>
 			</plugin>
+                        <plugin>
+                                <groupId>org.jacoco</groupId>
+                                <artifactId>jacoco-maven-plugin</artifactId>
+                                <version>0.8.8</version>
+                                <executions>
+                                        <execution>
+                                                <goals>
+                                                        <goal>prepare-agent</goal>
+                                                </goals>
+                                        </execution>
+                                        <execution>
+                                                <id>report</id>
+                                                <phase>prepare-package</phase>
+                                                <goals>
+                                                        <goal>report</goal>
+                                                </goals>
+                                        </execution>
+                                </executions>
+                        </plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
## Summary
- add Codecov badge to README
- generate coverage via Jacoco
- upload coverage in CI

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685029b7ce848324b8969dbe5197e3bf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added code coverage reporting and badge to the project.
- **Chores**
  - Integrated JaCoCo for code coverage in the build process.
  - Configured automated upload of coverage reports to Codecov via GitHub Actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->