### PR TITLE
Sort observations arrays

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -76,8 +76,8 @@ Stores event versions for each feed. Table was redesigned in version 1.15.
 | `type` | `text` |
 | `name` | `text` |
 | `description` | `text` |
-| `episodes` | `jsonb` |
-| `observations` | `uuid[]` |
+| `episodes` | `jsonb` | sorted by `started_at`; episode observation IDs sorted |
+| `observations` | `uuid[]` | sorted by ID for stable comparison |
 | `event_details` | `jsonb` default `{}` |
 | `geometries` | `jsonb` |
 | `urls` | `text[]` |

--- a/src/main/java/io/kontur/eventapi/typehandler/FeedEpisodeTypeHandler.java
+++ b/src/main/java/io/kontur/eventapi/typehandler/FeedEpisodeTypeHandler.java
@@ -21,6 +21,15 @@ public class FeedEpisodeTypeHandler extends BaseTypeHandler<List<FeedEpisode>> {
     @Override
     public void setNonNullParameter(PreparedStatement ps, int i, List<FeedEpisode> parameter,
                                     JdbcType jdbcType) throws SQLException {
+        // sort observations ids inside episodes and order episodes chronologically
+        if (parameter != null) {
+            parameter.sort(java.util.Comparator.comparing(FeedEpisode::getStartedAt));
+            parameter.forEach(ep -> {
+                if (ep.getObservations() != null) {
+                    ep.setObservations(new java.util.TreeSet<>(ep.getObservations()));
+                }
+            });
+        }
         ps.setObject(i, writeJson(parameter));
     }
 

--- a/src/main/java/io/kontur/eventapi/typehandler/UUIDArrayTypeHandler.java
+++ b/src/main/java/io/kontur/eventapi/typehandler/UUIDArrayTypeHandler.java
@@ -11,7 +11,9 @@ public class UUIDArrayTypeHandler extends BaseTypeHandler<Set<UUID>> {
     @Override
     public void setNonNullParameter(PreparedStatement ps, int i, Set<UUID> parameter,
                                     JdbcType jdbcType) throws SQLException {
-        Array array = ps.getConnection().createArrayOf("uuid", parameter.toArray());
+        // sort for deterministic representation so arrays can be compared directly
+        UUID[] sorted = parameter.stream().sorted().toArray(UUID[]::new);
+        Array array = ps.getConnection().createArrayOf("uuid", sorted);
         ps.setArray(i, array);
     }
 

--- a/src/test/java/io/kontur/eventapi/dao/FeedObservationsSortingIT.java
+++ b/src/test/java/io/kontur/eventapi/dao/FeedObservationsSortingIT.java
@@ -1,0 +1,82 @@
+package io.kontur.eventapi.dao;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.kontur.eventapi.entity.Feed;
+import io.kontur.eventapi.entity.FeedData;
+import io.kontur.eventapi.entity.FeedEpisode;
+import io.kontur.eventapi.test.AbstractCleanableIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FeedObservationsSortingIT extends AbstractCleanableIntegrationTest {
+
+    private final FeedDao feedDao;
+    private final JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    public FeedObservationsSortingIT(JdbcTemplate jdbcTemplate, FeedDao feedDao) {
+        super(jdbcTemplate, feedDao);
+        this.feedDao = feedDao;
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Test
+    void testObservationsAndEpisodesAreSorted() throws Exception {
+        Feed feed = feedDao.getFeeds().get(0);
+        UUID id1 = UUID.randomUUID();
+        UUID id2 = UUID.randomUUID();
+
+        Set<UUID> unsorted = new LinkedHashSet<>();
+        unsorted.add(id2);
+        unsorted.add(id1);
+
+        FeedEpisode later = new FeedEpisode();
+        later.setStartedAt(java.time.OffsetDateTime.parse("2024-01-02T00:00:00Z"));
+        later.setEndedAt(java.time.OffsetDateTime.parse("2024-01-03T00:00:00Z"));
+        later.setObservations(new LinkedHashSet<>(List.of(id2, id1)));
+
+        FeedEpisode earlier = new FeedEpisode();
+        earlier.setStartedAt(java.time.OffsetDateTime.parse("2024-01-01T00:00:00Z"));
+        earlier.setEndedAt(java.time.OffsetDateTime.parse("2024-01-01T12:00:00Z"));
+        earlier.setObservations(new LinkedHashSet<>(List.of(id2, id1)));
+
+        FeedData feedData = new FeedData(UUID.randomUUID(), feed.getFeedId(), 1L);
+        feedData.setObservations(unsorted);
+        // intentionally put later episode first
+        feedData.setEpisodes(List.of(later, earlier));
+        feedData.setEnriched(true);
+
+        feedDao.insertFeedData(feedData, feed.getAlias());
+
+        UUID[] storedObservations = jdbcTemplate.queryForObject(
+                "select observations from feed_data where event_id=?",
+                (rs, rowNum) -> (UUID[]) rs.getArray(1).getArray(),
+                feedData.getEventId());
+        assertArrayEquals(new UUID[]{id1, id2}, storedObservations);
+
+        String episodesJson = jdbcTemplate.queryForObject(
+                "select episodes from feed_data where event_id=?",
+                String.class, feedData.getEventId());
+        JsonNode node = new ObjectMapper().readTree(episodesJson);
+        // verify episodes order by startedAt
+        assertEquals("2024-01-01T00:00:00Z", node.get(0).get("startedAt").asText());
+        assertEquals("2024-01-02T00:00:00Z", node.get(1).get("startedAt").asText());
+
+        List<String> episodeObs = StreamSupport.stream(node.get(0).get("observations").spliterator(), false)
+                .map(JsonNode::asText)
+                .collect(Collectors.toList());
+        assertEquals(List.of(id1.toString(), id2.toString()), episodeObs);
+    }
+}


### PR DESCRIPTION
## Summary
- keep uuid arrays sorted when inserting feed data
- sort episodes by `started_at`
- describe sorted arrays in DB docs
- test that arrays and episodes are sorted on insert

Fibery link: https://kontur.fibery.io/Tasks/Task/6844

------
https://chatgpt.com/codex/tasks/task_e_68505a10264c8324b5324e9793d7974f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the ordering and sorting of episodes and observations in the documentation for improved understanding.

- **Bug Fixes**
  - Ensured that episodes and observations are consistently sorted before being stored, resulting in stable and predictable data ordering.

- **Tests**
  - Added new integration tests to verify that episodes and observations are correctly sorted when persisted to the database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->