### PR TITLE
feat(core): 12537 add cross_provider_merge feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ There are five config files:
 - `application-test.yml` - config file for TEST environment
 - `application-prod.yml` - config file for PROD environment
 - `config.yaml` - template of external config
+- See `docs/feature_flags.md` for available feature flags.
 
 We should use `dev`, `test` and `prod` config files to store different properties for different environments.
 

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -1,0 +1,9 @@
+# Feature Flags
+
+This project uses simple feature flags to enable experimental functionality for a limited set of users.
+
+## `cross_provider_merge`
+
+Enables cross-provider merge mode in DN. Access is granted only to users that have one of the roles listed in `features.cross_provider_merge.roles` in `application.yml` (by default `cross_provider_merge`).
+
+The feature is considered **beta** and should only be enabled for testers from the relevant Keycloak role group.

--- a/src/main/java/io/kontur/eventapi/service/BetaFeaturesService.java
+++ b/src/main/java/io/kontur/eventapi/service/BetaFeaturesService.java
@@ -1,0 +1,29 @@
+package io.kontur.eventapi.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+public class BetaFeaturesService {
+
+    private final List<String> crossProviderMergeRoles;
+
+    public BetaFeaturesService(@Value("${features.cross_provider_merge.roles:}") String[] roles) {
+        this.crossProviderMergeRoles = roles != null ? Arrays.asList(roles) : Collections.emptyList();
+    }
+
+    public boolean isCrossProviderMergeAllowed(Authentication authentication) {
+        if (authentication == null) {
+            return false;
+        }
+        return authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .anyMatch(crossProviderMergeRoles::contains);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -273,6 +273,10 @@ management:
       path-mapping:
         prometheus: metrics
 
+features:
+  cross_provider_merge:
+    roles: cross_provider_merge
+
 sentry:
   dsn: https://fixme@dsn.ingest.sentry.io/project-id
   # Set traces-sample-rate to 1.0 to capture 100% of transactions for performance monitoring.

--- a/src/test/java/io/kontur/eventapi/service/BetaFeaturesServiceTest.java
+++ b/src/test/java/io/kontur/eventapi/service/BetaFeaturesServiceTest.java
@@ -1,0 +1,28 @@
+package io.kontur.eventapi.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BetaFeaturesServiceTest {
+
+    @Test
+    void shouldAllowAccessWhenRolePresent() {
+        BetaFeaturesService service = new BetaFeaturesService(new String[]{"cross_provider_merge"});
+        TestingAuthenticationToken auth = new TestingAuthenticationToken("user", null,
+                List.of(new SimpleGrantedAuthority("cross_provider_merge")));
+        assertTrue(service.isCrossProviderMergeAllowed(auth));
+    }
+
+    @Test
+    void shouldDenyAccessWhenRoleAbsent() {
+        BetaFeaturesService service = new BetaFeaturesService(new String[]{"cross_provider_merge"});
+        TestingAuthenticationToken auth = new TestingAuthenticationToken("user", null,
+                List.of(new SimpleGrantedAuthority("another_role")));
+        assertFalse(service.isCrossProviderMergeAllowed(auth));
+    }
+}


### PR DESCRIPTION
## Summary
- add BetaFeaturesService to evaluate cross_provider_merge flag
- document available feature flags
- expose cross_provider_merge roles in application.yml
- mention feature flag docs in README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851b2e358b08324bc7ef39d35182ead