### PR TITLE
fix(pdc): map warning severity as minor

### DIFF
--- a/src/main/java/io/kontur/eventapi/pdc/normalization/PdcHazardNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/pdc/normalization/PdcHazardNormalizer.java
@@ -38,7 +38,7 @@ public abstract class PdcHazardNormalizer extends Normalizer {
     );
 
     private static final Map<String, Severity> severityMap = Map.of(
-            "WARNING", Severity.EXTREME,
+            "WARNING", Severity.MINOR,
             "WATCH", Severity.SEVERE,
             "ADVISORY", Severity.MODERATE,
             "INFORMATION", Severity.MINOR,

--- a/src/test/java/io/kontur/eventapi/pdc/normalization/HpSrvSearchNormalizerTest.java
+++ b/src/test/java/io/kontur/eventapi/pdc/normalization/HpSrvSearchNormalizerTest.java
@@ -41,7 +41,7 @@ class HpSrvSearchNormalizerTest {
         assertEquals(dataLake.getProvider(), obs.getProvider());
         assertEquals("d26f0681-70e2-48b2-83eb-c8b9d8ef69fe", obs.getExternalEventId());
         assertEquals("d26f0681-70e2-48b2-83eb-c8b9d8ef69fe", obs.getExternalEpisodeId());
-        assertEquals(Severity.EXTREME, obs.getEventSeverity());
+        assertEquals(Severity.MINOR, obs.getEventSeverity());
         assertEquals("Flood - Huron, SD Region, United States", obs.getName());
         assertEquals("The National Weather Service (NWS) ...", obs.getDescription());
         assertEquals(EventType.FLOOD, obs.getType());


### PR DESCRIPTION
## Summary
- map PDC WARNING messages to MINOR severity
- update test expectations

Fixes: https://kontur.fibery.io/Tasks/Task/10051


------
https://chatgpt.com/codex/tasks/task_e_6851b3e799f483248107cf742ad7654c