### PR TITLE
feat(feed): add event severity data

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -79,6 +79,8 @@ Stores event versions for each feed. Table was redesigned in version 1.15.
 | `episodes` | `jsonb` |
 | `observations` | `uuid[]` |
 | `event_details` | `jsonb` default `{}` |
+| `severity_data` | `jsonb` default `{}` |
+| `event_severity_data` | `jsonb` default `{}` |
 | `geometries` | `jsonb` |
 | `urls` | `text[]` |
 | `proper_name` | `text` |

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 
 	<artifactId>event-api</artifactId>
-	<version>1.21.0</version>
+        <version>1.22.0</version>
 
 	<name>event-api</name>
 	<description>Kontur Event API</description>

--- a/src/main/java/io/kontur/eventapi/dao/FeedDao.java
+++ b/src/main/java/io/kontur/eventapi/dao/FeedDao.java
@@ -42,7 +42,8 @@ public class FeedDao {
                 feedData.getName(), feedData.getProperName(), feedData.getDescription(), feedData.getType(),
                 feedData.getSeverity(), feedData.getActive(), feedData.getStartedAt(), feedData.getEndedAt(),
                 feedData.getUpdatedAt(), feedData.getLocation(), feedData.getUrls(), feedData.getLoss(),
-                feedData.getSeverityData(), feedData.getObservations(), episodesJson, feedData.getEnriched(),
+                feedData.getSeverityData(), feedData.getEventSeverityData(),
+                feedData.getObservations(), episodesJson, feedData.getEnriched(),
                 feedData.getAutoExpire(), feedData.getGeomFuncType());
 
         if (count > 0) {

--- a/src/main/java/io/kontur/eventapi/dao/NormalizedObservationsDao.java
+++ b/src/main/java/io/kontur/eventapi/dao/NormalizedObservationsDao.java
@@ -30,7 +30,8 @@ public class NormalizedObservationsDao {
                 obs.getProvider(), obs.getOrigin(), obs.getName(), obs.getProperName(), obs.getDescription(),
                 obs.getEpisodeDescription(), obs.getType(), obs.getEventSeverity(), obs.getActive(), obs.getLoadedAt(),
                 obs.getStartedAt(), obs.getEndedAt(), obs.getSourceUpdatedAt(), obs.getRegion(), obs.getUrls(),
-                obs.getCost(), obs.getLoss(), obs.getSeverityData(), obs.getPoint(), geometries, obs.getAutoExpire(), obs.getRecombined());
+                obs.getCost(), obs.getLoss(), obs.getSeverityData(), obs.getEventSeverityData(),
+                obs.getPoint(), geometries, obs.getAutoExpire(), obs.getRecombined());
     }
 
     public void markAsRecombined(UUID observationId) {

--- a/src/main/java/io/kontur/eventapi/dao/mapper/FeedMapper.java
+++ b/src/main/java/io/kontur/eventapi/dao/mapper/FeedMapper.java
@@ -31,6 +31,7 @@ public interface FeedMapper {
                        @Param("urls") List<String> urls,
                        @Param("loss") Map<String, Object> loss,
                        @Param("severityData") Map<String, Object> severityData,
+                       @Param("eventSeverityData") Map<String, Object> eventSeverityData,
                        @Param("observations") Set<UUID> observations,
                        @Param("episodes") String episodes,
                        @Param("enriched") Boolean enriched,

--- a/src/main/java/io/kontur/eventapi/dao/mapper/NormalizedObservationsMapper.java
+++ b/src/main/java/io/kontur/eventapi/dao/mapper/NormalizedObservationsMapper.java
@@ -35,6 +35,7 @@ public interface NormalizedObservationsMapper {
                @Param("cost") BigDecimal cost,
                @Param("loss") Map<String, Object> loss,
                @Param("severityData") Map<String, Object> severityData,
+               @Param("eventSeverityData") Map<String, Object> eventSeverityData,
                @Param("point") String point,
                @Param("geometries") String geometries,
                @Param("autoExpire") Boolean autoExpire,

--- a/src/main/java/io/kontur/eventapi/entity/FeedData.java
+++ b/src/main/java/io/kontur/eventapi/entity/FeedData.java
@@ -25,6 +25,7 @@ public class FeedData {
     private List<String> urls = new ArrayList<>();
     private Map<String, Object> loss = new HashMap<>();
     private Map<String, Object> severityData = new HashMap<>();
+    private Map<String, Object> eventSeverityData = new HashMap<>();
     private Map<String, Object> eventDetails;
     private Set<UUID> observations = new HashSet<>();
     private FeatureCollection geometries;

--- a/src/main/java/io/kontur/eventapi/entity/NormalizedObservation.java
+++ b/src/main/java/io/kontur/eventapi/entity/NormalizedObservation.java
@@ -31,6 +31,7 @@ public class NormalizedObservation {
     private BigDecimal cost;
     private Map<String, Object> loss = new HashMap<>();
     private Map<String, Object> severityData = new HashMap<>();
+    private Map<String, Object> eventSeverityData = new HashMap<>();
     private String point;
     private FeatureCollection geometries;
     private Boolean autoExpire;

--- a/src/main/java/io/kontur/eventapi/job/FeedCompositionJob.java
+++ b/src/main/java/io/kontur/eventapi/job/FeedCompositionJob.java
@@ -172,6 +172,14 @@ public class FeedCompositionJob extends AbstractJob {
         setMaxSeverityDataValues(episodes, severityData);
         feedData.setSeverityData(severityData);
 
+        Map<String, Object> eventSeverityData = new HashMap<>();
+        eventObservations.stream()
+                .sorted(comparing(NormalizedObservation::getSourceUpdatedAt))
+                .forEachOrdered(obs -> obs.getEventSeverityData().entrySet().stream()
+                        .filter(e -> e.getValue() != null)
+                        .forEach(e -> eventSeverityData.put(e.getKey(), e.getValue())));
+        feedData.setEventSeverityData(eventSeverityData);
+
         feedData.setActive(eventObservations.stream()
                 .filter(ep -> ep.getActive() != null)
                 .max(comparing(NormalizedObservation::getSourceUpdatedAt))

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -70,3 +70,6 @@ databaseChangeLog:
 - include:
     relativeToChangelogFile: true
     file: v1.21.0/v1.21.0.yaml
+- include:
+    relativeToChangelogFile: true
+    file: v1.22.0/v1.22.0.yaml

--- a/src/main/resources/db/changelog/v1.22.0/add-event-severity-data-column.sql
+++ b/src/main/resources/db/changelog/v1.22.0/add-event-severity-data-column.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset event-api-migrations:v1.22.0/add-event-severity-data-column.sql runOnChange:true
+
+alter table feed_data
+add column event_severity_data jsonb default '{}'::jsonb;

--- a/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
+++ b/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
@@ -1,0 +1,4 @@
+databaseChangeLog:
+  - include:
+      relativeToChangelogFile: true
+      file: add-event-severity-data-column.sql

--- a/src/main/resources/db/mappers/FeedMapper.xml
+++ b/src/main/resources/db/mappers/FeedMapper.xml
@@ -20,6 +20,7 @@
                                active, started_at, ended_at, updated_at, location, urls,
                                <if test='loss != null'>loss,</if>
                                <if test='severityData != null'>severity_data,</if>
+                               <if test='eventSeverityData != null'>event_severity_data,</if>
                                observations, geometries, episodes, enriched, auto_expire)
         values (#{eventId}, #{feedId}, #{version}, #{name}, #{properName}, #{description}, #{type},
                 (select severity_id from severities where severity = #{severity}),
@@ -27,6 +28,7 @@
                 #{urls, typeHandler=io.kontur.eventapi.typehandler.StringArrayTypeHandler},
                 <if test='loss != null'>#{loss,typeHandler=io.kontur.eventapi.typehandler.MapTypeHandler}::jsonb,</if>
                 <if test='severityData != null'>#{severityData,typeHandler=io.kontur.eventapi.typehandler.MapTypeHandler}::jsonb,</if>
+                <if test='eventSeverityData != null'>#{eventSeverityData,typeHandler=io.kontur.eventapi.typehandler.MapTypeHandler}::jsonb,</if>
                 #{observations, typeHandler=io.kontur.eventapi.typehandler.UUIDArrayTypeHandler},
                 <choose>
                     <when test="geomFuncType != null &amp;&amp; geomFuncType == 1">
@@ -147,6 +149,7 @@
         <result property="urls" column="urls" typeHandler="io.kontur.eventapi.typehandler.StringArrayTypeHandler" />
         <result property="loss" column="loss" typeHandler="io.kontur.eventapi.typehandler.MapTypeHandler" />
         <result property="severityData" column="severity_data" typeHandler="io.kontur.eventapi.typehandler.MapTypeHandler" />
+        <result property="eventSeverityData" column="event_severity_data" typeHandler="io.kontur.eventapi.typehandler.MapTypeHandler" />
         <result property="eventDetails" column="event_details" typeHandler="io.kontur.eventapi.typehandler.MapTypeHandler"/>
         <result property="observations" column="observations" typeHandler="io.kontur.eventapi.typehandler.UUIDArrayTypeHandler" />
         <result property="geometries" column="geometries" typeHandler="io.kontur.eventapi.typehandler.FeatureCollectionTypeHandler"/>

--- a/src/main/resources/db/mappers/NormalizedObservationsMapper.xml
+++ b/src/main/resources/db/mappers/NormalizedObservationsMapper.xml
@@ -10,6 +10,7 @@
             ended_at, source_updated_at, region, urls, cost,
             <if test='loss != null'>loss,</if>
             <if test='severityData != null'>severity_data,</if>
+            <if test='eventSeverityData != null'>event_severity_data,</if>
             <if test='point != null'>point,</if>
             <if test='geometries != null'>geometries,</if>
             auto_expire, recombined
@@ -20,6 +21,7 @@
             #{cost},
             <if test='loss != null'>#{loss,typeHandler=io.kontur.eventapi.typehandler.MapTypeHandler}::jsonb,</if>
             <if test='severityData != null'>#{severityData,typeHandler=io.kontur.eventapi.typehandler.MapTypeHandler}::jsonb,</if>
+            <if test='eventSeverityData != null'>#{eventSeverityData,typeHandler=io.kontur.eventapi.typehandler.MapTypeHandler}::jsonb,</if>
             <if test='point != null'>'SRID=4326;${point}'::geometry,</if>
             <if test='geometries != null'>#{geometries}::jsonb,</if>
             #{autoExpire}, #{recombined}
@@ -33,6 +35,7 @@
             urls = #{urls, typeHandler=io.kontur.eventapi.typehandler.StringArrayTypeHandler}, cost = #{cost},
             <if test='loss != null'>loss = #{loss,typeHandler=io.kontur.eventapi.typehandler.MapTypeHandler}::jsonb,</if>
             <if test='severityData != null'>severity_data = #{severityData,typeHandler=io.kontur.eventapi.typehandler.MapTypeHandler}::jsonb,</if>
+            <if test='eventSeverityData != null'>event_severity_data = #{eventSeverityData,typeHandler=io.kontur.eventapi.typehandler.MapTypeHandler}::jsonb,</if>
             <if test='point != null'>point = 'SRID=4326;${point}'::geometry,</if>
             <if test='geometries != null'>geometries = #{geometries}::jsonb,</if>
             auto_expire = #{autoExpire}, recombined = #{recombined}
@@ -136,6 +139,7 @@
         <result property="cost" column="cost"/>
         <result property="loss" column="loss" typeHandler="io.kontur.eventapi.typehandler.MapTypeHandler"/>
         <result property="severityData" column="severity_data" typeHandler="io.kontur.eventapi.typehandler.MapTypeHandler"/>
+        <result property="eventSeverityData" column="event_severity_data" typeHandler="io.kontur.eventapi.typehandler.MapTypeHandler"/>
         <result property="point" column="point"/>
         <result property="geometries" column="geometries" typeHandler="io.kontur.eventapi.typehandler.FeatureCollectionTypeHandler"/>
         <result property="autoExpire" column="auto_expire"/>


### PR DESCRIPTION
## Summary
- add `eventSeverityData` field to observations and feed data entities
- propagate `eventSeverityData` in FeedCompositionJob
- support new column in MyBatis mappers and DAO layer
- document feed_data schema changes
- bump version to 1.22.0
- add Liquibase changelog for new column

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_6851b3b6da908324934ae8dd1a7580e9