### PR TITLE
perf(sql): speed up getObservationsByEventId

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -87,6 +87,18 @@ Stores event versions for each feed. Table was redesigned in version 1.15.
 
 Unique key: (`event_id`, `version`, `feed_id`). Several GIST and BTREE indexes exist for geometry and timestamps.
 
+## `kontur_events`
+Links observations with the events they belong to.
+
+| Column | Type | Notes |
+| ------ | ---- | ----- |
+| `event_id` | `uuid` | |
+| `observation_id` | `uuid` references `normalized_observations` |
+| `provider` | `text` |
+| `recombined_at` | `timestamptz` default `now()` |
+
+Unique key: (`event_id`, `observation_id`). Index on `recombined_at` speeds up aging queries.
+
 ## `severities`
 Reference table of possible severity levels.
 

--- a/src/main/resources/db/mappers/NormalizedObservationsMapper.xml
+++ b/src/main/resources/db/mappers/NormalizedObservationsMapper.xml
@@ -82,9 +82,10 @@
     </select>
 
     <select id="getObservationsByEventId" resultMap="normalizedObservationsDtoMap">
-        select *
-        from normalized_observations
-        where observation_id in (select observation_id from kontur_events where event_id = #{eventId});
+        select no.*
+        from normalized_observations no
+                 join kontur_events ke on ke.observation_id = no.observation_id
+        where ke.event_id = #{eventId};
     </select>
 
     <select id="getObservations" resultMap="normalizedObservationsDtoMap">


### PR DESCRIPTION
## Summary
- use join instead of subquery in getObservationsByEventId
- document `kontur_events` table in schema

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851b33bf80c832499839675f9b13331