### PR TITLE
fix(events): 14306 handle null enums in request params

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -13,8 +13,8 @@ Search for events within a feed.
 - `datetime` – interval filter. Accepts single RFC3339 timestamp or open/closed interval.
 - `bbox` – bounding box defined as `minLon,minLat,maxLon,maxLat`.
 - `limit` – page size (default `20`).
-- `sortOrder` – `ASC` or `DESC` by `updatedAt`.
-- `episodeFilterType` – `ANY`, `LATEST` or `NONE`.
+- `sortOrder` – `ASC` or `DESC` by `updatedAt`. Defaults to `ASC` when omitted.
+- `episodeFilterType` – `ANY`, `LATEST` or `NONE`. Defaults to `NONE` when omitted.
 
 Returns events sorted by update date using cursor based pagination. Response body is JSON containing `pageMetadata.nextAfterValue` and event data.
 

--- a/src/main/java/io/kontur/eventapi/resource/EventResource.java
+++ b/src/main/java/io/kontur/eventapi/resource/EventResource.java
@@ -103,14 +103,20 @@ public class EventResource {
             @Max(1000)
             int limit,
             @Parameter(description = "Sort selection. Default value is ASC")
-            @RequestParam(value = "sortOrder", defaultValue = "ASC")
+            @RequestParam(value = "sortOrder", required = false)
             SortOrder sortOrder,
             @Parameter(description = "How many episodes to select: " +
                     "<ul><li>ANY - all episodes</li>" +
                     "<li>LATEST - the latest episode</li>" +
                     "<li>NONE - no episodes</li></ul>")
-            @RequestParam(value = "episodeFilterType", defaultValue = "NONE")
+            @RequestParam(value = "episodeFilterType", required = false)
             EpisodeFilterType episodeFilterType) {
+        if (sortOrder == null) {
+            sortOrder = SortOrder.ASC;
+        }
+        if (episodeFilterType == null) {
+            episodeFilterType = EpisodeFilterType.NONE;
+        }
         Optional<String> dataOpt = eventResourceService.searchEvents(feed, eventTypes,
                 datetime != null && datetime.getFrom() != null ? datetime.getFrom() : null,
                 datetime != null && datetime.getTo() != null ? datetime.getTo() : null,
@@ -191,14 +197,20 @@ public class EventResource {
             @Min(1) @Max(1000)
             int limit,
             @Parameter(description = "Sort selection. Default value is ASC")
-            @RequestParam(value = "sortOrder", defaultValue = "ASC")
+            @RequestParam(value = "sortOrder", required = false)
             SortOrder sortOrder,
             @Parameter(description = "How many episodes to select: " +
                     "<ul><li>ANY - all episodes</li>" +
                     "<li>LATEST - the latest episode</li>" +
                     "<li>NONE - no episodes</li></ul>")
-            @RequestParam(value = "episodeFilterType", defaultValue = "ANY")
+            @RequestParam(value = "episodeFilterType", required = false)
             EpisodeFilterType episodeFilterType) {
+        if (sortOrder == null) {
+            sortOrder = SortOrder.ASC;
+        }
+        if (episodeFilterType == null) {
+            episodeFilterType = EpisodeFilterType.ANY;
+        }
         Optional<String> geoJsonOpt = eventResourceService.searchEventsGeoJson(feed, eventTypes,
                 datetime != null && datetime.getFrom() != null ? datetime.getFrom() : null,
                 datetime != null && datetime.getTo() != null ? datetime.getTo() : null,
@@ -251,8 +263,11 @@ public class EventResource {
                     "<ul><li>ANY - all episodes</li>" +
                     "<li>LATEST - the latest episode</li>" +
                     "<li>NONE - no episodes</li></ul>")
-            @RequestParam(value = "episodeFilterType", defaultValue = "NONE")
+            @RequestParam(value = "episodeFilterType", required = false)
             EpisodeFilterType episodeFilterType) {
+        if (episodeFilterType == null) {
+            episodeFilterType = EpisodeFilterType.NONE;
+        }
         return eventResourceService.getEventByEventIdAndByVersionOrLast(eventId, feed, version, episodeFilterType)
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.noContent().build());


### PR DESCRIPTION
## Summary
- handle null SortOrder and EpisodeFilterType parameters in EventResource
- document defaults for optional parameters

## Testing
- `mvn -q -DskipTests=false test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851b31ed32c8324989a271ed3aaa041