### PR TITLE
feat(api): add endpoint for latest active events

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -39,3 +39,10 @@ Return a single event by feed alias, event ID and optional version. When the ver
 
 ## `GET /v1/user_feeds`
 Return the list of feeds available for the authenticated user. The list is built from the roles present in the JWT token.
+
+## `GET /v1/latest`
+Return active significant events from all feeds sorted by update date.
+
+**Parameters**
+- `limit` – maximum number of events to return (default `20`, min `0`, max `1000`).
+- `bbox` – bounding box filter `minLon,minLat,maxLon,maxLat` (optional).

--- a/src/main/java/io/kontur/eventapi/dao/ApiDao.java
+++ b/src/main/java/io/kontur/eventapi/dao/ApiDao.java
@@ -62,7 +62,18 @@ public class ApiDao {
 				null, null, null, null, episodeFilterType);
 	}
 
-	public Optional<String> getEventByEventIdAndByVersionOrLast(UUID eventId, String feed, Long version, EpisodeFilterType episodeFilterType) {
-		return mapper.getEventByEventIdAndByVersionOrLast(eventId, feed, version, episodeFilterType);
-	}
+        public Optional<String> getEventByEventIdAndByVersionOrLast(UUID eventId, String feed, Long version, EpisodeFilterType episodeFilterType) {
+                return mapper.getEventByEventIdAndByVersionOrLast(eventId, feed, version, episodeFilterType);
+        }
+
+        public String getLatestEvents(int limit, List<BigDecimal> bBox) {
+                if (bBox != null) {
+                        var xMin = bBox.get(0);
+                        var yMin = bBox.get(1);
+                        var xMax = bBox.get(2);
+                        var yMax = bBox.get(3);
+                        return mapper.getLatestEvents(limit, xMin, xMax, yMin, yMax);
+                }
+                return mapper.getLatestEvents(limit, null, null, null, null);
+        }
 }

--- a/src/main/java/io/kontur/eventapi/dao/mapper/ApiMapper.java
+++ b/src/main/java/io/kontur/eventapi/dao/mapper/ApiMapper.java
@@ -47,8 +47,14 @@ public interface ApiMapper {
 	                              @Param("yMax") BigDecimal yMax,
 	                              @Param("episodeFilterType") EpisodeFilterType episodeFilterType);
 
-	Optional<String> getEventByEventIdAndByVersionOrLast(@Param("eventId") UUID eventId,
-	                                                     @Param("feedAlias") String feedAlias,
-	                                                     @Param("version") Long version,
-	                                                     @Param("episodeFilterType") EpisodeFilterType episodeFilterType);
+    Optional<String> getEventByEventIdAndByVersionOrLast(@Param("eventId") UUID eventId,
+                                                         @Param("feedAlias") String feedAlias,
+                                                         @Param("version") Long version,
+                                                         @Param("episodeFilterType") EpisodeFilterType episodeFilterType);
+
+    String getLatestEvents(@Param("limit") int limit,
+                           @Param("xMin") BigDecimal xMin,
+                           @Param("xMax") BigDecimal xMax,
+                           @Param("yMin") BigDecimal yMin,
+                           @Param("yMax") BigDecimal yMax);
 }

--- a/src/main/java/io/kontur/eventapi/resource/EventResource.java
+++ b/src/main/java/io/kontur/eventapi/resource/EventResource.java
@@ -276,4 +276,22 @@ public class EventResource {
                 .toList();
         return ResponseEntity.ok(allowedFeeds);
     }
+
+    @GetMapping(path = "/latest", produces = {MediaType.APPLICATION_JSON_VALUE})
+    @Operation(
+            tags = "Events",
+            summary = "Returns active significant events")
+    @ApiResponse(
+            responseCode = "200",
+            description = "Successful operation",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class)))
+    public ResponseEntity<String> getLatestEvents(
+            @Parameter(description = "Number of records to return, maximum 1000", example = "20")
+            @RequestParam(value = "limit", defaultValue = "20")
+            @Min(0) @Max(1000) int limit,
+            @Parameter(description = "Bounding box as four numbers: minLon,minLat,maxLon,maxLat")
+            @RequestParam(value = "bbox", required = false) @ValidBbox List<BigDecimal> bbox) {
+        Optional<String> res = eventResourceService.getLatestEvents(limit, bbox);
+        return res.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.noContent().build());
+    }
 }

--- a/src/main/java/io/kontur/eventapi/service/EventResourceService.java
+++ b/src/main/java/io/kontur/eventapi/service/EventResourceService.java
@@ -63,4 +63,9 @@ public class EventResourceService {
                 updatedAfter, limit, severities, sortOrder, bbox, episodeFilterType);
         return geoJson == null ? Optional.empty() : Optional.of(geoJson);
     }
+
+    public Optional<String> getLatestEvents(int limit, List<BigDecimal> bbox) {
+        String result = apiDao.getLatestEvents(limit, bbox);
+        return result == null ? Optional.empty() : Optional.of(result);
+    }
 }

--- a/src/main/resources/db/mappers/ApiMapper.xml
+++ b/src/main/resources/db/mappers/ApiMapper.xml
@@ -246,6 +246,56 @@
         from props
     </select>
 
+    <select id="getLatestEvents" resultType="java.lang.String">
+        with events as (
+            select f.alias as feed, fd.event_id, fd.version, fd.name, fd.proper_name, fd.description,
+                   fd.type, sv.severity, fd.active, fd.started_at, fd.ended_at, fd.updated_at,
+                   fd.location, fd.urls, fd.loss, fd.severity_data, fd.event_details,
+                   fd.observations, fd.geometries, fd.episodes,
+                   jsonb_array_length(fd.episodes) as episode_count,
+                   box2d(fd.collected_geometry) as bbox,
+                   st_pointonsurface(fd.collected_geometry) as centroid
+            from feed_event_status fes
+                join feed_data fd on fes.feed_id = fd.feed_id and fes.event_id = fd.event_id
+                join feeds f on fd.feed_id = f.feed_id
+                left join severities sv on fd.severity_id = sv.severity_id
+            where fes.actual
+              and fd.is_latest_version and fd.enriched
+              and fd.active
+              <if test="xMin!=null and yMin!=null and xMax!=null and yMax!=null">
+                  and ST_Intersects(ST_MakeEnvelope(#{xMin}, #{yMin}, #{xMax}, #{yMax}, 4326), fd.collected_geometry)
+              </if>
+            order by fd.updated_at desc
+            limit #{limit}
+        )
+        select case when count(*) > 0 then json_agg(json_build_object(
+                'feed', feed,
+                'eventId', event_id,
+                'version', version,
+                'name', name,
+                'properName', proper_name,
+                'description', description,
+                'type', type,
+                'severity', severity,
+                'active', active,
+                'startedAt', started_at,
+                'endedAt', ended_at,
+                'updatedAt', updated_at,
+                'location', location,
+                'urls', urls,
+                'loss', loss,
+                'severityData', severity_data,
+                'eventDetails', event_details,
+                'observations', observations,
+                'geometries', geometries,
+                'episodes', episodes,
+                'episodeCount', episode_count,
+                'bbox', array[st_xmin(bbox), st_ymin(bbox), st_xmax(bbox), st_ymax(bbox)],
+                'centroid', array[st_x(centroid), st_y(centroid)]
+              )) end
+        from events
+    </select>
+
     <resultMap id="feedDtoMap" type="io.kontur.eventapi.resource.dto.FeedDto">
         <result property="feed" column="alias"/>
         <result property="name" column="name"/>


### PR DESCRIPTION
## Summary
- add `/v1/latest` endpoint to fetch active significant events
- expose DAO and SQL mapper for latest events selection
- document new endpoint

## Testing
- `mvn -q -DskipTests install` *(fails: Non-resolvable parent POM)*
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851b2fb718c83248fb2118b757878bf