### PR TITLE
feat(tornado-japan-ma): add csv import job

### DIFF
--- a/docs/sketchy_issues.md
+++ b/docs/sketchy_issues.md
@@ -16,3 +16,8 @@ The table `feed_event_status` tracks the latest events per feed, but there are n
 
 ## External dependencies
 The project depends on a private Maven repository (`nexus.kontur.io`). Without access to it the build and tests cannot be executed.
+
+## `tornado.japan-ma` CSV ingestion
+The original implementation parsed HTML pages from the Japan Meteorological Agency.
+Updated data is provided as a CSV file. The import job now downloads the CSV and
+stores each row in `data_lake` without transformation.

--- a/src/main/java/io/kontur/eventapi/config/WorkerScheduler.java
+++ b/src/main/java/io/kontur/eventapi/config/WorkerScheduler.java
@@ -25,6 +25,7 @@ import io.kontur.eventapi.pdc.job.HpSrvMagsJob;
 import io.kontur.eventapi.pdc.job.HpSrvSearchJob;
 import io.kontur.eventapi.tornadojapanma.job.HistoricalTornadoJapanMaImportJob;
 import io.kontur.eventapi.tornadojapanma.job.TornadoJapanMaImportJob;
+import io.kontur.eventapi.tornadojapanma.job.TornadoJapanMaCsvImportJob;
 import io.kontur.eventapi.uhc.job.HumanitarianCrisisImportJob;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -47,6 +48,7 @@ public class WorkerScheduler {
     private final StaticImportJob staticImportJob;
     private final StormsNoaaImportJob stormsNoaaImportJob;
     private final TornadoJapanMaImportJob tornadoJapanMaImportJob;
+    private final TornadoJapanMaCsvImportJob tornadoJapanMaCsvImportJob;
     private final HistoricalTornadoJapanMaImportJob historicalTornadoJapanMaImportJob;
     private final PdcMapSrvSearchJobs pdcMapSrvSearchJobs;
     private final EnrichmentJob enrichmentJob;
@@ -87,6 +89,8 @@ public class WorkerScheduler {
     private String stormsNoaaImportEnabled;
     @Value("${scheduler.tornadoJapanMaImport.enable}")
     private String tornadoJapanMaImportEnabled;
+    @Value("${scheduler.tornadoJapanMaCsvImport.enable}")
+    private String tornadoJapanMaCsvImportEnabled;
     @Value("${scheduler.historicalTornadoJapanMaImport.enable}")
     private String historicalTornadoJapanMaImportEnabled;
     @Value("${scheduler.pdcMapSrvSearch.enable}")
@@ -122,6 +126,7 @@ public class WorkerScheduler {
                            FirmsImportNoaaJob firmsImportNoaaJob, FirmsImportSuomiJob firmsImportSuomiJob,
                            EmDatImportJob emDatImportJob, StaticImportJob staticImportJob,
                            StormsNoaaImportJob stormsNoaaImportJob, TornadoJapanMaImportJob tornadoJapanMaImportJob,
+                           TornadoJapanMaCsvImportJob tornadoJapanMaCsvImportJob,
                            HistoricalTornadoJapanMaImportJob historicalTornadoJapanMaImportJob,
                            PdcMapSrvSearchJobs pdcMapSrvSearchJobs,
                            EnrichmentJob enrichmentJob, CalFireSearchJob calFireSearchJob, NifcImportJob nifcImportJob,
@@ -142,6 +147,7 @@ public class WorkerScheduler {
         this.staticImportJob = staticImportJob;
         this.stormsNoaaImportJob = stormsNoaaImportJob;
         this.tornadoJapanMaImportJob = tornadoJapanMaImportJob;
+        this.tornadoJapanMaCsvImportJob = tornadoJapanMaCsvImportJob;
         this.historicalTornadoJapanMaImportJob = historicalTornadoJapanMaImportJob;
         this.pdcMapSrvSearchJobs = pdcMapSrvSearchJobs;
         this.enrichmentJob = enrichmentJob;
@@ -237,6 +243,13 @@ public class WorkerScheduler {
     public void startTornadoJapanMaImport() {
         if (Boolean.parseBoolean(tornadoJapanMaImportEnabled)) {
             tornadoJapanMaImportJob.run();
+        }
+    }
+
+    @Scheduled(initialDelayString = "${scheduler.tornadoJapanMaCsvImport.initialDelay}", fixedDelayString = "${scheduler.tornadoJapanMaCsvImport.fixedDelay}")
+    public void startTornadoJapanMaCsvImport() {
+        if (Boolean.parseBoolean(tornadoJapanMaCsvImportEnabled)) {
+            tornadoJapanMaCsvImportJob.run();
         }
     }
 

--- a/src/main/java/io/kontur/eventapi/tornadojapanma/job/TornadoJapanMaCsvImportJob.java
+++ b/src/main/java/io/kontur/eventapi/tornadojapanma/job/TornadoJapanMaCsvImportJob.java
@@ -1,0 +1,36 @@
+package io.kontur.eventapi.tornadojapanma.job;
+
+import io.kontur.eventapi.job.AbstractJob;
+import io.kontur.eventapi.tornadojapanma.service.TornadoJapanMaImportService;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.OffsetDateTime;
+
+@Component
+public class TornadoJapanMaCsvImportJob extends AbstractJob {
+
+    private final TornadoJapanMaImportService service;
+    private final String csvUrl;
+
+    public TornadoJapanMaCsvImportJob(MeterRegistry meterRegistry,
+                                      TornadoJapanMaImportService service,
+                                      @Value("${tornadoJapanMa.csv}") String csvUrl) {
+        super(meterRegistry);
+        this.service = service;
+        this.csvUrl = csvUrl;
+    }
+
+    @Override
+    public String getName() {
+        return "tornadoJapanMaCsvImport";
+    }
+
+    @Override
+    public void execute() throws Exception {
+        String csvData = service.downloadCsv(csvUrl);
+        OffsetDateTime updatedAt = OffsetDateTime.now();
+        service.storeCsvData(csvData, updatedAt);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,6 +78,7 @@ humanitarianCrisis:
 
 tornadoJapanMa:
   host: 'https://www.data.jma.go.jp/obd/stats/data/bosai/tornado/'
+  csv: 'https://www.data.jma.go.jp/obd/stats/data/bosai/tornado/data/ichiran.csv'
 
 calfire:
   host: 'https://www.fire.ca.gov/'
@@ -136,6 +137,10 @@ scheduler:
     initialDelay: 1000
     fixedDelay: P1D # every day
   tornadoJapanMaImport:
+    enable: false
+    initialDelay: 1000
+    fixedDelay: P1D
+  tornadoJapanMaCsvImport:
     enable: false
     initialDelay: 1000
     fixedDelay: P1D

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -31,6 +31,7 @@ humanitarianCrisis:
 
 tornadoJapanMa:
   host: 'https://www.data.jma.go.jp/obd/stats/data/bosai/tornado/'
+  csv: 'https://www.data.jma.go.jp/obd/stats/data/bosai/tornado/data/ichiran.csv'
 
 calfire:
   host: 'https://www.fire.ca.gov/'
@@ -89,6 +90,10 @@ scheduler:
     initialDelay: 999999
     fixedDelay: 999999
   tornadoJapanMaImport:
+    enable: false
+    initialDelay: 999999
+    fixedDelay: 999999
+  tornadoJapanMaCsvImport:
     enable: false
     initialDelay: 999999
     fixedDelay: 999999


### PR DESCRIPTION
## Summary
- add CSV ingestion job for tornado.japan-ma
- wire new job in worker scheduler
- document CSV ingestion in sketchy_issues
- configure CSV URL and scheduler properties

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851b37ce33483249768bdf62f802ee4