### PR TITLE
feat(pdc): 3284 add HpSrv products import job

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ pdc:
 
 Jobs for data import:
 - `hpSrvImport` - collects the raw data from PDC's Hazard and Product service (HpSrv)
+- `hpSrvProductsImport` - collects product information from HpSrv
 - `gdacsImport` - collects the raw data from Gdacs
 - ...
 
@@ -96,6 +97,9 @@ scheduler:
   hpSrvImport:
     enable: true
     initialDelay: 1000
+  hpSrvProductsImport:
+    enable: true
+    initialDelay: 15000
   gdacsImport:
     enable: true
     cron: 0 1/5 * * * *

--- a/src/main/java/io/kontur/eventapi/config/WorkerScheduler.java
+++ b/src/main/java/io/kontur/eventapi/config/WorkerScheduler.java
@@ -22,6 +22,7 @@ import io.kontur.eventapi.staticdata.job.StaticImportJob;
 import io.kontur.eventapi.emdat.jobs.EmDatImportJob;
 import io.kontur.eventapi.gdacs.job.GdacsSearchJob;
 import io.kontur.eventapi.pdc.job.HpSrvMagsJob;
+import io.kontur.eventapi.pdc.job.HpSrvProductsJob;
 import io.kontur.eventapi.pdc.job.HpSrvSearchJob;
 import io.kontur.eventapi.tornadojapanma.job.HistoricalTornadoJapanMaImportJob;
 import io.kontur.eventapi.tornadojapanma.job.TornadoJapanMaImportJob;
@@ -35,6 +36,7 @@ public class WorkerScheduler {
 
     private final HpSrvSearchJob hpSrvSearchJob;
     private final HpSrvMagsJob hpSrvMagsJob;
+    private final HpSrvProductsJob hpSrvProductsJob;
     private final GdacsSearchJob gdacsSearchJob;
     private final FirmsImportModisJob firmsImportModisJob;
     private final FirmsImportNoaaJob firmsImportNoaaJob;
@@ -65,6 +67,8 @@ public class WorkerScheduler {
     private String hpSrvImportEnabled;
     @Value("${scheduler.hpSrvMagsImport.enable}")
     private String hpSrvMagsImportEnabled;
+    @Value("${scheduler.hpSrvProductsImport.enable}")
+    private String hpSrvProductsImportEnabled;
     @Value("${scheduler.gdacsImport.enable}")
     private String gdacsImportEnabled;
     @Value("${scheduler.firmsModisImport.enable}")
@@ -116,6 +120,7 @@ public class WorkerScheduler {
 
 
     public WorkerScheduler(HpSrvSearchJob hpSrvSearchJob, HpSrvMagsJob hpSrvMagsJob,
+                           HpSrvProductsJob hpSrvProductsJob,
                            GdacsSearchJob gdacsSearchJob, NormalizationJob normalizationJob,
                            EventCombinationJob eventCombinationJob, FirmsEventCombinationJob firmsEventCombinationJob,
                            FeedCompositionJob feedCompositionJob, FirmsImportModisJob firmsImportModisJob,
@@ -130,6 +135,7 @@ public class WorkerScheduler {
                            MetricsJob metricsJob, ReEnrichmentJob reEnrichmentJob, EventExpirationJob eventExpirationJob) {
         this.hpSrvSearchJob = hpSrvSearchJob;
         this.hpSrvMagsJob = hpSrvMagsJob;
+        this.hpSrvProductsJob = hpSrvProductsJob;
         this.gdacsSearchJob = gdacsSearchJob;
         this.normalizationJob = normalizationJob;
         this.eventCombinationJob = eventCombinationJob;
@@ -168,6 +174,13 @@ public class WorkerScheduler {
     public void startPdcMagsImport() {
         if (Boolean.parseBoolean(hpSrvMagsImportEnabled)) {
             hpSrvMagsJob.run();
+        }
+    }
+
+    @Scheduled(initialDelayString = "${scheduler.hpSrvProductsImport.initialDelay}", fixedDelay = Integer.MAX_VALUE)
+    public void startPdcProductsImport() {
+        if (Boolean.parseBoolean(hpSrvProductsImportEnabled)) {
+            hpSrvProductsJob.run();
         }
     }
 

--- a/src/main/java/io/kontur/eventapi/pdc/client/HpSrvClient.java
+++ b/src/main/java/io/kontur/eventapi/pdc/client/HpSrvClient.java
@@ -19,4 +19,8 @@ public interface HpSrvClient {
 
     @GetMapping("/hp_srv/services/mags/1/json/get_mags")
     JsonNode getMags(@RequestParam("hazard_id") String hazardId);
+
+    @PostMapping("/hp_srv/services/products/1/json/search_product")
+    @Headers({"Content-Type: application/json", "accept: application/json"})
+    JsonNode searchProducts(@RequestBody HpSrvSearchBody body);
 }

--- a/src/main/java/io/kontur/eventapi/pdc/converter/PdcDataLakeConverter.java
+++ b/src/main/java/io/kontur/eventapi/pdc/converter/PdcDataLakeConverter.java
@@ -30,6 +30,7 @@ public class PdcDataLakeConverter {
 
     public final static String HP_SRV_SEARCH_PROVIDER = "hpSrvSearch";
     public final static String HP_SRV_MAG_PROVIDER = "hpSrvMag";
+    public final static String HP_SRV_PRODUCT_PROVIDER = "hpSrvProduct";
     public final static String PDC_SQS_PROVIDER = "pdcSqs";
     public final static String PDC_MAP_SRV_PROVIDER = "pdcMapSrv";
     public final static String PDC_SQS_NASA_PROVIDER = "pdcSqsNasa";
@@ -62,6 +63,19 @@ public class PdcDataLakeConverter {
         }
 
         return result;
+    }
+
+    public DataLake convertHpSrvProductData(JsonNode node) {
+        DataLake dataLake = new DataLake();
+        dataLake.setObservationId(UUID.randomUUID());
+        dataLake.setExternalId(node.get("uuid").asText());
+        if (node.has("updateDate")) {
+            dataLake.setUpdatedAt(getDateTimeFromMillis(node.get("updateDate")));
+        }
+        dataLake.setProvider(HP_SRV_PRODUCT_PROVIDER);
+        dataLake.setLoadedAt(DateTimeUtil.uniqueOffsetDateTime());
+        dataLake.setData(node.toString());
+        return dataLake;
     }
 
     public DataLake convertSQSMessage(String messageJson, String type, String messageId) {

--- a/src/main/java/io/kontur/eventapi/pdc/job/HpSrvProductsJob.java
+++ b/src/main/java/io/kontur/eventapi/pdc/job/HpSrvProductsJob.java
@@ -1,0 +1,69 @@
+package io.kontur.eventapi.pdc.job;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.kontur.eventapi.dao.DataLakeDao;
+import io.kontur.eventapi.entity.DataLake;
+import io.kontur.eventapi.job.AbstractJob;
+import io.kontur.eventapi.pdc.dto.HpSrvSearchBody;
+import io.kontur.eventapi.pdc.service.HpSrvService;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static io.kontur.eventapi.pdc.converter.PdcDataLakeConverter.HP_SRV_PRODUCT_PROVIDER;
+
+@Component
+public class HpSrvProductsJob extends AbstractJob {
+
+    private final DataLakeDao dataLakeDao;
+    private final HpSrvService hpSrvService;
+
+    @Autowired
+    public HpSrvProductsJob(DataLakeDao dataLakeDao, HpSrvService hpSrvService, MeterRegistry meterRegistry) {
+        super(meterRegistry);
+        this.dataLakeDao = dataLakeDao;
+        this.hpSrvService = hpSrvService;
+    }
+
+    @Override
+    public void execute() {
+        importProducts();
+    }
+
+    @Override
+    public String getName() {
+        return "hpSrvProductImport";
+    }
+
+    private void importProducts() {
+        HpSrvSearchBody searchBody = generateProductSearchBody();
+        JsonNode products = hpSrvService.obtainProducts(searchBody);
+
+        while (!products.isEmpty()) {
+            products.forEach(hpSrvService::saveProduct);
+            searchBody.getPagination().setOffset(searchBody.getPagination().getOffset() + products.size());
+            products = hpSrvService.obtainProducts(searchBody);
+        }
+    }
+
+    private HpSrvSearchBody generateProductSearchBody() {
+        HpSrvSearchBody searchBody = new HpSrvSearchBody();
+        searchBody.getOrder().getOrderList().put("updateDate", "ASC");
+        searchBody.getOrder().getOrderList().put("productId", "ASC");
+        searchBody.getPagination().setOffset(0);
+        searchBody.getPagination().setPageSize(20);
+
+        dataLakeDao.getLatestUpdatedHazard(HP_SRV_PRODUCT_PROVIDER)
+                .map(DataLake::getUpdatedAt)
+                .ifPresent(lastUpdateTime -> searchBody.addAndRestriction("GREATER_THAN", "updateDate",
+                        convertOffsetDateTimeToEpochMillis(lastUpdateTime)));
+        return searchBody;
+    }
+
+    private String convertOffsetDateTimeToEpochMillis(OffsetDateTime dateTime) {
+        return String.valueOf(dateTime.atZoneSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -105,6 +105,9 @@ scheduler:
     enable: false
     initialDelay: 10000
     fixedDelay: 600000
+  hpSrvProductsImport:
+    enable: false
+    initialDelay: 15000
   pdcMapSrvSearch:
     enable: false
     initialDelay: 1000

--- a/src/test/java/io/kontur/eventapi/config/WorkerSchedulerTest.java
+++ b/src/test/java/io/kontur/eventapi/config/WorkerSchedulerTest.java
@@ -23,6 +23,7 @@ import io.kontur.eventapi.nifc.job.NifcImportJob;
 import io.kontur.eventapi.pdc.job.PdcMapSrvSearchJob;
 import io.kontur.eventapi.stormsnoaa.job.StormsNoaaImportJob;
 import io.kontur.eventapi.pdc.job.HpSrvMagsJob;
+import io.kontur.eventapi.pdc.job.HpSrvProductsJob;
 import io.kontur.eventapi.pdc.job.HpSrvSearchJob;
 import io.kontur.eventapi.staticdata.job.StaticImportJob;
 import io.kontur.eventapi.tornadojapanma.job.HistoricalTornadoJapanMaImportJob;
@@ -44,6 +45,7 @@ class WorkerSchedulerTest {
 
     private final HpSrvSearchJob hpSrvSearchJob = mock(HpSrvSearchJob.class);
     private final HpSrvMagsJob hpSrvMagsJob = mock(HpSrvMagsJob.class);
+    private final HpSrvProductsJob hpSrvProductsJob = mock(HpSrvProductsJob.class);
     private final NormalizationJob normalizationJob = mock(NormalizationJob.class);
     private final EventCombinationJob eventCombinationJob = mock(EventCombinationJob.class);
     private final FeedCompositionJob feedCompositionJob = mock(FeedCompositionJob.class);
@@ -71,7 +73,7 @@ class WorkerSchedulerTest {
     private final ReEnrichmentJob reEnrichmentJob = mock(ReEnrichmentJob.class);
     private final EventExpirationJob eventExpirationJob = mock(EventExpirationJob.class);
 
-    private final WorkerScheduler scheduler = new WorkerScheduler(hpSrvSearchJob, hpSrvMagsJob, gdacsSearchJob, normalizationJob,
+    private final WorkerScheduler scheduler = new WorkerScheduler(hpSrvSearchJob, hpSrvMagsJob, hpSrvProductsJob, gdacsSearchJob, normalizationJob,
             eventCombinationJob, firmsEventCombinationJob, feedCompositionJob, firmsImportModisJob, firmsImportNoaaJob,
             firmsImportSuomiJob, emDatImportJob, staticImportJob, stormsNoaaImportJob, tornadoJapanMaImportJob,
             historicalTornadoJapanMaImportJob, pdcMapSrvSearchJobs, enrichmentJob, calFireSearchJob,
@@ -82,6 +84,7 @@ class WorkerSchedulerTest {
     public void resetMocks() {
         Mockito.reset(hpSrvSearchJob);
         Mockito.reset(hpSrvMagsJob);
+        Mockito.reset(hpSrvProductsJob);
         Mockito.reset(gdacsSearchJob);
         Mockito.reset(firmsImportModisJob);
         Mockito.reset(firmsImportNoaaJob);
@@ -130,6 +133,22 @@ class WorkerSchedulerTest {
         scheduler.startPdcMagsImport();
 
         verify(hpSrvMagsJob, never()).run();
+    }
+
+    @Test
+    public void startHpSrvProductsJob() {
+        ReflectionTestUtils.setField(scheduler, "hpSrvProductsImportEnabled", "true");
+        scheduler.startPdcProductsImport();
+
+        verify(hpSrvProductsJob, times(1)).run();
+    }
+
+    @Test
+    public void skipHpSrvProductsJob() {
+        ReflectionTestUtils.setField(scheduler, "hpSrvProductsImportEnabled", "false");
+        scheduler.startPdcProductsImport();
+
+        verify(hpSrvProductsJob, never()).run();
     }
 
     @Test

--- a/src/test/java/io/kontur/eventapi/pdc/job/HpSrvProductsJobTest.java
+++ b/src/test/java/io/kontur/eventapi/pdc/job/HpSrvProductsJobTest.java
@@ -1,0 +1,98 @@
+package io.kontur.eventapi.pdc.job;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import io.kontur.eventapi.dao.DataLakeDao;
+import io.kontur.eventapi.entity.DataLake;
+import io.kontur.eventapi.pdc.dto.HpSrvSearchBody;
+import io.kontur.eventapi.pdc.service.HpSrvService;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+
+import static io.kontur.eventapi.pdc.converter.PdcDataLakeConverter.HP_SRV_PRODUCT_PROVIDER;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class HpSrvProductsJobTest {
+
+    @Mock
+    HpSrvService hpSrvService;
+    @Mock
+    DataLakeDao dataLakeDao;
+
+    @Test
+    public void testPagination() {
+        HpSrvSearchBody body0 = generateSearchBody(0);
+        when(hpSrvService.obtainProducts(eq(body0))).thenReturn(generateArrayNodeSize20());
+
+        HpSrvSearchBody body20 = generateSearchBody(20);
+        when(hpSrvService.obtainProducts(eq(body20))).thenReturn(generateArrayNodeSize10());
+
+        HpSrvSearchBody body30 = generateSearchBody(30);
+        when(hpSrvService.obtainProducts(eq(body30))).thenReturn(generateArrayNodeSize0());
+
+        HpSrvProductsJob job = new HpSrvProductsJob(dataLakeDao, hpSrvService, new SimpleMeterRegistry());
+        job.run();
+
+        verify(hpSrvService, times(30)).saveProduct(any());
+        verify(hpSrvService, times(3)).obtainProducts(any(HpSrvSearchBody.class));
+    }
+
+    @Test
+    public void testRestartFromLatest() {
+        long testMillis = 1602445516323L;
+        Instant instant = Instant.ofEpochMilli(testMillis);
+        OffsetDateTime now = OffsetDateTime.ofInstant(instant, ZoneId.systemDefault());
+
+        when(hpSrvService.obtainProducts(any(HpSrvSearchBody.class))).thenReturn(generateArrayNodeSize0());
+        DataLake dataLake = mock(DataLake.class);
+        when(dataLake.getUpdatedAt()).thenReturn(now);
+        when(dataLakeDao.getLatestUpdatedHazard(HP_SRV_PRODUCT_PROVIDER)).thenReturn(Optional.of(dataLake));
+
+        HpSrvProductsJob job = new HpSrvProductsJob(dataLakeDao, hpSrvService, new SimpleMeterRegistry());
+        job.run();
+
+        verify(dataLakeDao).getLatestUpdatedHazard(HP_SRV_PRODUCT_PROVIDER);
+        HpSrvSearchBody body = generateSearchBody(0);
+        body.addAndRestriction("GREATER_THAN", "updateDate", String.valueOf(testMillis));
+        verify(hpSrvService).obtainProducts(eq(body));
+    }
+
+    private ArrayNode generateArrayNodeSize20() {
+        ArrayNode arrayNodeSize20 = new ObjectMapper().createArrayNode();
+        for (int i = 0; i < 20; i++) {
+            arrayNodeSize20.add(i);
+        }
+        return arrayNodeSize20;
+    }
+
+    private ArrayNode generateArrayNodeSize10() {
+        ArrayNode arrayNodeSize20 = new ObjectMapper().createArrayNode();
+        for (int i = 0; i < 10; i++) {
+            arrayNodeSize20.add(i);
+        }
+        return arrayNodeSize20;
+    }
+
+    private ArrayNode generateArrayNodeSize0() {
+        return new ObjectMapper().createArrayNode();
+    }
+
+    private HpSrvSearchBody generateSearchBody(int offset) {
+        HpSrvSearchBody searchBody = new HpSrvSearchBody();
+        searchBody.getOrder().getOrderList().put("updateDate", "ASC");
+        searchBody.getOrder().getOrderList().put("productId", "ASC");
+        searchBody.getPagination().setOffset(offset);
+        searchBody.getPagination().setPageSize(20);
+        return searchBody;
+    }
+}


### PR DESCRIPTION
## Summary
- add job to fetch PDC products from HpSrv
- support new HpSrv `/search_product` API
- keep job state across restarts
- document new job and scheduler options
- test job scheduling

## Testing
- `mvn -q -DskipTests=false test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851b20deeb883248e62523b78cb44f4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for importing product data from HpSrv as a new scheduled job.
  - Introduced configuration options to enable or disable the HpSrv product import job and set its initial delay.

- **Documentation**
  - Updated documentation to describe the new HpSrv product import job and its scheduler configuration.

- **Tests**
  - Added and updated tests to cover the new HpSrv product import job and its scheduler integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->