### PR TITLE
Fix CalFire provider import

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -80,7 +80,7 @@ tornadoJapanMa:
   host: 'https://www.data.jma.go.jp/obd/stats/data/bosai/tornado/'
 
 calfire:
-  host: 'https://incidents.fire.ca.gov'
+  host: 'https://www.fire.ca.gov/'
 
 nifc:
   host: 'https://services3.arcgis.com/T4QMspbfLg3qTGWY/arcgis/rest/services'


### PR DESCRIPTION
Fixes: https://kontur.fibery.io/Tasks/Task/12024

Updated CalFire host to use the new incidents domain. This prevents the job from failing due to redirect responses.


------
https://chatgpt.com/codex/tasks/task_e_6851b20652348324b138dfca70872946

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the CalFire service host URL to use the new endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->