### PR TITLE
12024 Fix CalFire provider import

### DIFF
--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -70,3 +70,6 @@ databaseChangeLog:
 - include:
     relativeToChangelogFile: true
     file: v1.21.0/v1.21.0.yaml
+- include:
+    relativeToChangelogFile: true
+    file: v1.22.0/v1.22.0.yaml

--- a/src/main/resources/db/changelog/v1.22.0/delete-calfire-data.sql
+++ b/src/main/resources/db/changelog/v1.22.0/delete-calfire-data.sql
@@ -1,0 +1,22 @@
+--liquibase formatted sql
+
+--changeset event-api-migrations:v1.22.0/delete-calfire-data.sql runOnChange:false
+
+-- remove unused CalFire provider data
+delete from feed_data
+where feed_id in (select feed_id from feeds where alias in ('calfire', 'test-calfire'));
+
+delete from feed_event_status
+where feed_id in (select feed_id from feeds where alias in ('calfire', 'test-calfire'));
+
+delete from kontur_events
+where provider = 'wildfire.calfire';
+
+delete from normalized_observations
+where provider = 'wildfire.calfire';
+
+delete from data_lake
+where provider = 'wildfire.calfire';
+
+delete from feeds
+where alias in ('calfire', 'test-calfire');

--- a/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
+++ b/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
@@ -1,0 +1,4 @@
+databaseChangeLog:
+  - include:
+      relativeToChangelogFile: true
+      file: delete-calfire-data.sql


### PR DESCRIPTION
## Summary
- add Liquibase migration to delete wildfire.calfire data

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850684ce01c83248b3928d0736e0714

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added a new database migration for version 1.22.0 to remove all CalFire provider data from the system. This update ensures that related data and feeds are deleted as part of the migration process. No impact on application features or user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->