### PR TITLE
fix(api): 10726 use enrichedAt for pagination

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -9,11 +9,11 @@ Search for events within a feed.
 - `feed` – feed name (required).
 - `types` – list of event types.
 - `severities` – list of severity values.
-- `after` – return events updated after this timestamp.
+- `after` – return events enriched after this timestamp.
 - `datetime` – interval filter. Accepts single RFC3339 timestamp or open/closed interval.
 - `bbox` – bounding box defined as `minLon,minLat,maxLon,maxLat`.
 - `limit` – page size (default `20`).
-- `sortOrder` – `ASC` or `DESC` by `updatedAt`.
+- `sortOrder` – `ASC` or `DESC` by `enrichedAt`.
 - `episodeFilterType` – `ANY`, `LATEST` or `NONE`.
 
 Returns events sorted by update date using cursor based pagination. Response body is JSON containing `pageMetadata.nextAfterValue` and event data.

--- a/src/main/java/io/kontur/eventapi/resource/EventResource.java
+++ b/src/main/java/io/kontur/eventapi/resource/EventResource.java
@@ -69,7 +69,7 @@ public class EventResource {
             @Parameter(description = "Filters events by severity. More than one can be chosen at once")
             @RequestParam(value = "severities", defaultValue = "")
             List<Severity> severities,
-            @Parameter(description = "Includes events that were updated after this time. `updatedAt` property is used for selection. A date-time in ISO8601 format (e.g. \\\"2020-04-12T23:20:50.52Z\\\")")
+            @Parameter(description = "Includes events that were enriched after this time. `enrichedAt` property is used for selection. A date-time in ISO8601 format (e.g. \\\"2020-04-12T23:20:50.52Z\\\")")
             @RequestParam(value = "after", required = false)
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
             OffsetDateTime updatedAfter,
@@ -154,9 +154,7 @@ public class EventResource {
             @Parameter(description = "Filters events by severity. More than one can be chosen at once")
             @RequestParam(value = "severities", defaultValue = "")
             List<Severity> severities,
-            @Parameter(description = "Includes events that were updated after this time. " +
-                    "`updatedAt` property is used for selection. " +
-                    "A date-time in ISO8601 format (e.g. \\\"2020-04-12T23:20:50.52Z\\\")")
+            @Parameter(description = "Includes events that were enriched after this time. `enrichedAt` property is used for selection. A date-time in ISO8601 format (e.g. "2020-04-12T23:20:50.52Z")")
             @RequestParam(value = "after", required = false)
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
             OffsetDateTime updatedAfter,

--- a/src/main/resources/db/mappers/ApiMapper.xml
+++ b/src/main/resources/db/mappers/ApiMapper.xml
@@ -17,7 +17,7 @@
         with events as (
             select
                 fd.event_id, fd.version, fd.name, fd.proper_name, fd.description, fd.type, sv.severity, fd.active,
-                fd.started_at, fd.ended_at, fd.updated_at, fd.location, fd.urls, fd.loss, fd.severity_data, fd.event_details, fd.observations, fd.geometries,
+                fd.started_at, fd.ended_at, fd.updated_at, fd.enriched_at, fd.location, fd.urls, fd.loss, fd.severity_data, fd.event_details, fd.observations, fd.geometries,
                 jsonb_array_length(fd.episodes) as episode_count,
                 <choose>
                     <when test='"LATEST".equalsIgnoreCase(episodeFilterType)'>
@@ -51,21 +51,21 @@
                 <if test='from != null'><![CDATA[and (fd.ended_at >= #{from})]]></if>
                 <if test='to != null'><![CDATA[and (fd.started_at <= #{to})]]></if>
                 <if test='updatedAfter != null'>
-                    <if test='"asc".equalsIgnoreCase(sortOrder)'>and fd.updated_at > #{updatedAfter}</if>
-                    <if test='"desc".equalsIgnoreCase(sortOrder)'>and fd.updated_at &lt; #{updatedAfter}</if>
+                    <if test='"asc".equalsIgnoreCase(sortOrder)'>and fd.enriched_at &gt; #{updatedAfter}</if>
+                    <if test='"desc".equalsIgnoreCase(sortOrder)'>and fd.enriched_at &lt; #{updatedAfter}</if>
                 </if>
                 <if test="xMin!=null &amp;&amp; yMin!=null &amp;&amp; xMax!=null &amp;&amp; yMax!=null">
                     and ST_Intersects(ST_MakeEnvelope(#{xMin}, #{yMin}, #{xMax}, #{yMax}, 4326), fd.collected_geometry)
                 </if>
-            order by fd.updated_at ${sortOrder}
+            order by fd.enriched_at ${sortOrder}
             limit #{limit}
         )
         select case when count(*) > 0 then json_build_object(
             'pageMetadata', json_build_object('nextAfterValue',
                 (select
                     <choose>
-                        <when test='"desc".equalsIgnoreCase(sortOrder)'>min(e.updated_at)</when>
-                        <otherwise>max(e.updated_at)</otherwise>
+                        <when test='"desc".equalsIgnoreCase(sortOrder)'>min(e.enriched_at)</when>
+                        <otherwise>max(e.enriched_at)</otherwise>
                     </choose>
                 from events e)),
             'data', json_agg(json_build_object(
@@ -156,7 +156,7 @@
     <select id="searchForEventsGeoJson" resultType="java.lang.String">
         with events as (
             select
-                fd.event_id, fd.updated_at,
+                fd.event_id, fd.updated_at, fd.enriched_at,
                 <choose>
                     <when test='"LATEST".equalsIgnoreCase(episodeFilterType)'>
                         jsonb_build_array((select episode from jsonb_array_elements(fd.episodes) episode
@@ -188,13 +188,13 @@
                 <if test='from != null'><![CDATA[and (fd.ended_at >= #{from})]]></if>
                 <if test='to != null'><![CDATA[and (fd.started_at <= #{to})]]></if>
                 <if test='updatedAfter != null'>
-                    <if test='"asc".equalsIgnoreCase(sortOrder)'>and fd.updated_at > #{updatedAfter}</if>
-                    <if test='"desc".equalsIgnoreCase(sortOrder)'>and fd.updated_at &lt; #{updatedAfter}</if>
+                    <if test='"asc".equalsIgnoreCase(sortOrder)'>and fd.enriched_at &gt; #{updatedAfter}</if>
+                    <if test='"desc".equalsIgnoreCase(sortOrder)'>and fd.enriched_at &lt; #{updatedAfter}</if>
                 </if>
                 <if test="xMin!=null &amp;&amp; yMin!=null &amp;&amp; xMax!=null &amp;&amp; yMax!=null">
                     and ST_MakeEnvelope(#{xMin}, #{yMin}, #{xMax}, #{yMax}, 4326) &amp;&amp; fd.collected_geometry
                 </if>
-            order by fd.updated_at ${sortOrder}
+            order by fd.enriched_at ${sortOrder}
             limit #{limit}
         ),
         episodes as (
@@ -237,8 +237,8 @@
                 'pageMetadata', json_build_object('nextAfterValue',
                     (select
                         <choose>
-                            <when test='"desc".equalsIgnoreCase(sortOrder)'>min(e.updated_at)</when>
-                            <otherwise>max(e.updated_at)</otherwise>
+                            <when test='"desc".equalsIgnoreCase(sortOrder)'>min(e.enriched_at)</when>
+                            <otherwise>max(e.enriched_at)</otherwise>
                         </choose>
                     from events e)),
                 'features', json_agg(ST_AsGeoJSON(props.*)::json))

--- a/src/test/java/io/kontur/eventapi/service/EventResourceServiceIT.java
+++ b/src/test/java/io/kontur/eventapi/service/EventResourceServiceIT.java
@@ -78,6 +78,7 @@ public class EventResourceServiceIT extends AbstractCleanableIntegrationTest {
         feedEpisode.setGeometries(new FeatureCollection(new Feature[]{new Feature(write, Map.of())}));
         feedData.getEpisodes().add(feedEpisode);
         feedData.setEnriched(true);
+        feedData.setEnrichedAt(feedData.getUpdatedAt());
         feedDao.insertFeedData(feedData, feedAlias);
 
         //when-then
@@ -101,6 +102,7 @@ public class EventResourceServiceIT extends AbstractCleanableIntegrationTest {
         feedData.setStartedAt(dateTimeOf(2020, 5, 1));
         feedData.setEndedAt(dateTimeOf(2020, 6, 1));
         feedData.setEnriched(true);
+        feedData.setEnrichedAt(feedData.getUpdatedAt());
         feedDao.insertFeedData(feedData, feedAlias);
 
         var resultOfSearching01 = findEvent(dateTimeOf(2020, 4, 15), dateTimeOf(2020, 5, 15));
@@ -154,16 +156,19 @@ public class EventResourceServiceIT extends AbstractCleanableIntegrationTest {
         var earliestEvent = new FeedData(UUID.randomUUID(), feed.getFeedId(), 1L);
         earliestEvent.setUpdatedAt(OffsetDateTime.of(LocalDateTime.of(2021, 1, 1, 13, 22), ZoneOffset.UTC));
         earliestEvent.setEnriched(true);
+        earliestEvent.setEnrichedAt(earliestEvent.getUpdatedAt());
         feedDao.insertFeedData(earliestEvent, feedAlias);
 
         var middleEvent = new FeedData(UUID.randomUUID(), feed.getFeedId(), 1L);
         middleEvent.setUpdatedAt(OffsetDateTime.of(LocalDateTime.of(2021, 1, 1, 13, 23), ZoneOffset.UTC));
         middleEvent.setEnriched(true);
+        middleEvent.setEnrichedAt(middleEvent.getUpdatedAt());
         feedDao.insertFeedData(middleEvent, feedAlias);
 
         var latestEvent = new FeedData(UUID.randomUUID(), feed.getFeedId(), 1L);
         latestEvent.setUpdatedAt(OffsetDateTime.of(LocalDateTime.of(2021, 1, 1, 13, 24), ZoneOffset.UTC));
         latestEvent.setEnriched(true);
+        latestEvent.setEnrichedAt(latestEvent.getUpdatedAt());
         feedDao.insertFeedData(latestEvent, feedAlias);
 
         //when page 1 ASC
@@ -177,7 +182,7 @@ public class EventResourceServiceIT extends AbstractCleanableIntegrationTest {
 
         //when page 2 ASC
         List<TestEventDto> page2Asc = objectMapper.readValue(eventResourceService
-                .searchEvents(feedAlias, null, null, null, middleEvent.getUpdatedAt(), 2, null, ASC, null, ANY).get(), TestEventListDto.class).getData();
+                .searchEvents(feedAlias, null, null, null, middleEvent.getEnrichedAt(), 2, null, ASC, null, ANY).get(), TestEventListDto.class).getData();
 
         //then
         assertEquals(1, page2Asc.size());
@@ -194,7 +199,7 @@ public class EventResourceServiceIT extends AbstractCleanableIntegrationTest {
 
         //when page 2 DESC
         List<TestEventDto> page2Desc = objectMapper.readValue(eventResourceService
-                .searchEvents(feedAlias, null, null, null, middleEvent.getUpdatedAt(), 2, null, DESC, null, ANY).get(), TestEventListDto.class).getData();
+                .searchEvents(feedAlias, null, null, null, middleEvent.getEnrichedAt(), 2, null, DESC, null, ANY).get(), TestEventListDto.class).getData();
 
         //then
         assertEquals(1, page2Desc.size());


### PR DESCRIPTION
## Summary
- avoid missing events by filtering and sorting by `enriched_at`
- clarify docs and swagger about `after` filter
- adjust tests for the new behaviour

## Testing
- `mvn -q -DskipTests=false test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851b29b5cc08324ac4ba82ee62ab6c7