### PR TITLE
feat(database): 0834fe30 split geometries on antimeridian

### DIFF
--- a/docs/antimeridian.md
+++ b/docs/antimeridian.md
@@ -1,0 +1,8 @@
+# Handling the 180th meridian
+
+Incoming geometries may cross the antimeridian. To keep coordinates consistent the API applies the following steps:
+
+1. **Shift longitudes** using `ST_ShiftLongitude` so that all points are within `[-180, 180]` range.
+2. **Split** geometries that span more than 180 degrees into separate parts along the antimeridian. This is done by the `split_antimeridian` database function.
+
+Both `collectGeomFromGeoJSON` and `collectGeometryFromEpisodes` use this helper, so stored geometries never wrap around the 180° meridian.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -83,7 +83,7 @@ Stores event versions for each feed. Table was redesigned in version 1.15.
 | `urls` | `text[]` |
 | `proper_name` | `text` |
 | `location` | `text` |
-| `collected_geometry` | `geometry` generated from episodes |
+| `collected_geometry` | `geometry` generated from episodes (split on the 180° meridian if needed) |
 
 Unique key: (`event_id`, `version`, `feed_id`). Several GIST and BTREE indexes exist for geometry and timestamps.
 

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -70,3 +70,6 @@ databaseChangeLog:
 - include:
     relativeToChangelogFile: true
     file: v1.21.0/v1.21.0.yaml
+- include:
+    relativeToChangelogFile: true
+    file: v1.22.0/v1.22.0.yaml

--- a/src/main/resources/db/changelog/v1.22.0/create-split-antimeridian-function.sql
+++ b/src/main/resources/db/changelog/v1.22.0/create-split-antimeridian-function.sql
@@ -1,0 +1,19 @@
+--liquibase formatted sql
+
+--changeset event-api-migrations:v1.22.0/create-split-antimeridian-function.sql runOnChange:true splitStatements:false
+
+CREATE OR REPLACE FUNCTION split_antimeridian(geom geometry)
+RETURNS geometry
+LANGUAGE plpgsql
+IMMUTABLE
+STRICT AS $$
+DECLARE
+    shifted geometry := ST_ShiftLongitude(geom);
+    line geometry := ST_SetSRID('LINESTRING(180 -90,180 90)'::geometry,4326);
+BEGIN
+    IF ST_MaxX(shifted) - ST_MinX(shifted) > 180 THEN
+        RETURN ST_CollectionExtract(ST_Split(shifted, line), 3);
+    END IF;
+    RETURN shifted;
+END;
+$$;

--- a/src/main/resources/db/changelog/v1.22.0/update-collect-functions-antimeridian.sql
+++ b/src/main/resources/db/changelog/v1.22.0/update-collect-functions-antimeridian.sql
@@ -1,0 +1,16 @@
+--liquibase formatted sql
+
+--changeset event-api-migrations:v1.22.0/update-collect-functions-antimeridian.sql runOnChange:true splitStatements:false
+
+CREATE OR REPLACE FUNCTION collectGeomFromGeoJSON(jsonb) RETURNS geometry
+AS $$
+select ST_Collect(split_antimeridian(ST_GeomFromGeoJSON(feature->'geometry')))
+from jsonb_array_elements($1->'features') feature;
+$$ LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
+
+CREATE OR REPLACE FUNCTION collectGeometryFromEpisodes(jsonb) RETURNS geometry
+AS $$
+select ST_Collect(split_antimeridian(ST_GeomFromGeoJSON(NULLIF(feature.geometries, 'null'::jsonb))))
+from (select jsonb_array_elements(e -> 'geometries' -> 'features') -> 'geometry' as geometries
+      from jsonb_array_elements($1) e) feature;
+$$ LANGUAGE SQL STRICT IMMUTABLE PARALLEL SAFE;

--- a/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
+++ b/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
@@ -1,0 +1,7 @@
+databaseChangeLog:
+  - include:
+      relativeToChangelogFile: true
+      file: create-split-antimeridian-function.sql
+  - include:
+      relativeToChangelogFile: true
+      file: update-collect-functions-antimeridian.sql


### PR DESCRIPTION
## Summary
- store incoming geometries in parts when they cross the 180° meridian
- document antimeridian handling

## Testing
- `mvn -q -DskipTests=false test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851b220d9588324909d8114fbcb1744

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved handling of geometries crossing the 180° meridian (antimeridian) to ensure accurate spatial data representation.
- **Documentation**
  - Added a new guide explaining how the system processes geometries that cross the antimeridian.
  - Updated schema documentation to clarify how geometry data is managed when spanning the 180° meridian.
- **Chores**
  - Updated database changelog to include new spatial processing functions for antimeridian handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->