### PR TITLE
Fix map filter caching

### DIFF
--- a/docs/sketchy_issues.md
+++ b/docs/sketchy_issues.md
@@ -6,7 +6,7 @@ During review a few areas looked unclear or potentially problematic. They may re
 The listener contains a TODO comment to "skip products until it is clear how to handle them". It is not documented what kind of SQS messages are ignored and whether products will be supported in the future.
 
 ## Caching behaviour
-`EventResourceService` enables caching unless the `cacheDisabled` profile is active. There is no documentation describing cache invalidation rules or expected time to live.
+`EventResourceService` enables caching unless the `cacheDisabled` profile is active. Starting from v1.21.1 requests that specify a `bbox` filter bypass the cache. There is still no documentation describing cache invalidation rules or expected time to live.
 
 ## Database functions
 Liquibase scripts reference helper functions such as `collectgeometryfromepisodes` and `collectGeomFromGeoJSON`. Their definitions are not present in the repository, making it difficult to understand how geometry is aggregated.

--- a/src/main/java/io/kontur/eventapi/service/EventResourceService.java
+++ b/src/main/java/io/kontur/eventapi/service/EventResourceService.java
@@ -40,7 +40,7 @@ public class EventResourceService {
         return !Arrays.asList(environment.getActiveProfiles()).contains("cacheDisabled");
     }
 
-    @Cacheable(cacheResolver = "cacheResolver", condition = "#root.target.isCacheEnabled()")
+    @Cacheable(cacheResolver = "cacheResolver", condition = "#root.target.isCacheEnabled() && #bbox == null")
     public Optional<String> searchEvents(String feedAlias, List<EventType> eventTypes, OffsetDateTime from,
                                        OffsetDateTime to, OffsetDateTime updatedAfter, int limit,
                                        List<Severity> severities, SortOrder sortOrder, List<BigDecimal> bbox,


### PR DESCRIPTION
## Summary
- bypass cache when bbox filter is used
- document new caching rule in docs

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851b32c9d74832488dfafa36a138137