### PR TITLE
style(sql): lowercase keywords

### DIFF
--- a/src/main/resources/db/changelog/v0.9/add-nifc-feed.sql
+++ b/src/main/resources/db/changelog/v0.9/add-nifc-feed.sql
@@ -2,5 +2,5 @@
 
 --changeset event-api-migrations:v0.9/add-public-feed.sql runOnChange:false
 
-INSERT INTO feeds (feed_id, alias, description, providers)
-VALUES (uuid_generate_v4(), 'nifc', 'Real-time wildfires from California','{"wildfire.perimeters.nifc","wildfire.locations.nifc"}');
+insert into feeds (feed_id, alias, description, providers)
+values (uuid_generate_v4(), 'nifc', 'Real-time wildfires from California','{"wildfire.perimeters.nifc","wildfire.locations.nifc"}');

--- a/src/main/resources/db/changelog/v0.9/insert-calfire-feed.sql
+++ b/src/main/resources/db/changelog/v0.9/insert-calfire-feed.sql
@@ -2,5 +2,5 @@
 
 --changeset event-api-migrations:v0.9/insert-calfire-feed runOnChange:false
 
-INSERT INTO feeds (feed_id, alias, description, providers)
-VALUES (uuid_generate_v4(), 'calfire', 'Real-time wildfires from California (CalFire)', '{"wildfire.calfire"}');
+insert into feeds (feed_id, alias, description, providers)
+values (uuid_generate_v4(), 'calfire', 'Real-time wildfires from California (CalFire)', '{"wildfire.calfire"}');

--- a/src/main/resources/db/changelog/v0/01-create-schema.sql
+++ b/src/main/resources/db/changelog/v0/01-create-schema.sql
@@ -1,7 +1,7 @@
 --liquibase formatted sql
 
 --changeset event-api-migrations:01-create-schema runOnChange:false
-CREATE TABLE IF NOT EXISTS data_lake
+create table if not exists data_lake
 (
     observation_id uuid unique,
     external_id    text,
@@ -10,10 +10,10 @@ CREATE TABLE IF NOT EXISTS data_lake
     provider       text,
     data           text,
 
-    UNIQUE (external_id, provider, updated_at)
+    unique (external_id, provider, updated_at)
 );
 
-CREATE TABLE IF NOT EXISTS normalized_observations
+create table if not exists normalized_observations
 (
     observation_id      uuid unique references data_lake (observation_id),
     external_id         text,
@@ -35,18 +35,18 @@ CREATE TABLE IF NOT EXISTS normalized_observations
     source_uri          text
 );
 
-CREATE INDEX ON normalized_observations (external_id);
+create index on normalized_observations (external_id);
 
-CREATE TABLE IF NOT EXISTS kontur_events
+create table if not exists kontur_events
 (
     event_id       uuid,
     version        bigint,
     observation_id uuid,
 
-    UNIQUE (event_id, version, observation_id)
+    unique (event_id, version, observation_id)
 );
 
-CREATE TABLE IF NOT EXISTS feeds
+create table if not exists feeds
 (
     feed_id     uuid primary key,
     description text,
@@ -55,7 +55,7 @@ CREATE TABLE IF NOT EXISTS feeds
     roles       text[]
 );
 
-CREATE TABLE IF NOT EXISTS feed_data
+create table if not exists feed_data
 (
     event_id     uuid,
     feed_id      uuid,
@@ -68,8 +68,8 @@ CREATE TABLE IF NOT EXISTS feed_data
     observations uuid[],
     episodes     jsonb,
 
-    UNIQUE (event_id, feed_id, version)
+    unique (event_id, feed_id, version)
 );
 
-CREATE INDEX ON feed_data (event_id, version);
-CREATE INDEX on feed_data (feed_id);
+create index on feed_data (event_id, version);
+create index on feed_data (feed_id);

--- a/src/main/resources/db/changelog/v0/02-insert-pdc-feed.sql
+++ b/src/main/resources/db/changelog/v0/02-insert-pdc-feed.sql
@@ -2,5 +2,5 @@
 
 --changeset event-api-migrations:02-insert-pdc-feed runOnChange:false
 
-INSERT INTO feeds (feed_id, alias, description, providers)
-VALUES (uuid_generate_v4(), 'pdc', 'Pacific Disaster Center feed', '{"hpSrvMag", "hpSrvSearch"}');
+insert into feeds (feed_id, alias, description, providers)
+values (uuid_generate_v4(), 'pdc', 'Pacific Disaster Center feed', '{"hpSrvMag", "hpSrvSearch"}');

--- a/src/main/resources/db/changelog/v0/12-add-unique-loaded-at-constraint.sql
+++ b/src/main/resources/db/changelog/v0/12-add-unique-loaded-at-constraint.sql
@@ -2,11 +2,11 @@
 
 --changeset event-api-migrations:12-add-unique-loaded-at-constraint runOnChange:false
 
-CREATE UNIQUE INDEX feed_data_updated_at_unique
-    ON feed_data (updated_at);
+create unique index feed_data_updated_at_unique
+    on feed_data (updated_at);
 
-CREATE UNIQUE INDEX normalized_observations_loaded_at_unique
-    ON normalized_observations (loaded_at);
+create unique index normalized_observations_loaded_at_unique
+    on normalized_observations (loaded_at);
 
-CREATE UNIQUE INDEX data_lake_loaded_at_unique
-    ON data_lake (loaded_at);
+create unique index data_lake_loaded_at_unique
+    on data_lake (loaded_at);

--- a/src/main/resources/db/changelog/v0/15-separate-data-lake-mags.sql
+++ b/src/main/resources/db/changelog/v0/15-separate-data-lake-mags.sql
@@ -3,7 +3,7 @@
 --changeset event-api-migrations:15-separate-data-lake-mags runOnChange:false
 
 
-create table data_lake_temp AS
+create table data_lake_temp as
 select uuid_generate_v4() as observation_id,
        external_id,
        updated_at,
@@ -23,10 +23,10 @@ from (
                   where provider = 'hpSrvMag') t
      ) t2;
 
-CREATE UNIQUE INDEX ON data_lake_temp (loaded_at);
+create unique index on data_lake_temp (loaded_at);
 
 delete from data_lake where provider = 'hpSrvMag';
 
-insert into data_lake SELECT * from data_lake_temp;
+insert into data_lake select * from data_lake_temp;
 
 drop table data_lake_temp;

--- a/src/main/resources/db/changelog/v0/17-insert-gdacs-feed.sql
+++ b/src/main/resources/db/changelog/v0/17-insert-gdacs-feed.sql
@@ -2,5 +2,5 @@
 
 --changeset event-api-migrations:17-insert-gdacs-feed runOnChange:false
 
-INSERT INTO feeds (feed_id, alias, description, providers)
-VALUES (uuid_generate_v4(), 'gdacs', 'Global Disaster Alert and Coordination System feed', '{"gdacsAlert", "gdacsAlertGeometry"}');
+insert into feeds (feed_id, alias, description, providers)
+values (uuid_generate_v4(), 'gdacs', 'Global Disaster Alert and Coordination System feed', '{"gdacsAlert", "gdacsAlertGeometry"}');

--- a/src/main/resources/db/changelog/v0/18-clear-feed-data-and-duplicated-kontur-events.sql
+++ b/src/main/resources/db/changelog/v0/18-clear-feed-data-and-duplicated-kontur-events.sql
@@ -4,7 +4,7 @@
 
 delete from feed_data;
 
-WITH latest_events AS (select event_id, observation_id, max(version) as max_version
+WITH latest_events as (select event_id, observation_id, max(version) as max_version
                           from kontur_events
                           group by event_id, observation_id)
 delete from kontur_events e using latest_events

--- a/src/main/resources/db/changelog/v0/19-add-collected-geometry-to-normalized-observation.sql
+++ b/src/main/resources/db/changelog/v0/19-add-collected-geometry-to-normalized-observation.sql
@@ -2,12 +2,12 @@
 
 --changeset event-api-migrations:18-add-collected-geometry-to-normalized-observation runOnChange:false
 
-CREATE FUNCTION collectGeomFromGeoJSON(jsonb) RETURNS geometry
-    AS 'select ST_Collect( ST_GeomFromGeoJSON(feature->''geometry'')) from jsonb_array_elements($1->''features'') feature;'
-    LANGUAGE SQL
-    IMMUTABLE
-    RETURNS NULL ON NULL INPUT;
+create function collectGeomFromGeoJSON(jsonb) returns geometry
+    as 'select ST_Collect(ST_GeomFromGeoJSON(feature->''geometry'')) from jsonb_array_elements($1->''features'') feature;'
+    language sql
+    immutable
+    strict;
 
-ALTER TABLE normalized_observations ADD COLUMN collected_geometry geometry GENERATED ALWAYS AS (collectGeomFromGeoJSON(geometries)) STORED;
+alter table normalized_observations add column collected_geometry geometry generated always as (collectGeomFromGeoJSON(geometries)) stored;
 
-CREATE INDEX ON normalized_observations USING GIST (collected_geometry);
+create index on normalized_observations using gist (collected_geometry);

--- a/src/main/resources/db/changelog/v0/20-alter-kontur_events-drop-version.sql
+++ b/src/main/resources/db/changelog/v0/20-alter-kontur_events-drop-version.sql
@@ -2,10 +2,10 @@
 
 --changeset event-api-migrations:20-alter-kontur_events-drop-version.sql runOnChange:false
 
-ALTER TABLE kontur_events DROP CONSTRAINT kontur_events_event_id_version_observation_id_key;
-ALTER TABLE kontur_events DROP COLUMN version;
-ALTER TABLE kontur_events ADD CONSTRAINT kontur_events_event_id_observation_id_key UNIQUE (event_id, observation_id);
+alter table kontur_events drop constraint kontur_events_event_id_version_observation_id_key;
+alter table kontur_events drop column version;
+alter table kontur_events add constraint kontur_events_event_id_observation_id_key unique (event_id, observation_id);
 
-DROP INDEX feed_data_updated_at_unique;
-CREATE UNIQUE INDEX feed_data_updated_at_version_unique ON feed_data (updated_at, version);
-CREATE INDEX feed_data_observations ON feed_data USING GIN(observations);
+drop index feed_data_updated_at_unique;
+create unique index feed_data_updated_at_version_unique on feed_data (updated_at, version);
+create index feed_data_observations on feed_data using gin(observations);

--- a/src/main/resources/db/changelog/v0/21-insert-firms-feed.sql
+++ b/src/main/resources/db/changelog/v0/21-insert-firms-feed.sql
@@ -2,5 +2,5 @@
 
 --changeset event-api-migrations:21-insert-firms-feed.sql runOnChange:false
 
-INSERT INTO feeds (feed_id, alias, description, providers)
-VALUES (uuid_generate_v4(), 'firms', 'Fire Information for Resource Management System', '{"firms.modis-c6", "firms.suomi-npp-viirs-c2", "firms.noaa-20-viirs-c2"}');
+insert into feeds (feed_id, alias, description, providers)
+values (uuid_generate_v4(), 'firms', 'Fire Information for Resource Management System', '{"firms.modis-c6", "firms.suomi-npp-viirs-c2", "firms.noaa-20-viirs-c2"}');

--- a/src/main/resources/db/changelog/v0/add-collected-geography-to-normalized-observation.sql
+++ b/src/main/resources/db/changelog/v0/add-collected-geography-to-normalized-observation.sql
@@ -1,9 +1,9 @@
 --liquibase formatted sql
 
 --changeset event-api-migrations:v0/add-collected-geography-to-normalized-observation runOnChange:false
-DELETE FROM feed_data; -- because of changes in episode composition job
-DELETE FROM kontur_events WHERE provider in ('firms.modis-c6','firms.suomi-npp-viirs-c2','firms.noaa-20-viirs-c2'); -- because of changes for firms event composition
+delete from feed_data; -- because of changes in episode composition job
+delete from kontur_events where provider in ('firms.modis-c6','firms.suomi-npp-viirs-c2','firms.noaa-20-viirs-c2'); -- because of changes for firms event composition
 
-ALTER TABLE normalized_observations DROP COLUMN collected_geometry;
-ALTER TABLE normalized_observations ADD COLUMN collected_geography geography GENERATED ALWAYS AS (collectGeomFromGeoJSON(geometries)::geography) STORED;
-CREATE INDEX ON normalized_observations USING GIST (collected_geography);
+alter table normalized_observations drop column collected_geometry;
+alter table normalized_observations add column collected_geography geography generated always as (collectGeomFromGeoJSON(geometries)::geography) stored;
+create index on normalized_observations using gist (collected_geography);

--- a/src/main/resources/db/changelog/v0/add-em-dat-feed.sql
+++ b/src/main/resources/db/changelog/v0/add-em-dat-feed.sql
@@ -2,6 +2,6 @@
 
 --changeset event-api-migrations:v0/add-em-dat-feed.sql runOnChange:false
 
-INSERT INTO feeds (feed_id, alias, description, providers)
-VALUES (uuid_generate_v4(), 'em-dat', 'EM-DAT', '{"em-dat"}');
+insert into feeds (feed_id, alias, description, providers)
+values (uuid_generate_v4(), 'em-dat', 'EM-DAT', '{"em-dat"}');
 

--- a/src/main/resources/db/changelog/v0/add-event-geometries-in-feed-data.sql
+++ b/src/main/resources/db/changelog/v0/add-event-geometries-in-feed-data.sql
@@ -2,14 +2,14 @@
 
 --changeset event-api-migrations:v0/add-event-geometries-in-feed-data.sql runOnChange:true splitStatements:false
 
-CREATE OR REPLACE FUNCTION collectEventGeometries(jsonb) RETURNS JSONB
-AS $$
+create or replace function collectEventGeometries(jsonb) returns jsonb
+as $$
     select jsonb_build_object('type', 'FeatureCollection', 'features',
            json_agg(ST_AsGeoJSON(t.*)::json))
     from (
         select
             f.feature -> 'properties' -> 'areaType' as areaType,
-            st_union(st_makevalid(st_geomfromgeojson(NULLIF(feature -> 'geometry', 'null'::jsonb)))) as geom
+            ST_Union(ST_MakeValid(ST_GeomFromGeoJSON(nullif(feature -> 'geometry', 'null'::jsonb)))) as geom
         from (
             select jsonb_array_elements(e -> 'geometries' -> 'features') as feature
             from jsonb_array_elements($1) e
@@ -18,11 +18,11 @@ AS $$
     ) t(areaType, geom)
     where geom is not null;
     $$
-    LANGUAGE SQL
-    STRICT
-    IMMUTABLE PARALLEL SAFE;
+    language sql
+    strict
+    immutable parallel safe;
 
-ALTER TABLE feed_data DROP COLUMN IF EXISTS geometries;
+alter table feed_data drop column IF EXISTS geometries;
 
-ALTER TABLE feed_data ADD COLUMN IF NOT EXISTS geometries JSONB;
+alter table feed_data add column if not exists geometries jsonb;
 

--- a/src/main/resources/db/changelog/v0/add-feed-data-is-latest-version-column.sql
+++ b/src/main/resources/db/changelog/v0/add-feed-data-is-latest-version-column.sql
@@ -2,7 +2,7 @@
 
 --changeset event-api-migrations:v0/add-feed-data-is-latest-version-column.sql runOnChange:false
 --preconditions onFail:MARK_RAN
---precondition-sql-check expectedResult:0 SELECT count(*) FROM information_schema.columns WHERE table_name = 'feed_data' AND column_name = 'is_latest_version';
+--precondition-sql-check expectedResult:0 select count(*) from information_schema.columns where table_name = 'feed_data' AND column_name = 'is_latest_version';
 
 alter table feed_data
     add is_latest_version bool default true;
@@ -21,4 +21,4 @@ where fd.feed_id = e.feed_id
 
 drop index if exists feed_data_updated_at_idx;
 
-CREATE INDEX if not exists feed_data_updated_at_feed_id_is_latest_version_idx ON public.feed_data USING btree (updated_at, feed_id) where is_latest_version;
+create index if not exists feed_data_updated_at_feed_id_is_latest_version_idx on public.feed_data using btree (updated_at, feed_id) where is_latest_version;

--- a/src/main/resources/db/changelog/v0/add-feed-data-types-column.sql
+++ b/src/main/resources/db/changelog/v0/add-feed-data-types-column.sql
@@ -2,16 +2,16 @@
 
 --changeset event-api-migrations:v0/add-feed-data-types-column.sql runOnChange:false
 
-CREATE OR REPLACE FUNCTION collectTypesFromEpisodes(episodes jsonb) RETURNS text[]
-AS $$
+create or replace function collectTypesFromEpisodes(episodes jsonb) returns text[]
+as $$
     select array_agg(t.type)
     from (select distinct jsonb_array_elements(episodes) ->> 'type' as type) as t
     $$
-    LANGUAGE SQL
-    STRICT
-    IMMUTABLE
-    PARALLEL SAFE;
+    language sql
+    strict
+    immutable
+    parallel safe;
 
 alter table feed_data
-    add column episode_types text[] GENERATED ALWAYS AS (collectTypesFromEpisodes(episodes)) STORED;
+    add column episode_types text[] generated always as (collectTypesFromEpisodes(episodes)) stored;
 

--- a/src/main/resources/db/changelog/v0/add-feeds-providers-index.sql
+++ b/src/main/resources/db/changelog/v0/add-feeds-providers-index.sql
@@ -2,4 +2,4 @@
 
 --changeset event-api-migrations:v0/add-feeds-providers-index.sql runOnChange:false
 
-CREATE INDEX if not exists feeds_providers ON feeds USING GIN (providers);
+create index if not exists feeds_providers on feeds using gin (providers);

--- a/src/main/resources/db/changelog/v0/add-gdacs-firms-feed.sql
+++ b/src/main/resources/db/changelog/v0/add-gdacs-firms-feed.sql
@@ -2,13 +2,13 @@
 
 --changeset event-api-migrations:v0/add-gdacs-firms-feed.sql runOnChange:true
 
-UPDATE feeds set alias = 'disaster-ninja-02' where alias = 'gdacs-firms';
+update feeds set alias = 'disaster-ninja-02' where alias = 'gdacs-firms';
 
-INSERT INTO feeds (feed_id, alias, description, providers, enrichment)
-VALUES (uuid_generate_v4(), 'disaster-ninja-02', 'GDACS+FIRMS',
+insert into feeds (feed_id, alias, description, providers, enrichment)
+values (uuid_generate_v4(), 'disaster-ninja-02', 'GDACS+FIRMS',
         '{"firms.modis-c6","firms.suomi-npp-viirs-c2","firms.noaa-20-viirs-c2","gdacsAlert","gdacsAlertGeometry"}',
         '{"population", "peopleWithoutOsmBuildings", "areaWithoutOsmBuildingsKm2", "peopleWithoutOsmRoads", "areaWithoutOsmRoadsKm2", "peopleWithoutOsmObjects", "areaWithoutOsmObjectsKm2", "osmGapsPercentage", "industrialAreaKm2", "forestAreaKm2", "volcanoesCount", "hotspotDaysPerYearMax"}')
-ON CONFLICT DO NOTHING;
+on conflict do nothing;
 
 insert into feed_event_status (feed_id, event_id, actual)
 select distinct on (event_id) fs.feed_id, event_id, false
@@ -17,4 +17,4 @@ from kontur_events,
 where provider in
       ('firms.modis-c6', 'firms.suomi-npp-viirs-c2', 'firms.noaa-20-viirs-c2', 'gdacsAlert', 'gdacsAlertGeometry')
   and alias = 'disaster-ninja-02'
-ON CONFLICT DO NOTHING;
+on conflict do nothing;

--- a/src/main/resources/db/changelog/v0/add-public-feed.sql
+++ b/src/main/resources/db/changelog/v0/add-public-feed.sql
@@ -2,8 +2,8 @@
 
 --changeset event-api-migrations:v0/add-public-feed.sql runOnChange:false
 
-INSERT INTO feeds (feed_id, alias, description, providers)
-VALUES (uuid_generate_v4(), 'kontur-public', 'Public feed','{"gdacsAlert","gdacsAlertGeometry"}');
+insert into feeds (feed_id, alias, description, providers)
+values (uuid_generate_v4(), 'kontur-public', 'Public feed','{"gdacsAlert","gdacsAlertGeometry"}');
 
 insert into feed_event_status (feed_id, event_id, actual)
 select distinct on (event_id) fs.feed_id, event_id, false

--- a/src/main/resources/db/changelog/v0/add-schema-to-functions.sql
+++ b/src/main/resources/db/changelog/v0/add-schema-to-functions.sql
@@ -2,16 +2,16 @@
 
 --changeset event-api-migrations:v0/add-schema-to-functions runOnChange:false
 
-ALTER TABLE normalized_observations DROP COLUMN collected_geography;
+alter table normalized_observations drop column collected_geography;
 
-DROP FUNCTION collectGeomFromGeoJSON;
+drop function collectGeomFromGeoJSON;
 
-CREATE FUNCTION collectGeomFromGeoJSON(jsonb) RETURNS geometry
-    AS 'select public.ST_Collect( public.ST_GeomFromGeoJSON(feature->''geometry'')) from jsonb_array_elements($1->''features'') feature;'
-    LANGUAGE SQL
-    IMMUTABLE
-    RETURNS NULL ON NULL INPUT;
+create function collectGeomFromGeoJSON(jsonb) returns geometry
+    as 'select public.ST_Collect(public.ST_GeomFromGeoJSON(feature->''geometry'')) from jsonb_array_elements($1->''features'') feature;'
+    language sql
+    immutable
+    strict;
 
-ALTER TABLE normalized_observations ADD COLUMN collected_geography geography GENERATED ALWAYS AS (collectGeomFromGeoJSON(geometries)::geography) STORED;
+alter table normalized_observations add column collected_geography geography generated always as (collectGeomFromGeoJSON(geometries)::geography) stored;
 
-CREATE INDEX ON normalized_observations USING GIST (collected_geography);
+create index on normalized_observations using gist (collected_geography);

--- a/src/main/resources/db/changelog/v0/add_constraints.sql
+++ b/src/main/resources/db/changelog/v0/add_constraints.sql
@@ -1,6 +1,6 @@
 --liquibase formatted sql
 
 --changeset event-api-migrations:v0/add_constraints runOnChange:false
-ALTER TABLE feed_event_status ALTER COLUMN actual SET NOT NULL;
-ALTER TABLE data_lake ALTER COLUMN normalized SET NOT NULL;
-ALTER TABLE normalized_observations ALTER COLUMN recombined SET NOT NULL;
+alter table feed_event_status alter column actual set not null;
+alter table data_lake alter column normalized set not null;
+alter table normalized_observations alter column recombined set not null;

--- a/src/main/resources/db/changelog/v0/add_feed_event_status.sql
+++ b/src/main/resources/db/changelog/v0/add_feed_event_status.sql
@@ -2,24 +2,24 @@
 
 --changeset event-api-migrations:add_feed_event_status runOnChange:false
 
-CREATE TABLE feed_event_status
+create table feed_event_status
 (
     feed_id     uuid references feeds (feed_id),
     event_id    uuid,
     actual      boolean,
 
-    UNIQUE (feed_id, event_id)
+    unique (feed_id, event_id)
 );
 
-CREATE INDEX ON feed_event_status (feed_id, actual);
+create index on feed_event_status (feed_id, actual);
 
-DELETE FROM feed_data;
+delete from feed_data;
 
-INSERT INTO feed_event_status (event_id, feed_id, actual)
-SELECT ke.event_id, f.feed_id, false
-FROM kontur_events ke, feeds f
-WHERE ke.provider = ANY(f.providers)
-GROUP BY ke.event_id, f.feed_id
+insert into feed_event_status (event_id, feed_id, actual)
+select ke.event_id, f.feed_id, false
+from kontur_events ke, feeds f
+where ke.provider = ANY(f.providers)
+group by ke.event_id, f.feed_id
 
 
 

--- a/src/main/resources/db/changelog/v0/add_flags_for_processed_items.sql
+++ b/src/main/resources/db/changelog/v0/add_flags_for_processed_items.sql
@@ -1,8 +1,8 @@
 --liquibase formatted sql
 
 --changeset event-api-migrations:v0/add_flags_for_processed_items.sql runOnChange:false
-ALTER TABLE data_lake ADD COLUMN normalized boolean;
-UPDATE data_lake dl SET normalized  = EXISTS (SELECT 1 FROM normalized_observations nr WHERE dl.observation_id = nr.observation_id);
+alter table data_lake add column normalized boolean;
+update data_lake dl set normalized = exists(select 1 from normalized_observations nr where dl.observation_id = nr.observation_id);
 
-ALTER TABLE normalized_observations ADD COLUMN recombined boolean;
-UPDATE normalized_observations no SET recombined  = EXISTS(SELECT 1 FROM kontur_events ke WHERE ke.observation_id = no.observation_id);
+alter table normalized_observations add column recombined boolean;
+update normalized_observations no set recombined = exists(select 1 from kontur_events ke where ke.observation_id = no.observation_id);

--- a/src/main/resources/db/changelog/v0/add_geometry_column_in_feed_data.sql
+++ b/src/main/resources/db/changelog/v0/add_geometry_column_in_feed_data.sql
@@ -2,15 +2,15 @@
 
 --changeset event-api-migrations:v0/add_geometry_column_in_feed_data runOnChange:false splitStatements:false
 
-CREATE FUNCTION collectGeometryFromEpisodes(jsonb) RETURNS geometry
-AS $$
+create function collectGeometryFromEpisodes(jsonb) returns geometry
+as $$
     select ST_Collect(ST_GeomFromGeoJSON(feature.geometries))
     from (select jsonb_array_elements(e -> 'geometries' -> 'features') -> 'geometry' as geometries
           from jsonb_array_elements($1) e) feature;
     $$
-    LANGUAGE SQL
-    STRICT
-    IMMUTABLE PARALLEL SAFE;
+    language sql
+    strict
+    immutable parallel safe;
 
-ALTER TABLE feed_data ADD COLUMN collected_geometry geometry GENERATED ALWAYS AS (collectGeometryFromEpisodes(episodes)) STORED;
-CREATE INDEX ON feed_data USING GIST (collected_geometry);
+alter table feed_data add column collected_geometry geometry generated always as (collectGeometryFromEpisodes(episodes)) stored;
+create index on feed_data using gist (collected_geometry);

--- a/src/main/resources/db/changelog/v0/add_missed_indexes.sql
+++ b/src/main/resources/db/changelog/v0/add_missed_indexes.sql
@@ -2,8 +2,8 @@
 
 --changeset event-api-migrations:add_missed_indexes runOnChange:false
 
-CREATE INDEX ON data_lake (normalized, loaded_at);
-CREATE INDEX ON normalized_observations (recombined);
+create index on data_lake (normalized, loaded_at);
+create index on normalized_observations (recombined);
 
 
 

--- a/src/main/resources/db/changelog/v0/add_normalized_observations_external_episode_id_loaded_at_observation_provider_index.sql
+++ b/src/main/resources/db/changelog/v0/add_normalized_observations_external_episode_id_loaded_at_observation_provider_index.sql
@@ -2,5 +2,5 @@
 
 --changeset event-api-migrations:v0/add_normalized_observations_external_episode_id_loaded_at_observation_provider_index.sql runOnChange:false
 
-CREATE INDEX normalized_observations_external_episode_id_loaded_at_observation_provider_index
-    ON normalized_observations (external_episode_id, loaded_at, observation_id, provider);
+create index normalized_observations_external_episode_id_loaded_at_observation_provider_index
+    on normalized_observations (external_episode_id, loaded_at, observation_id, provider);

--- a/src/main/resources/db/changelog/v0/add_updated_at_index_for_feed_data.sql
+++ b/src/main/resources/db/changelog/v0/add_updated_at_index_for_feed_data.sql
@@ -2,4 +2,4 @@
 
 --changeset event-api-migrations:add_updated_at_index_for_feed_data runOnChange:false
 
-CREATE INDEX ON feed_data (updated_at);
+create index on feed_data (updated_at);

--- a/src/main/resources/db/changelog/v0/create_collectGeomFromGeoJSON_function.sql
+++ b/src/main/resources/db/changelog/v0/create_collectGeomFromGeoJSON_function.sql
@@ -2,8 +2,8 @@
 
 --changeset event-api-migrations:create_collectGeomFromGeoJSON_function.sql runOnChange:true
 
-CREATE OR REPLACE FUNCTION collectGeomFromGeoJSON(jsonb) RETURNS geometry
-AS 'select public.ST_Collect(public.ST_GeomFromGeoJSON(NULLIF(feature -> ''geometry'', ''null''::jsonb))) from jsonb_array_elements($1->''features'') feature;'
-    LANGUAGE SQL
-    IMMUTABLE
-    RETURNS NULL ON NULL INPUT;
+create or replace function collectGeomFromGeoJSON(jsonb) returns geometry
+as 'select public.ST_Collect(public.ST_GeomFromGeoJSON(nullif(feature -> ''geometry'', ''null''::jsonb))) from jsonb_array_elements($1->''features'') feature;'
+    language sql
+    immutable
+    strict;

--- a/src/main/resources/db/changelog/v0/create_collectGeometryFromEpisodes_function.sql
+++ b/src/main/resources/db/changelog/v0/create_collectGeometryFromEpisodes_function.sql
@@ -2,12 +2,12 @@
 
 --changeset event-api-migrations:v0/create_collectGeometryFromEpisodes_function.sql runOnChange:true splitStatements:false
 
-CREATE OR REPLACE FUNCTION collectGeometryFromEpisodes(jsonb) RETURNS geometry
-AS $$
-select ST_Collect(ST_GeomFromGeoJSON(NULLIF(feature.geometries, 'null'::jsonb)))
+create or replace function collectGeometryFromEpisodes(jsonb) returns geometry
+as $$
+select ST_Collect(ST_GeomFromGeoJSON(nullif(feature.geometries, 'null'::jsonb)))
 from (select jsonb_array_elements(e -> 'geometries' -> 'features') -> 'geometry' as geometries
       from jsonb_array_elements($1) e) feature;
 $$
-    LANGUAGE SQL
-    STRICT
-    IMMUTABLE PARALLEL SAFE;
+    language sql
+    strict
+    immutable parallel safe;

--- a/src/main/resources/db/changelog/v0/fix_feed_data_index.sql
+++ b/src/main/resources/db/changelog/v0/fix_feed_data_index.sql
@@ -1,6 +1,6 @@
 --liquibase formatted sql
 
 --changeset event-api-migrations:v0/fix_feed_data_index.sql runOnChange:false
-DROP INDEX feed_data_observations;
-DROP INDEX feed_data_updated_at_version_unique;
-CREATE UNIQUE INDEX feed_data_event_id_updated_at_version_unique ON feed_data (feed_id, event_id, updated_at, version);
+drop index feed_data_observations;
+drop index feed_data_updated_at_version_unique;
+create unique index feed_data_event_id_updated_at_version_unique on feed_data (feed_id, event_id, updated_at, version);

--- a/src/main/resources/db/changelog/v0/insert-swiss-re-feed.sql
+++ b/src/main/resources/db/changelog/v0/insert-swiss-re-feed.sql
@@ -2,5 +2,5 @@
 
 --changeset event-api-migrations:insert-swiss-re-feed.sql runOnChange:false
 
-INSERT INTO feeds (feed_id, alias,description, providers)
-VALUES (uuid_generate_v4(), 'swissre-02', 'Swiss Re version 02 historical hazards', '{"tornado.canada-gov", "tornado.australian-bm", "tornado.osm-wiki", "tornado.noaa", "wildfire.frap.cal"}');
+insert into feeds (feed_id, alias,description, providers)
+values (uuid_generate_v4(), 'swissre-02', 'Swiss Re version 02 historical hazards', '{"tornado.canada-gov", "tornado.australian-bm", "tornado.osm-wiki", "tornado.noaa", "wildfire.frap.cal"}');

--- a/src/main/resources/db/changelog/v0/update-feed-data-is-latest-version-index.sql
+++ b/src/main/resources/db/changelog/v0/update-feed-data-is-latest-version-index.sql
@@ -4,4 +4,4 @@
 
 drop index if exists feed_data_updated_at_feed_id_is_latest_version_idx;
 
-CREATE INDEX if not exists feed_data_updated_at_feed_id_is_latest_version_enriched_idx ON public.feed_data USING btree (updated_at, feed_id) where is_latest_version and enriched;
+create index if not exists feed_data_updated_at_feed_id_is_latest_version_enriched_idx on public.feed_data using btree (updated_at, feed_id) where is_latest_version and enriched;

--- a/src/main/resources/db/changelog/v1.0/insert-test-inciweb-feed.sql
+++ b/src/main/resources/db/changelog/v1.0/insert-test-inciweb-feed.sql
@@ -2,5 +2,5 @@
 
 --changeset event-api-migrations:v1.0/insert-test-inciweb-feed runOnChange:false
 
-INSERT INTO feeds (feed_id, alias, description, providers)
-VALUES (uuid_generate_v4(), 'test-inciweb', 'Real-time wildfires of the USA from Incident Information System (InciWeb)', '{"wildfire.inciweb"}');
+insert into feeds (feed_id, alias, description, providers)
+values (uuid_generate_v4(), 'test-inciweb', 'Real-time wildfires of the USA from Incident Information System (InciWeb)', '{"wildfire.inciweb"}');

--- a/src/main/resources/db/changelog/v1.11/create-collect-cyclone-geometry-function.sql
+++ b/src/main/resources/db/changelog/v1.11/create-collect-cyclone-geometry-function.sql
@@ -14,7 +14,7 @@ $$
     with features as (
         select
             f.feature -> 'properties' as props,
-            st_makevalid(st_geomfromgeojson(NULLIF(f.feature -> 'geometry', 'null'::jsonb))) as geom
+            ST_MakeValid(ST_GeomFromGeoJSON(nullif(f.feature -> 'geometry', 'null'::jsonb))) as geom
         from (
             select jsonb_array_elements(e -> 'geometries' -> 'features') as feature
             from jsonb_array_elements($1) e
@@ -29,8 +29,8 @@ $$
     ),
     trackline as (
         select jsonb_build_object('areaType', 'track', 'windSpeedKph', (p.props ->> 'windSpeedKph')::numeric, 'isObserved',
-            ((LEAD(p.props) OVER(ORDER BY (p.props ->> 'timestamp'))) ->> 'isObserved')::boolean),
-               ST_MakeLine(p.geom, LEAD(p.geom) OVER(ORDER BY (p.props ->> 'timestamp'))) AS geom
+            ((lead(p.props) over(order by (p.props ->> 'timestamp'))) ->> 'isObserved')::boolean),
+               ST_MakeLine(p.geom, lead(p.geom) over(order by (p.props ->> 'timestamp'))) as geom
         from positions p
     ),
     alerts34 as (

--- a/src/main/resources/db/changelog/v1.11/insert-nhc-feed.sql
+++ b/src/main/resources/db/changelog/v1.11/insert-nhc-feed.sql
@@ -2,6 +2,6 @@
 
 --changeset event-api-migrations:v1.11/insert-nhc-feed.sql runOnChange:false
 
-INSERT INTO feeds (feed_id, alias, description, providers)
-VALUES (uuid_generate_v4(), 'test-cyclone', 'Real-time cyclones from NHC',
+insert into feeds (feed_id, alias, description, providers)
+values (uuid_generate_v4(), 'test-cyclone', 'Real-time cyclones from NHC',
         '{"cyclones.nhc-at.noaa", "cyclones.nhc-ep.noaa", "cyclones.nhc-cp.noaa"}');

--- a/src/main/resources/db/changelog/v1.13/update-collect-cyclone-geometry-function.sql
+++ b/src/main/resources/db/changelog/v1.13/update-collect-cyclone-geometry-function.sql
@@ -14,7 +14,7 @@ $$
     with features as (
         select
             f.feature -> 'properties' as props,
-            st_makevalid(st_geomfromgeojson(NULLIF(f.feature -> 'geometry', 'null'::jsonb))) as geom
+            ST_MakeValid(ST_GeomFromGeoJSON(nullif(f.feature -> 'geometry', 'null'::jsonb))) as geom
         from (
             select jsonb_array_elements(e -> 'geometries' -> 'features') as feature
             from jsonb_array_elements($1) e
@@ -29,8 +29,8 @@ $$
     ),
     trackline as (
         select jsonb_build_object('areaType', 'track', 'windSpeedKph', (p.props ->> 'windSpeedKph')::numeric, 'isObserved',
-            ((LEAD(p.props) OVER(ORDER BY (p.props ->> 'timestamp'))) ->> 'isObserved')::boolean),
-               ST_MakeLine(p.geom, LEAD(p.geom) OVER(ORDER BY (p.props ->> 'timestamp'))) AS geom
+            ((lead(p.props) over(order by (p.props ->> 'timestamp'))) ->> 'isObserved')::boolean),
+               ST_MakeLine(p.geom, lead(p.geom) over(order by (p.props ->> 'timestamp'))) as geom
         from positions p
     ),
     alerts34 as (

--- a/src/main/resources/db/changelog/v1.14.4/update-schema-for-collectcyclonegeometry-function.sql
+++ b/src/main/resources/db/changelog/v1.14.4/update-schema-for-collectcyclonegeometry-function.sql
@@ -12,7 +12,7 @@ as
     with features as (
         select
             f.feature -> ''properties'' as props,
-            public.st_makevalid(public.st_geomfromgeojson(NULLIF(f.feature -> ''geometry'', ''null''::jsonb))) as geom
+            public.ST_MakeValid(public.ST_GeomFromGeoJSON(nullif(f.feature -> ''geometry'', ''null''::jsonb))) as geom
         from (
             select jsonb_array_elements(e -> ''geometries'' -> ''features'') as feature
             from jsonb_array_elements($1) e
@@ -27,8 +27,8 @@ as
     ),
     trackline as (
         select jsonb_build_object(''areaType'', ''track'', ''windSpeedKph'', (p.props ->> ''windSpeedKph'')::numeric, ''isObserved'',
-            ((LEAD(p.props) OVER(ORDER BY (p.props ->> ''timestamp''))) ->> ''isObserved'')::boolean),
-               public.ST_MakeLine(p.geom, LEAD(p.geom) OVER(ORDER BY (p.props ->> ''timestamp''))) AS geom
+            ((lead(p.props) over(order by (p.props ->> ''timestamp''))) ->> ''isObserved'')::boolean),
+               public.ST_MakeLine(p.geom, lead(p.geom) over(order by (p.props ->> ''timestamp''))) as geom
         from positions p
     ),
     alerts34 as (

--- a/src/main/resources/db/changelog/v1.14.4/update-schema-for-collecteventgeometries-function.sql
+++ b/src/main/resources/db/changelog/v1.14.4/update-schema-for-collecteventgeometries-function.sql
@@ -10,7 +10,7 @@ as '
     with features as (
         select
             f.feature -> ''properties'' as props,
-            public.st_makevalid(public.st_geomfromgeojson(NULLIF(f.feature -> ''geometry'', ''null''::jsonb))) as geom
+            public.ST_MakeValid(public.ST_GeomFromGeoJSON(nullif(f.feature -> ''geometry'', ''null''::jsonb))) as geom
         from (
             select jsonb_array_elements(e -> ''geometries'' -> ''features'') as feature
             from jsonb_array_elements($1) e
@@ -19,7 +19,7 @@ as '
         where f.feature -> ''geometry'' != ''null''::jsonb
     ),
     areas as (
-        select f.props as props, public.st_setsrid(public.st_union(f.geom), 4326) as geom
+        select f.props as props, public.ST_SetSRID(public.ST_Union(f.geom), 4326) as geom
         from features f
         where f.props ->> ''areaType'' in (''exposure'', ''alertArea'', ''globalArea'')
         group by f.props
@@ -39,7 +39,7 @@ as '
         select jsonb_build_object(''areaType'', ''centerPoint'') as props, (
             case
                 when exists(select * from areas) or exists(select * from startPoint) or exists(select * from other) then (
-                    select public.st_centroid(public.st_collect(f.geom)) as geom
+                    select public.ST_Centroid(public.ST_Collect(f.geom)) as geom
                     from (
                         select * from areas
                         union select * from startPoint

--- a/src/main/resources/db/changelog/v1.14.4/update-schema-for-collectgeometryfromepisodes-function.sql
+++ b/src/main/resources/db/changelog/v1.14.4/update-schema-for-collectgeometryfromepisodes-function.sql
@@ -7,7 +7,7 @@ create or replace function collectGeometryFromEpisodes(jsonb) returns geometry
     strict
     immutable parallel safe
 as '
-select public.ST_Collect(public.ST_GeomFromGeoJSON(NULLIF(feature.geometries, ''null''::jsonb)))
+select public.ST_Collect(public.ST_GeomFromGeoJSON(nullif(feature.geometries, ''null''::jsonb)))
 from (select jsonb_array_elements(e -> ''geometries'' -> ''features'') -> ''geometry'' as geometries
       from jsonb_array_elements($1) e) feature;
 ';

--- a/src/main/resources/db/changelog/v1.15/create-new-feed-data-table.sql
+++ b/src/main/resources/db/changelog/v1.15/create-new-feed-data-table.sql
@@ -2,13 +2,13 @@
 
 --changeset event-api-migrations:v1.15/create-new-feed-data-table.sql runOnChange:true
 
-drop table if exists public.severities CASCADE;
+drop table if exists public.severities cascade;
 
 create table public.severities
 (
     severity_id smallserial not null,
     severity    text,
-    UNIQUE (severity_id)
+    unique (severity_id)
 );
 
 insert into public.severities(severity_id, severity)
@@ -33,7 +33,7 @@ create table public.feed_data_upd
     updated_at          timestamp with time zone,                           --8
     started_at          timestamp with time zone,                           --8
     ended_at            timestamp with time zone,                           --8
-    composed_at         timestamp with time zone default CURRENT_TIMESTAMP, --8
+    composed_at         timestamp with time zone default current_timestamp, --8
     enriched_at         timestamp with time zone,                           --8
     enrichment_skipped  boolean                  default false,             --1
     type                text,
@@ -41,17 +41,17 @@ create table public.feed_data_upd
     description         text,
     episodes            jsonb,
     observations        uuid[],
-    collected_geometry  public.geometry GENERATED ALWAYS AS (public.collectgeometryfromepisodes(episodes)) STORED,
+    collected_geometry  public.geometry generated always as (public.collectgeometryfromepisodes(episodes)) stored,
     event_details       jsonb                    default '{}'::jsonb,
     geometries          jsonb,
     urls                text[]                   default '{}'::text[],
     proper_name         text,
     location            text,
-    FOREIGN KEY (feed_id)
-        REFERENCES public.feeds (feed_id),
-    FOREIGN KEY (severity_id)
-        REFERENCES public.severities (severity_id),
-    UNIQUE (event_id, version, feed_id)
+    foreign key (feed_id)
+        references public.feeds (feed_id),
+    foreign key (severity_id)
+        references public.severities (severity_id),
+    unique (event_id, version, feed_id)
 );
 
 insert into public.feed_data_upd
@@ -113,7 +113,7 @@ from feed_data;
 create index feed_data_collected_geometry_gist_idx
     on feed_data_upd
     using gist (collected_geometry)
-    where (is_latest_version AND enriched);
+    where (is_latest_version and enriched);
 
 create index feed_data_composed_at_btree_idx
     on feed_data_upd
@@ -143,10 +143,10 @@ create index feed_data_updated_at_btree_idx
 
 create index feed_data_updated_at_is_not_enriched_btree_idx
     on feed_data_upd
-    using btree (enrichment_attempts NULLS FIRST, updated_at)
+    using btree (enrichment_attempts nulls first, updated_at)
     where not enriched;
 
 create index feed_data_updated_at_latest_version_enriched_btree_idx
     on feed_data_upd
     using btree (updated_at)
-    where not is_latest_version AND enriched;
+    where not is_latest_version and enriched;

--- a/src/main/resources/db/changelog/v1.15/replace-feed-data-table-with-new-one.sql
+++ b/src/main/resources/db/changelog/v1.15/replace-feed-data-table-with-new-one.sql
@@ -3,8 +3,8 @@
 --changeset event-api-migrations:v1.15/replace-feed-data-table-with-new-one.sql runOnChange:true
 
 --BEGIN;
-ALTER TABLE public.feed_data
+alter table public.feed_data
     RENAME TO feed_data__old;
-ALTER TABLE public.feed_data_upd
+alter table public.feed_data_upd
     RENAME TO feed_data;
 --COMMIT;

--- a/src/main/resources/db/mappers/ApiMapper.xml
+++ b/src/main/resources/db/mappers/ApiMapper.xml
@@ -8,9 +8,9 @@
     </select>
 
     <select id="findDataByObservationId" resultType="java.lang.String">
-        SELECT data
-        FROM data_lake
-        WHERE observation_id = #{observationId}
+        select data
+        from data_lake
+        where observation_id = #{observationId}
     </select>
 
     <select id="searchForEvents" resultType="java.lang.String">
@@ -30,10 +30,10 @@
                     </when>
                     <otherwise>fd.episodes,</otherwise>
                 </choose>
-                box2d(fd.collected_geometry) as bbox, st_pointonsurface(fd.collected_geometry) as centroid
+                box2d(fd.collected_geometry) as bbox, ST_PointOnSurface(fd.collected_geometry) as centroid
             from feed_data fd
             left join severities sv on fd.severity_id = sv.severity_id
-            where fd.feed_id = ( select feed_id from feeds where alias = #{feedAlias} )
+            where fd.feed_id = (select feed_id from feeds where alias = #{feedAlias})
                 and fd.is_latest_version and fd.enriched
                 <if test="eventTypes!=null &amp;&amp; !eventTypes.isEmpty" >
                     <foreach item="eventType" collection="eventTypes" separator="," open="and fd.type in (" close=")">
@@ -51,20 +51,20 @@
                 <if test='from != null'><![CDATA[and (fd.ended_at >= #{from})]]></if>
                 <if test='to != null'><![CDATA[and (fd.started_at <= #{to})]]></if>
                 <if test='updatedAfter != null'>
-                    <if test='"ASC".equalsIgnoreCase(sortOrder)'>and fd.updated_at > #{updatedAfter}</if>
-                    <if test='"DESC".equalsIgnoreCase(sortOrder)'>and fd.updated_at &lt; #{updatedAfter}</if>
+                    <if test='"asc".equalsIgnoreCase(sortOrder)'>and fd.updated_at > #{updatedAfter}</if>
+                    <if test='"desc".equalsIgnoreCase(sortOrder)'>and fd.updated_at &lt; #{updatedAfter}</if>
                 </if>
                 <if test="xMin!=null &amp;&amp; yMin!=null &amp;&amp; xMax!=null &amp;&amp; yMax!=null">
                     and ST_Intersects(ST_MakeEnvelope(#{xMin}, #{yMin}, #{xMax}, #{yMax}, 4326), fd.collected_geometry)
                 </if>
             order by fd.updated_at ${sortOrder}
             limit #{limit}
-        )
+       )
         select case when count(*) > 0 then json_build_object(
             'pageMetadata', json_build_object('nextAfterValue',
                 (select
                     <choose>
-                        <when test='"DESC".equalsIgnoreCase(sortOrder)'>min(e.updated_at)</when>
+                        <when test='"desc".equalsIgnoreCase(sortOrder)'>min(e.updated_at)</when>
                         <otherwise>max(e.updated_at)</otherwise>
                     </choose>
                 from events e)),
@@ -89,9 +89,9 @@
                 'geometries', geometries,
                 'episodes', episodes,
                 'episodeCount', episode_count,
-                'bbox', array[st_xmin(bbox), st_ymin(bbox), st_xmax(bbox),st_ymax(bbox)],
-                'centroid', array[st_x(centroid), st_y(centroid)]
-              )))
+                'bbox', array[ST_XMin(bbox), ST_YMin(bbox), ST_XMax(bbox), ST_YMax(bbox)],
+                'centroid', array[ST_X(centroid), ST_Y(centroid)]
+             )))
             end
         from events
     </select>
@@ -108,23 +108,23 @@
                         select episode from jsonb_array_elements(fd.episodes) episode
                         order by (episode ->> 'updatedAt')::timestamptz desc
                         limit 1
-                        )) as episodes,
+                       )) as episodes,
                     </when>
                     <when test='"NONE".equalsIgnoreCase(episodeFilterType)'>
                         '[]'::jsonb as episodes,
                     </when>
                     <otherwise>fd.episodes,</otherwise>
                 </choose>
-                box2d(fd.collected_geometry) as bbox, st_pointonsurface(fd.collected_geometry) as centroid
+                box2d(fd.collected_geometry) as bbox, ST_PointOnSurface(fd.collected_geometry) as centroid
             from feed_data fd
             left join severities sv on fd.severity_id = sv.severity_id
             where fd.event_id = #{eventId}
-                and fd.feed_id = ( select feed_id from feeds where alias = #{feedAlias} )
+                and fd.feed_id = (select feed_id from feeds where alias = #{feedAlias})
                 <choose>
                     <when test="version != null">and fd.version = #{version}</when>
                     <otherwise>and fd.is_latest_version</otherwise>
                 </choose>
-        )
+       )
         select
             json_build_object(
                 'eventId', event_id,
@@ -147,9 +147,9 @@
                 'geometries', geometries,
                 'episodes', episodes,
                 'episodeCount', episode_count,
-                'bbox', array[st_xmin(bbox), st_ymin(bbox), st_xmax(bbox),st_ymax(bbox)],
-                'centroid', array[st_x(centroid), st_y(centroid)]
-              )
+                'bbox', array[ST_XMin(bbox), ST_YMin(bbox), ST_XMax(bbox), ST_YMax(bbox)],
+                'centroid', array[ST_X(centroid), ST_Y(centroid)]
+             )
         from event
     </select>
 
@@ -170,7 +170,7 @@
                 </choose>
             from feed_data fd
             left join severities sv on fd.severity_id = sv.severity_id
-            where fd.feed_id = ( select feed_id from feeds where alias = #{feedAlias} )
+            where fd.feed_id = (select feed_id from feeds where alias = #{feedAlias})
                 and fd.is_latest_version and fd.enriched
                 <if test="eventTypes!=null &amp;&amp; !eventTypes.isEmpty" >
                     <foreach item="eventType" collection="eventTypes" separator="," open="and fd.type in (" close=")">
@@ -188,23 +188,23 @@
                 <if test='from != null'><![CDATA[and (fd.ended_at >= #{from})]]></if>
                 <if test='to != null'><![CDATA[and (fd.started_at <= #{to})]]></if>
                 <if test='updatedAfter != null'>
-                    <if test='"ASC".equalsIgnoreCase(sortOrder)'>and fd.updated_at > #{updatedAfter}</if>
-                    <if test='"DESC".equalsIgnoreCase(sortOrder)'>and fd.updated_at &lt; #{updatedAfter}</if>
+                    <if test='"asc".equalsIgnoreCase(sortOrder)'>and fd.updated_at > #{updatedAfter}</if>
+                    <if test='"desc".equalsIgnoreCase(sortOrder)'>and fd.updated_at &lt; #{updatedAfter}</if>
                 </if>
                 <if test="xMin!=null &amp;&amp; yMin!=null &amp;&amp; xMax!=null &amp;&amp; yMax!=null">
                     and ST_MakeEnvelope(#{xMin}, #{yMin}, #{xMax}, #{yMax}, 4326) &amp;&amp; fd.collected_geometry
                 </if>
             order by fd.updated_at ${sortOrder}
             limit #{limit}
-        ),
+       ),
         episodes as (
             select event_id, jsonb_array_elements(episodes) episode
             from events
-        ),
+       ),
         features as (
             select event_id, episode, jsonb_array_elements(episode -> 'geometries' -> 'features') feature
             from episodes
-        ),
+       ),
         props as (
             select
                 event_id as "eventId",
@@ -230,14 +230,14 @@
                 feature -> 'properties' -> 'severityData' as "feature_severityData",
                 ST_GeomFromGeoJSON(feature -> 'geometry') as geom
             from features
-        )
+       )
         select
             case when count(*) > 0 then json_build_object(
                 'type', 'FeatureCollection',
                 'pageMetadata', json_build_object('nextAfterValue',
                     (select
                         <choose>
-                            <when test='"DESC".equalsIgnoreCase(sortOrder)'>min(e.updated_at)</when>
+                            <when test='"desc".equalsIgnoreCase(sortOrder)'>min(e.updated_at)</when>
                             <otherwise>max(e.updated_at)</otherwise>
                         </choose>
                     from events e)),

--- a/src/main/resources/db/mappers/DataLakeMapper.xml
+++ b/src/main/resources/db/mappers/DataLakeMapper.xml
@@ -5,123 +5,118 @@
 <mapper namespace="io.kontur.eventapi.dao.mapper.DataLakeMapper">
 
     <insert id="create" useGeneratedKeys="false">
-        INSERT INTO data_lake (observation_id, external_id, updated_at, loaded_at, provider, data, normalized, skipped)
-        VALUES (#{observationId}, #{externalId}, #{updatedAt}, #{loadedAt}, #{provider}, #{data}, #{normalized}, #{skipped})
+        insert into data_lake (observation_id, external_id, updated_at, loaded_at, provider, data, normalized, skipped)
+        values (#{observationId}, #{externalId}, #{updatedAt}, #{loadedAt}, #{provider}, #{data}, #{normalized}, #{skipped})
     </insert>
 
     <insert id="markAsNormalized">
-        UPDATE data_lake SET normalized = 'true' WHERE observation_id = #{observationId}
+        update data_lake set normalized = 'true' where observation_id = #{observationId}
     </insert>
 
     <insert id="markAsSkipped">
-        UPDATE data_lake SET skipped = true WHERE observation_id = #{observationId}
+        update data_lake set skipped = true where observation_id = #{observationId}
     </insert>
 
     <select id="getLatestUpdatedEventForProvider" resultType="io.kontur.eventapi.entity.DataLake">
-        SELECT observation_id as observationId, external_id as externalId, updated_at as updatedAt, loaded_at as loadedAt, provider, data
-        FROM data_lake
-        WHERE provider = #{provider}
-        ORDER BY updated_at DESC
-        LIMIT 1
+        select observation_id as observationId, external_id as externalId, updated_at as updatedAt, loaded_at as loadedAt, provider, data
+        from data_lake
+        where provider = #{provider}
+        order by updated_at desc
+        limit 1
     </select>
 
     <select id="getPdcHpSrvHazardsWithoutAreas" resultMap="dataLakeMap">
-        SELECT distinct on (e1.external_id) *
-        FROM data_lake e1
-        WHERE e1.provider = 'hpSrvSearch'
-          AND NOT EXISTS(
-                select * from data_lake e2 where e1.external_id = e2.external_id and e2.provider = 'hpSrvMag'
-              )
+        select distinct on (e1.external_id) *
+        from data_lake e1
+        where e1.provider = 'hpSrvSearch'
+          and not exists(
+                select 1 from data_lake e2 where e1.external_id = e2.external_id and e2.provider = 'hpSrvMag'
+             )
     </select>
 
     <select id="getDenormalizedEvents" resultMap="dataLakeMap">
-        SELECT *
-        FROM data_lake e
-        WHERE normalized is false and skipped is false
+        select *
+        from data_lake e
+        where normalized is false and skipped is false
         <foreach item="provider" collection="providers" separator="," open="and provider in (" close=")">
             #{provider}
         </foreach>
-        ORDER BY loaded_at
-        LIMIT 100000
+        order by loaded_at
+        limit 100000
     </select>
 
     <select id="getDataLakesByExternalId" resultMap="dataLakeMap">
-        SELECT *
-        FROM data_lake
-        WHERE external_id = #{externalId}
+        select *
+        from data_lake
+        where external_id = #{externalId}
     </select>
 
     <select id="getDataLakesByExternalIds" resultMap="dataLakeMap">
-        SELECT *
-        FROM data_lake
-        WHERE
+        select *
+        from data_lake
+        where
         <foreach item="externalId" collection="externalIds" separator="," open="external_id in (" close=")">
             #{externalId}
         </foreach>
     </select>
 
     <select id="getDataLakesByExternalIdsAndProvider" resultMap="dataLakeMap">
-        SELECT *
-        FROM data_lake
-        WHERE
-        provider = #{provider} AND
+        select *
+        from data_lake
+        where
+        provider = #{provider} and
         <foreach item="externalId" collection="externalIds" separator="," open="external_id in (" close=")">
             #{externalId}
         </foreach>
     </select>
 
     <select id="getDataLakesIdByExternalIdsAndProvider" resultType="java.lang.String">
-        SELECT external_id
-        FROM data_lake
-        WHERE
-        provider = #{provider} AND
+        select external_id
+        from data_lake
+        where
+        provider = #{provider} and
         <foreach item="externalId" collection="externalIds" separator="," open="external_id in (" close=")">
             #{externalId}
         </foreach>
     </select>
 
     <select id="getLatestDataLakeByExternalIdAndProvider" resultMap="dataLakeMap">
-        SELECT *
-        FROM data_lake
-        WHERE external_id = #{externalId}
-          AND provider = #{provider}
-        ORDER BY updated_at DESC
-        LIMIT 1
+        select *
+        from data_lake
+        where external_id = #{externalId}
+          and provider = #{provider}
+        order by updated_at desc
+        limit 1
     </select>
 
     <select id="getPdcExposureGeohashes" resultMap="exposureGeohash">
-        SELECT external_id, jsonb_object_field_text((data::jsonb)->'properties', 'geohash') as geohash
-        FROM data_lake
-        WHERE provider = 'pdcMapSrv' AND
+        select external_id, jsonb_object_field_text((data::jsonb)->'properties', 'geohash') as geohash
+        from data_lake
+        where provider = 'pdcMapSrv' and
         <foreach item="externalId" collection="externalIds" separator="," open="external_id in (" close=")">
             #{externalId}
         </foreach>
     </select>
 
     <select id="isNewPdcExposure" resultType="java.lang.Boolean">
-        WITH datalakes AS (
-            SELECT * FROM data_lake
-            WHERE external_id = #{externalId} AND provider = 'pdcMapSrv'
-        )
-        SELECT
-            CASE WHEN EXISTS (
-                SELECT * FROM datalakes
-                WHERE jsonb_object_field_text((data::jsonb)->'properties', 'geohash') = #{geoHash}
-            ) THEN FALSE ELSE TRUE
-            END
+        with datalakes as (
+            select * from data_lake
+            where external_id = #{externalId} and provider = 'pdcMapSrv'
+       )
+        select not exists(
+                select 1 from datalakes
+                where jsonb_object_field_text((data::jsonb)->'properties', 'geohash') = #{geoHash}
+            )
     </select>
 
     <select id="isNewEvent" resultType="java.lang.Boolean">
-        SELECT
-            CASE WHEN EXISTS (
-                    SELECT a.*
-                    FROM (SELECT * FROM data_lake
-                          WHERE external_id =  #{externalId}
-                            AND provider = #{provider}
-                            AND updated_at at time zone 'UTC' = to_timestamp(#{updatedAt}, 'YYYY-MM-DDThh24:mi:ss')::timestamp
-                         ) a
-                ) THEN FALSE ELSE TRUE
-                END
+        select not exists(
+                select 1
+                from data_lake
+                where external_id =  #{externalId}
+                  and provider = #{provider}
+                  and updated_at at time zone 'UTC' = to_timestamp(#{updatedAt}, 'YYYY-MM-DDThh24:mi:ss')::timestamp
+            )
     </select>
 
     <select id="getNotNormalizedObservationsCount" resultType="java.lang.Integer">

--- a/src/main/resources/db/mappers/FeedEventStatusMapper.xml
+++ b/src/main/resources/db/mappers/FeedEventStatusMapper.xml
@@ -5,17 +5,17 @@
 <mapper namespace="io.kontur.eventapi.dao.mapper.FeedEventStatusMapper">
 
     <insert id="markAsActual" >
-        INSERT INTO feed_event_status (feed_id, event_id, actual)
-        VALUES (#{feedId}, #{eventId}, #{actual})
-        ON CONFLICT (feed_id, event_id) DO UPDATE SET actual = #{actual}
+        insert into feed_event_status (feed_id, event_id, actual)
+        values (#{feedId}, #{eventId}, #{actual})
+        on conflict (feed_id, event_id) do update set actual = #{actual}
     </insert>
 
     <insert id="markAsNonActual" >
-        INSERT INTO feed_event_status (feed_id, event_id, actual)
+        insert into feed_event_status (feed_id, event_id, actual)
         select feed_id, #{eventId}, false
         from feeds
         where providers &amp;&amp; array[#{provider}::text]
-        ON CONFLICT (feed_id, event_id) DO UPDATE SET actual = false
+        on conflict (feed_id, event_id) do update set actual = false
     </insert>
 
 </mapper>

--- a/src/main/resources/db/mappers/GeneralMapper.xml
+++ b/src/main/resources/db/mappers/GeneralMapper.xml
@@ -12,7 +12,7 @@
     </select>
 
     <select id="getPgStatTables" resultMap="pgStatTableMap">
-        SELECT
+        select
                relname,
                last_vacuum,
                last_autovacuum,
@@ -24,7 +24,7 @@
                autoanalyze_count,
                vacuum_count,
                autovacuum_count
-        FROM pg_stat_user_tables;
+        from pg_stat_user_tables;
     </select>
 
     <select id="getObservationNormalizationDuration" resultMap="processingDuration">

--- a/src/main/resources/db/mappers/KonturEventsMapper.xml
+++ b/src/main/resources/db/mappers/KonturEventsMapper.xml
@@ -5,28 +5,28 @@
 <mapper namespace="io.kontur.eventapi.dao.mapper.KonturEventsMapper">
 
     <insert id="insert" useGeneratedKeys="false">
-        INSERT INTO kontur_events (event_id, provider, observation_id)
-        VALUES (#{eventId}, #{provider}, #{observationId})
-        ON CONFLICT (event_id, observation_id) DO UPDATE
-        SET provider = #{provider}
+        insert into kontur_events (event_id, provider, observation_id)
+        values (#{eventId}, #{provider}, #{observationId})
+        on conflict (event_id, observation_id) do update
+        set provider = #{provider}
     </insert>
 
     <select id="getEventByExternalId" resultMap="konturEventDtoMap" >
-        SELECT event_id, array_agg(observation_id)::uuid[] AS observation_ids, min(recombined_at) as recombined_at
-        FROM kontur_events
-        WHERE observation_id IN (
-            SELECT observation_id
-            FROM normalized_observations
-            WHERE external_event_id = #{externalId}
+        select event_id, array_agg(observation_id)::uuid[] as observation_ids, min(recombined_at) as recombined_at
+        from kontur_events
+        where observation_id IN (
+            select observation_id
+            from normalized_observations
+            where external_event_id = #{externalId}
             )
-        GROUP BY event_id
+        group by event_id
     </select>
 
     <select id="getEventById" resultMap="konturEventDtoMap" >
-        SELECT event_id, array_agg(observation_id)::uuid[] AS observation_ids, min(recombined_at) as recombined_at
-        FROM kontur_events
-        WHERE event_id = #{eventId}
-        GROUP BY event_id
+        select event_id, array_agg(observation_id)::uuid[] as observation_ids, min(recombined_at) as recombined_at
+        from kontur_events
+        where event_id = #{eventId}
+        group by event_id
     </select>
 
     <select id="findClosestEventsToObservations" resultMap="konturEventDtoMap">
@@ -51,7 +51,7 @@
                     and no.source_updated_at between obs.source_updated_at - interval '24 hours'
                         and obs.source_updated_at + interval '24 hours'
                     and ST_DWithin(obs.collected_geography, no.collected_geography, 2000)
-                order by st_distance(obs.collected_geography, no.collected_geography)
+                order by ST_Distance(obs.collected_geography, no.collected_geography)
                 limit 1)) as event_id, array_agg(obs.observation_id)::uuid[] as observation_ids
             from observations obs
             group by event_id
@@ -60,15 +60,15 @@
     </select>
 
     <select id="getEventsForRolloutEpisodes" resultType="java.util.UUID">
-        SELECT event_id
-        FROM feed_event_status
-        WHERE feed_id = #{feedId}
-            AND actual is false
-        LIMIT 100000;
+        select event_id
+        from feed_event_status
+        where feed_id = #{feedId}
+            and actual is false
+        limit 100000;
     </select>
 
     <select id="getNotComposedEventsCount" resultType="java.lang.Integer">
-        SELECT count(*) FROM feed_event_status WHERE NOT actual;
+        select count(*) from feed_event_status where not actual;
     </select>
 
     <resultMap id="konturEventDtoMap" type="io.kontur.eventapi.entity.KonturEvent">

--- a/src/main/resources/db/mappers/NormalizedObservationsMapper.xml
+++ b/src/main/resources/db/mappers/NormalizedObservationsMapper.xml
@@ -4,7 +4,7 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="io.kontur.eventapi.dao.mapper.NormalizedObservationsMapper">
     <insert id="insert">
-        INSERT INTO normalized_observations (
+        insert into normalized_observations (
             observation_id, external_event_id, external_episode_id, provider, origin, name, proper_name,
             description, episode_description, type, event_severity, active, loaded_at, started_at,
             ended_at, source_updated_at, region, urls, cost,
@@ -13,7 +13,7 @@
             <if test='point != null'>point,</if>
             <if test='geometries != null'>geometries,</if>
             auto_expire, recombined
-        ) VALUES (
+        ) values (
             #{observationId}, #{externalEventId}, #{externalEpisodeId}, #{provider}, #{origin}, #{name}, #{properName},
             #{description}, #{episodeDescription}, #{type}, #{eventSeverity}, #{active}, #{loadedAt}, #{startedAt},
             #{endedAt}, #{sourceUpdatedAt}, #{region}, #{urls, typeHandler=io.kontur.eventapi.typehandler.StringArrayTypeHandler},
@@ -39,42 +39,42 @@
     </insert>
 
     <insert id="markAsRecombined">
-        UPDATE normalized_observations SET recombined = 'true' WHERE observation_id = #{observationId}
+        update normalized_observations set recombined = 'true' where observation_id = #{observationId}
     </insert>
 
     <select id="getObservationsNotLinkedToEvent" resultMap="normalizedObservationsDtoMap">
-        SELECT *
-        FROM normalized_observations
-        WHERE recombined is false
+        select *
+        from normalized_observations
+        where recombined is false
         <foreach item="provider" collection="providers" separator="," open="and provider in (" close=")">
             #{provider}
         </foreach>
-        ORDER BY loaded_at
-        LIMIT 100000
+        order by loaded_at
+        limit 100000
     </select>
 
     <select id="getFirmsObservationsNotLinkedToEventFor24Hours" resultMap="normalizedObservationsDtoMap">
-        WITH obs AS (
-            SELECT min(source_updated_at) as min_sua
-            FROM normalized_observations
-            WHERE recombined IS FALSE
+        with obs as (
+            select min(source_updated_at) as min_sua
+            from normalized_observations
+            where recombined is false
                 and provider in ('firms.modis-c6', 'firms.suomi-npp-viirs-c2', 'firms.noaa-20-viirs-c2')
         )
-        SELECT * FROM normalized_observations
-        WHERE recombined IS FALSE
+        select * from normalized_observations
+        where recombined is false
             and provider in ('firms.modis-c6', 'firms.suomi-npp-viirs-c2', 'firms.noaa-20-viirs-c2')
             and source_updated_at between (select min_sua from obs) - interval '1s' and (select min_sua from obs) + interval '24 hours'
-        ORDER BY source_updated_at
-        LIMIT 30000
+        order by source_updated_at
+        limit 30000
     </select>
 
     <select id="clusterObservationsByGeography" resultType="java.util.Set">
         select array_agg(observation_id)::uuid[] from (
-            SELECT
+            select
                 ST_ClusterDBSCAN(ST_Transform(collected_geography::geometry, 54032), 2000, 1) over() as cid,
                 observation_id
-            FROM normalized_observations
-            <foreach item="observationId" collection="observationIds" separator="," open="WHERE observation_id in (" close=")">
+            from normalized_observations
+            <foreach item="observationId" collection="observationIds" separator="," open="where observation_id in (" close=")">
                   #{observationId}
             </foreach>
         ) as clusters
@@ -82,32 +82,32 @@
     </select>
 
     <select id="getObservationsByEventId" resultMap="normalizedObservationsDtoMap">
-        SELECT *
-        FROM normalized_observations
-        WHERE observation_id IN (SELECT observation_id FROM kontur_events WHERE event_id = #{eventId});
+        select *
+        from normalized_observations
+        where observation_id IN (select observation_id from kontur_events where event_id = #{eventId});
     </select>
 
     <select id="getObservations" resultMap="normalizedObservationsDtoMap">
-        SELECT *
-        FROM normalized_observations
+        select *
+        from normalized_observations
         <foreach item="obsId" collection="observationIds" separator="," open="where observation_id in (" close=")">
             #{obsId}
         </foreach>
     </select>
 
     <select id="getDuplicateObservation" resultMap="normalizedObservationsDtoMap">
-        SELECT *
-        FROM normalized_observations
-        WHERE external_episode_id = #{externalEpisodeId}
-          AND loaded_at &lt;= #{loadedAt}
-          AND observation_id != #{observationId}
-          AND provider = #{provider}
-        ORDER BY loaded_at DESC
-        LIMIT 1
+        select *
+        from normalized_observations
+        where external_episode_id = #{externalEpisodeId}
+          and loaded_at &lt;= #{loadedAt}
+          and observation_id != #{observationId}
+          and provider = #{provider}
+        order by loaded_at desc
+        limit 1
     </select>
 
     <select id="getTimestampAtTimezone" resultType="java.time.OffsetDateTime">
-        SELECT #{timestamp}::TIMESTAMP AT TIME ZONE #{timezone};
+        select #{timestamp}::timestamp at time zone #{timezone};
     </select>
 
     <select id="getNotRecombinedObservationsCount" resultType="java.lang.Integer">


### PR DESCRIPTION
## Summary
- fix SQL casing and spacing in mappers and migrations
- use `not exists` and `strict` for clarity
- adjust timestamp timezone helper query

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685044c39d9c8324bb2cd823e1e70dc2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Standardized SQL keyword and function call casing across all database migration scripts and mapper files for consistency.
  - Adjusted formatting and whitespace in SQL and XML queries for improved readability.
  - Normalized string literal casing in sorting and filter conditions within queries.

- **Documentation**
  - No user-facing documentation changes included.

No changes to application functionality or exported/public interfaces. These updates are purely stylistic and do not affect system behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->