### PR TITLE
fix(metrics): handle sqs metric retrieval failures

### DIFF
--- a/src/test/java/io/kontur/eventapi/metrics/collector/AwsSqsMetricsCollectorTest.java
+++ b/src/test/java/io/kontur/eventapi/metrics/collector/AwsSqsMetricsCollectorTest.java
@@ -1,0 +1,44 @@
+package io.kontur.eventapi.metrics.collector;
+
+import com.amazonaws.SdkClientException;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.model.GetQueueAttributesRequest;
+import com.amazonaws.services.sqs.model.GetQueueAttributesResult;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AwsSqsMetricsCollectorTest {
+
+    @Test
+    public void collectShouldNotFailWhenSdkClientExceptionOccurs() {
+        AmazonSQS sqs = mock(AmazonSQS.class);
+        AtomicInteger mainGauge = new AtomicInteger(1);
+        AtomicInteger dlqGauge = new AtomicInteger(2);
+
+        AwsSqsMetricsCollector collector = new AwsSqsMetricsCollector(mainGauge, dlqGauge, sqs);
+        ReflectionTestUtils.setField(collector, "awsEnable", true);
+        ReflectionTestUtils.setField(collector, "awsUrl", "mainUrl");
+        ReflectionTestUtils.setField(collector, "awsDLQUrl", "dlqUrl");
+
+        GetQueueAttributesResult result = new GetQueueAttributesResult();
+        result.setAttributes(Map.of("ApproximateNumberOfMessages", "5"));
+
+        when(sqs.getQueueAttributes(any(GetQueueAttributesRequest.class)))
+                .thenThrow(new SdkClientException("test"))
+                .thenReturn(result);
+
+        assertDoesNotThrow(collector::collect);
+
+        assertEquals(1, mainGauge.get());
+        assertEquals(5, dlqGauge.get());
+    }
+}


### PR DESCRIPTION
## Summary
- handle AWS SQS metrics failures gracefully
- add regression test for metrics collector

## Testing
- `mvn test` *(failed: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68505a571d548324a8e31afc655cc535

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for AWS SQS queue size retrieval to prevent failures and ensure metrics remain available even if an error occurs.
  - Added warning messages when issues are encountered during SQS queue size checks.

- **Tests**
  - Introduced new tests to verify that the metrics collection process continues smoothly even if AWS SQS client errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->