### PR TITLE
feat(feed): default flow for cost field

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -81,6 +81,7 @@ Stores event versions for each feed. Table was redesigned in version 1.15.
 | `event_details` | `jsonb` default `{}` |
 | `geometries` | `jsonb` |
 | `urls` | `text[]` |
+| `cost` | `jsonb` |
 | `proper_name` | `text` |
 | `location` | `text` |
 | `collected_geometry` | `geometry` generated from episodes |

--- a/src/main/java/io/kontur/eventapi/entity/FeedData.java
+++ b/src/main/java/io/kontur/eventapi/entity/FeedData.java
@@ -3,6 +3,8 @@ package io.kontur.eventapi.entity;
 import lombok.Data;
 import org.wololo.geojson.FeatureCollection;
 
+import java.math.BigDecimal;
+
 import java.time.OffsetDateTime;
 import java.util.*;
 
@@ -22,6 +24,7 @@ public class FeedData {
     private OffsetDateTime endedAt;
     private OffsetDateTime updatedAt;
     private String location;
+    private BigDecimal cost;
     private List<String> urls = new ArrayList<>();
     private Map<String, Object> loss = new HashMap<>();
     private Map<String, Object> severityData = new HashMap<>();

--- a/src/main/java/io/kontur/eventapi/entity/FeedEpisode.java
+++ b/src/main/java/io/kontur/eventapi/entity/FeedEpisode.java
@@ -6,6 +6,8 @@ import lombok.Data;
 import org.springframework.util.CollectionUtils;
 import org.wololo.geojson.FeatureCollection;
 
+import java.math.BigDecimal;
+
 import java.time.OffsetDateTime;
 import java.util.*;
 
@@ -22,6 +24,7 @@ public class FeedEpisode {
     private OffsetDateTime updatedAt;
     private OffsetDateTime sourceUpdatedAt;
     private String location;
+    private BigDecimal cost;
     private List<String> urls = new ArrayList<>();
     private Map<String, Object> loss = new HashMap<>();
     private Map<String, Object> severityData = new HashMap<>();

--- a/src/main/java/io/kontur/eventapi/episodecomposition/EpisodeCombinator.java
+++ b/src/main/java/io/kontur/eventapi/episodecomposition/EpisodeCombinator.java
@@ -44,6 +44,7 @@ public abstract class EpisodeCombinator implements Applicable<NormalizedObservat
         }
         feedEpisode.setProperName(observation.getProperName());
         feedEpisode.setLocation(observation.getRegion());
+        feedEpisode.setCost(observation.getCost());
         feedEpisode.setLoss(observation.getLoss());
         feedEpisode.setSeverityData(observation.getSeverityData());
 

--- a/src/main/java/io/kontur/eventapi/job/FeedCompositionJob.java
+++ b/src/main/java/io/kontur/eventapi/job/FeedCompositionJob.java
@@ -18,6 +18,7 @@ import org.springframework.util.CollectionUtils;
 
 import java.time.OffsetDateTime;
 import java.util.*;
+import java.math.BigDecimal;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
@@ -139,6 +140,12 @@ public class FeedCompositionJob extends AbstractJob {
                 .filter(e -> !isEmpty(e.getLocation()))
                 .max(comparing(FeedEpisode::getStartedAt).thenComparing(FeedEpisode::getUpdatedAt))
                 .map(FeedEpisode::getLocation).orElse(null));
+
+        feedData.setCost(episodes.stream()
+                .filter(e -> e.getCost() != null)
+                .max(comparing(FeedEpisode::getSourceUpdatedAt))
+                .map(FeedEpisode::getCost)
+                .orElse(null));
 
         feedData.setSeverity(episodes.stream()
                 .map(FeedEpisode::getSeverity)

--- a/src/main/java/io/kontur/eventapi/typehandler/BigDecimalJsonbTypeHandler.java
+++ b/src/main/java/io/kontur/eventapi/typehandler/BigDecimalJsonbTypeHandler.java
@@ -1,0 +1,37 @@
+package io.kontur.eventapi.typehandler;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+
+import java.math.BigDecimal;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class BigDecimalJsonbTypeHandler extends BaseTypeHandler<BigDecimal> {
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, BigDecimal parameter,
+                                    JdbcType jdbcType) throws SQLException {
+        ps.setObject(i, parameter);
+    }
+
+    @Override
+    public BigDecimal getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        String value = rs.getString(columnName);
+        return StringUtils.isBlank(value) ? null : new BigDecimal(value);
+    }
+
+    @Override
+    public BigDecimal getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        String value = rs.getString(columnIndex);
+        return StringUtils.isBlank(value) ? null : new BigDecimal(value);
+    }
+
+    @Override
+    public BigDecimal getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        String value = cs.getString(columnIndex);
+        return StringUtils.isBlank(value) ? null : new BigDecimal(value);
+    }
+}

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -70,3 +70,6 @@ databaseChangeLog:
 - include:
     relativeToChangelogFile: true
     file: v1.21.0/v1.21.0.yaml
+- include:
+    relativeToChangelogFile: true
+    file: v1.22.0/v1.22.0.yaml

--- a/src/main/resources/db/changelog/v1.22.0/add-cost-column-to-feed-data.sql
+++ b/src/main/resources/db/changelog/v1.22.0/add-cost-column-to-feed-data.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset event-api-migrations:v1.22.0/add-cost-column-to-feed-data.sql runOnChange:false
+
+alter table feed_data
+    add column if not exists cost jsonb;

--- a/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
+++ b/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
@@ -1,0 +1,4 @@
+databaseChangeLog:
+  - include:
+      relativeToChangelogFile: true
+      file: add-cost-column-to-feed-data.sql

--- a/src/main/resources/db/mappers/ApiMapper.xml
+++ b/src/main/resources/db/mappers/ApiMapper.xml
@@ -17,7 +17,7 @@
         with events as (
             select
                 fd.event_id, fd.version, fd.name, fd.proper_name, fd.description, fd.type, sv.severity, fd.active,
-                fd.started_at, fd.ended_at, fd.updated_at, fd.location, fd.urls, fd.loss, fd.severity_data, fd.event_details, fd.observations, fd.geometries,
+                fd.started_at, fd.ended_at, fd.updated_at, fd.location, fd.cost, fd.urls, fd.loss, fd.severity_data, fd.event_details, fd.observations, fd.geometries,
                 jsonb_array_length(fd.episodes) as episode_count,
                 <choose>
                     <when test='"LATEST".equalsIgnoreCase(episodeFilterType)'>
@@ -81,6 +81,7 @@
                 'endedAt', ended_at,
                 'updatedAt', updated_at,
                 'location', location,
+                'cost', cost,
                 'urls', urls,
                 'loss', loss,
                 'severityData', severity_data,
@@ -100,7 +101,7 @@
         with event as (
             select
                 fd.event_id, fd.feed_id, fd.version, fd.name, fd.proper_name, fd.description, fd.type, sv.severity, fd.active,
-                fd.started_at, fd.ended_at, fd.updated_at, fd.location, fd.urls, fd.loss, fd.severity_data, fd.event_details, fd.observations, fd.geometries,
+                fd.started_at, fd.ended_at, fd.updated_at, fd.location, fd.cost, fd.urls, fd.loss, fd.severity_data, fd.event_details, fd.observations, fd.geometries,
                 jsonb_array_length(fd.episodes) as episode_count,
                 <choose>
                     <when test='"LATEST".equalsIgnoreCase(episodeFilterType)'>
@@ -139,6 +140,7 @@
                 'endedAt', ended_at,
                 'updatedAt', updated_at,
                 'location', location,
+                'cost', cost,
                 'urls', urls,
                 'loss', loss,
                 'severityData', severity_data,
@@ -218,6 +220,7 @@
                 episode -> 'updatedAt' as "episode_updatedAt",
                 episode -> 'sourceUpdatedAt' as "episode_sourceUpdatedAt",
                 episode -> 'location' as episode_location,
+                episode -> 'cost' as episode_cost,
                 episode -> 'urls' as episode_urls,
                 episode -> 'loss' as episode_loss,
                 episode -> 'severityData' as "episode_severityData",

--- a/src/main/resources/db/mappers/FeedMapper.xml
+++ b/src/main/resources/db/mappers/FeedMapper.xml
@@ -17,13 +17,14 @@
 
     <insert id="insertFeedData" useGeneratedKeys="false">
         insert into feed_data (event_id, feed_id, version, name, proper_name, description, type, severity_id,
-                               active, started_at, ended_at, updated_at, location, urls,
+                               active, started_at, ended_at, updated_at, location, cost, urls,
                                <if test='loss != null'>loss,</if>
                                <if test='severityData != null'>severity_data,</if>
                                observations, geometries, episodes, enriched, auto_expire)
         values (#{eventId}, #{feedId}, #{version}, #{name}, #{properName}, #{description}, #{type},
                 (select severity_id from severities where severity = #{severity}),
                 #{active}, #{startedAt}, #{endedAt}, #{updatedAt}, #{location},
+                #{cost}::jsonb,
                 #{urls, typeHandler=io.kontur.eventapi.typehandler.StringArrayTypeHandler},
                 <if test='loss != null'>#{loss,typeHandler=io.kontur.eventapi.typehandler.MapTypeHandler}::jsonb,</if>
                 <if test='severityData != null'>#{severityData,typeHandler=io.kontur.eventapi.typehandler.MapTypeHandler}::jsonb,</if>
@@ -144,6 +145,7 @@
         <result property="endedAt" column="ended_at" />
         <result property="updatedAt" column="updated_at" />
         <result property="location" column="location"/>
+        <result property="cost" column="cost" typeHandler="io.kontur.eventapi.typehandler.BigDecimalJsonbTypeHandler" />
         <result property="urls" column="urls" typeHandler="io.kontur.eventapi.typehandler.StringArrayTypeHandler" />
         <result property="loss" column="loss" typeHandler="io.kontur.eventapi.typehandler.MapTypeHandler" />
         <result property="severityData" column="severity_data" typeHandler="io.kontur.eventapi.typehandler.MapTypeHandler" />


### PR DESCRIPTION
## Summary
- add `cost` jsonb column for feed data
- include cost in feed composition logic and DB mappers
- document new column in schema

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851b3a85cf483248472b4ee08eed0e3