### PR TITLE
feat(db): 7714 add reconnect job

### DIFF
--- a/docs/database_reconnect.md
+++ b/docs/database_reconnect.md
@@ -1,0 +1,9 @@
+# Database Reconnect Job
+
+The API uses HikariCP for database connections. In rare cases the pool may hold
+broken connections which block queries. A scheduled job `DatabaseReconnectJob`
+checks the datasource every minute.
+
+If the job fails to obtain a connection it evicts all connections from the pool.
+This forces HikariCP to open new ones automatically. Scheduler parameters can be
+changed in `application.yml` under `scheduler.dbReconnect`.

--- a/docs/sketchy_issues.md
+++ b/docs/sketchy_issues.md
@@ -16,3 +16,7 @@ The table `feed_event_status` tracks the latest events per feed, but there are n
 
 ## External dependencies
 The project depends on a private Maven repository (`nexus.kontur.io`). Without access to it the build and tests cannot be executed.
+
+## Database reconnection
+The service could previously become unavailable when all pooled database connections were broken.
+A scheduled job now evicts stale connections automatically (see `database_reconnect.md`).

--- a/src/main/java/io/kontur/eventapi/config/WorkerScheduler.java
+++ b/src/main/java/io/kontur/eventapi/config/WorkerScheduler.java
@@ -56,6 +56,7 @@ public class WorkerScheduler {
     private final HumanitarianCrisisImportJob humanitarianCrisisImportJob;
     private final MetricsJob metricsJob;
     private final ReEnrichmentJob reEnrichmentJob;
+    private final DatabaseReconnectJob databaseReconnectJob;
     private final NhcAtImportJob nhcAtImportJob;
     private final NhcCpImportJob nhcCpImportJob;
     private final NhcEpImportJob nhcEpImportJob;
@@ -111,6 +112,8 @@ public class WorkerScheduler {
     private String metricsEnabled;
     @Value("${scheduler.reEnrichment.enable}")
     private String reEnrichmentEnabled;
+    @Value("${scheduler.dbReconnect.enable}")
+    private String dbReconnectEnabled;
     @Value("${scheduler.eventExpiration.enable}")
     private String eventExpirationEnabled;
 
@@ -127,7 +130,8 @@ public class WorkerScheduler {
                            EnrichmentJob enrichmentJob, CalFireSearchJob calFireSearchJob, NifcImportJob nifcImportJob,
                            InciWebImportJob inciWebImportJob, HumanitarianCrisisImportJob humanitarianCrisisImportJob,
                            NhcAtImportJob nhcAtImportJob, NhcCpImportJob nhcCpImportJob, NhcEpImportJob nhcEpImportJob,
-                           MetricsJob metricsJob, ReEnrichmentJob reEnrichmentJob, EventExpirationJob eventExpirationJob) {
+                           MetricsJob metricsJob, ReEnrichmentJob reEnrichmentJob, DatabaseReconnectJob databaseReconnectJob,
+                           EventExpirationJob eventExpirationJob) {
         this.hpSrvSearchJob = hpSrvSearchJob;
         this.hpSrvMagsJob = hpSrvMagsJob;
         this.gdacsSearchJob = gdacsSearchJob;
@@ -153,6 +157,7 @@ public class WorkerScheduler {
         this.nhcEpImportJob = nhcEpImportJob;
         this.metricsJob = metricsJob;
         this.reEnrichmentJob = reEnrichmentJob;
+        this.databaseReconnectJob = databaseReconnectJob;
         this.humanitarianCrisisImportJob = humanitarianCrisisImportJob;
         this.eventExpirationJob = eventExpirationJob;
     }
@@ -343,6 +348,13 @@ public class WorkerScheduler {
     public void startMetricsJob() {
         if (Boolean.parseBoolean(metricsEnabled)) {
             metricsJob.run();
+        }
+    }
+
+    @Scheduled(initialDelayString = "${scheduler.dbReconnect.initialDelay}", fixedDelayString = "${scheduler.dbReconnect.fixedDelay}")
+    public void startDatabaseReconnectJob() {
+        if (Boolean.parseBoolean(dbReconnectEnabled)) {
+            databaseReconnectJob.run();
         }
     }
 

--- a/src/main/java/io/kontur/eventapi/job/DatabaseReconnectJob.java
+++ b/src/main/java/io/kontur/eventapi/job/DatabaseReconnectJob.java
@@ -1,0 +1,45 @@
+package io.kontur.eventapi.job;
+
+import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.pool.HikariPoolMXBean;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * Periodically checks database connectivity and evicts connections
+ * from Hikari pool when the database becomes unavailable.
+ */
+@Component
+public class DatabaseReconnectJob extends AbstractJob {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DatabaseReconnectJob.class);
+    private final HikariDataSource dataSource;
+
+    public DatabaseReconnectJob(MeterRegistry meterRegistry, HikariDataSource dataSource) {
+        super(meterRegistry);
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public void execute() {
+        try (Connection ignored = dataSource.getConnection()) {
+            LOG.debug("Database connection is alive");
+        } catch (SQLException e) {
+            LOG.error("Database connection failed. Evicting pool", e);
+            HikariPoolMXBean poolMxBean = dataSource.getHikariPoolMXBean();
+            if (poolMxBean != null) {
+                poolMxBean.softEvictConnections();
+            }
+        }
+    }
+
+    @Override
+    public String getName() {
+        return "databaseReconnect";
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -205,6 +205,10 @@ scheduler:
     enable: true
     initialDelay: 1000
     fixedDelay: 15000
+  dbReconnect:
+    enable: true
+    initialDelay: 1000
+    fixedDelay: 60000
   eventExpiration:
     enable: true
     initialDelay: 1000

--- a/src/test/java/io/kontur/eventapi/job/DatabaseReconnectJobTest.java
+++ b/src/test/java/io/kontur/eventapi/job/DatabaseReconnectJobTest.java
@@ -1,0 +1,43 @@
+package io.kontur.eventapi.job;
+
+import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.pool.HikariPoolMXBean;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.*;
+
+public class DatabaseReconnectJobTest {
+
+    @Test
+    public void shouldEvictPoolOnFailure() throws SQLException {
+        HikariDataSource dataSource = mock(HikariDataSource.class);
+        when(dataSource.getConnection()).thenThrow(new SQLException("fail"));
+        HikariPoolMXBean mxBean = mock(HikariPoolMXBean.class);
+        when(dataSource.getHikariPoolMXBean()).thenReturn(mxBean);
+
+        DatabaseReconnectJob job = new DatabaseReconnectJob(new SimpleMeterRegistry(), dataSource);
+        assertDoesNotThrow(job::run);
+
+        verify(mxBean, times(1)).softEvictConnections();
+    }
+
+    @Test
+    public void shouldNotEvictPoolWhenConnectionOk() throws Exception {
+        HikariDataSource dataSource = mock(HikariDataSource.class);
+        HikariPoolMXBean mxBean = mock(HikariPoolMXBean.class);
+        when(dataSource.getHikariPoolMXBean()).thenReturn(mxBean);
+        Connection connection = mock(Connection.class);
+        when(dataSource.getConnection()).thenReturn(connection);
+
+        DatabaseReconnectJob job = new DatabaseReconnectJob(new SimpleMeterRegistry(), dataSource);
+        job.run();
+
+        verify(mxBean, never()).softEvictConnections();
+        verify(connection, times(1)).close();
+    }
+}


### PR DESCRIPTION
## Summary
- reconnect to database automatically when pool is broken
- schedule the new job via `WorkerScheduler`
- document reconnection behaviour
- test the job logic

## Testing
- `mvn -q -DskipITs test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851b2454e3083248532555659ef5ae0