### PR TITLE
feat(event-api): mark forecasted events

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -15,6 +15,7 @@ Search for events within a feed.
 - `limit` – page size (default `20`).
 - `sortOrder` – `ASC` or `DESC` by `updatedAt`.
 - `episodeFilterType` – `ANY`, `LATEST` or `NONE`.
+- `forecasted` – `true` to request forecast events, `false` for only actual events.
 
 Returns events sorted by update date using cursor based pagination. Response body is JSON containing `pageMetadata.nextAfterValue` and event data.
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -84,6 +84,7 @@ Stores event versions for each feed. Table was redesigned in version 1.15.
 | `proper_name` | `text` |
 | `location` | `text` |
 | `collected_geometry` | `geometry` generated from episodes |
+| `forecasted` | `boolean` |
 
 Unique key: (`event_id`, `version`, `feed_id`). Several GIST and BTREE indexes exist for geometry and timestamps.
 

--- a/src/main/java/io/kontur/eventapi/dao/ApiDao.java
+++ b/src/main/java/io/kontur/eventapi/dao/ApiDao.java
@@ -33,36 +33,39 @@ public class ApiDao {
 	public String searchForEvents(String feedAlias, List<EventType> eventTypes, OffsetDateTime from,
 	                                      OffsetDateTime to, OffsetDateTime updatedAfter, int limit,
 	                                      List<Severity> severities, SortOrder sortOrder, List<BigDecimal> bBox,
-	                                      EpisodeFilterType episodeFilterType) {
+                                              EpisodeFilterType episodeFilterType,
+                                              Boolean forecasted) {
 		if (bBox != null) {
 			var xMin = bBox.get(0);
 			var yMin = bBox.get(1);
 			var xMax = bBox.get(2);
 			var yMax = bBox.get(3);
-			return mapper.searchForEvents(feedAlias, eventTypes, from, to, updatedAfter, limit, severities, sortOrder,
-					xMin, xMax, yMin, yMax, episodeFilterType);
-		}
-		return mapper.searchForEvents(feedAlias, eventTypes, from, to, updatedAfter, limit, severities, sortOrder,
-				null, null, null, null, episodeFilterType);
-	}
+                        return mapper.searchForEvents(feedAlias, eventTypes, from, to, updatedAfter, limit, severities, sortOrder,
+                                        xMin, xMax, yMin, yMax, episodeFilterType, forecasted);
+                }
+                return mapper.searchForEvents(feedAlias, eventTypes, from, to, updatedAfter, limit, severities, sortOrder,
+                                null, null, null, null, episodeFilterType, forecasted);
+        }
 
 	public String searchForEventsGeoJson(String feedAlias, List<EventType> eventTypes, OffsetDateTime from,
 	                                            OffsetDateTime to, OffsetDateTime updatedAfter, int limit,
 	                                            List<Severity> severities, SortOrder sortOrder, List<BigDecimal> bBox,
-	                                            EpisodeFilterType episodeFilterType) {
+                                                    EpisodeFilterType episodeFilterType,
+                                                    Boolean forecasted) {
 		if (bBox != null) {
 			var xMin = bBox.get(0);
 			var yMin = bBox.get(1);
 			var xMax = bBox.get(2);
 			var yMax = bBox.get(3);
-			return mapper.searchForEventsGeoJson(feedAlias, eventTypes, from, to, updatedAfter, limit, severities, sortOrder,
-					xMin, xMax, yMin, yMax, episodeFilterType);
-		}
-		return mapper.searchForEventsGeoJson(feedAlias, eventTypes, from, to, updatedAfter, limit, severities, sortOrder,
-				null, null, null, null, episodeFilterType);
-	}
+                        return mapper.searchForEventsGeoJson(feedAlias, eventTypes, from, to, updatedAfter, limit, severities, sortOrder,
+                                        xMin, xMax, yMin, yMax, episodeFilterType, forecasted);
+                }
+                return mapper.searchForEventsGeoJson(feedAlias, eventTypes, from, to, updatedAfter, limit, severities, sortOrder,
+                                null, null, null, null, episodeFilterType, forecasted);
+        }
 
-	public Optional<String> getEventByEventIdAndByVersionOrLast(UUID eventId, String feed, Long version, EpisodeFilterType episodeFilterType) {
-		return mapper.getEventByEventIdAndByVersionOrLast(eventId, feed, version, episodeFilterType);
-	}
+        public Optional<String> getEventByEventIdAndByVersionOrLast(UUID eventId, String feed, Long version, EpisodeFilterType episodeFilterType,
+                                                                    Boolean forecasted) {
+                return mapper.getEventByEventIdAndByVersionOrLast(eventId, feed, version, episodeFilterType, forecasted);
+        }
 }

--- a/src/main/java/io/kontur/eventapi/dao/FeedDao.java
+++ b/src/main/java/io/kontur/eventapi/dao/FeedDao.java
@@ -43,7 +43,7 @@ public class FeedDao {
                 feedData.getSeverity(), feedData.getActive(), feedData.getStartedAt(), feedData.getEndedAt(),
                 feedData.getUpdatedAt(), feedData.getLocation(), feedData.getUrls(), feedData.getLoss(),
                 feedData.getSeverityData(), feedData.getObservations(), episodesJson, feedData.getEnriched(),
-                feedData.getAutoExpire(), feedData.getGeomFuncType());
+                feedData.getAutoExpire(), feedData.getForecasted(), feedData.getGeomFuncType());
 
         if (count > 0) {
             mapper.markOutdatedEventsVersions(feedData.getEventId(), feedData.getFeedId(), feedData.getVersion());

--- a/src/main/java/io/kontur/eventapi/dao/mapper/ApiMapper.java
+++ b/src/main/java/io/kontur/eventapi/dao/mapper/ApiMapper.java
@@ -30,8 +30,9 @@ public interface ApiMapper {
 	                       @Param("xMin") BigDecimal xMin,
 	                       @Param("xMax") BigDecimal xMax,
 	                       @Param("yMin") BigDecimal yMin,
-	                       @Param("yMax") BigDecimal yMax,
-	                       @Param("episodeFilterType") EpisodeFilterType episodeFilterType);
+                               @Param("yMax") BigDecimal yMax,
+                               @Param("episodeFilterType") EpisodeFilterType episodeFilterType,
+                               @Param("forecasted") Boolean forecasted);
 
 	String searchForEventsGeoJson(@Param("feedAlias") String feedAlias,
 	                              @Param("eventTypes") List<EventType> eventTypes,
@@ -44,11 +45,13 @@ public interface ApiMapper {
 	                              @Param("xMin") BigDecimal xMin,
 	                              @Param("xMax") BigDecimal xMax,
 	                              @Param("yMin") BigDecimal yMin,
-	                              @Param("yMax") BigDecimal yMax,
-	                              @Param("episodeFilterType") EpisodeFilterType episodeFilterType);
+                                      @Param("yMax") BigDecimal yMax,
+                                      @Param("episodeFilterType") EpisodeFilterType episodeFilterType,
+                                      @Param("forecasted") Boolean forecasted);
 
 	Optional<String> getEventByEventIdAndByVersionOrLast(@Param("eventId") UUID eventId,
 	                                                     @Param("feedAlias") String feedAlias,
-	                                                     @Param("version") Long version,
-	                                                     @Param("episodeFilterType") EpisodeFilterType episodeFilterType);
+                                                             @Param("version") Long version,
+                                                             @Param("episodeFilterType") EpisodeFilterType episodeFilterType,
+                                                             @Param("forecasted") Boolean forecasted);
 }

--- a/src/main/java/io/kontur/eventapi/dao/mapper/FeedMapper.java
+++ b/src/main/java/io/kontur/eventapi/dao/mapper/FeedMapper.java
@@ -35,6 +35,7 @@ public interface FeedMapper {
                        @Param("episodes") String episodes,
                        @Param("enriched") Boolean enriched,
                        @Param("autoExpire") Boolean autoExpire,
+                       @Param("forecasted") Boolean forecasted,
                        @Param("geomFuncType") Integer geomFuncType);
 
     /**

--- a/src/main/java/io/kontur/eventapi/entity/FeedData.java
+++ b/src/main/java/io/kontur/eventapi/entity/FeedData.java
@@ -35,6 +35,7 @@ public class FeedData {
     private OffsetDateTime composedAt;
     private OffsetDateTime enrichedAt;
     private Boolean autoExpire;
+    private Boolean forecasted;
     private Integer geomFuncType;
 
     public FeedData(UUID eventId, UUID feedId, Long version) {

--- a/src/main/java/io/kontur/eventapi/entity/FeedEpisode.java
+++ b/src/main/java/io/kontur/eventapi/entity/FeedEpisode.java
@@ -28,6 +28,7 @@ public class FeedEpisode {
     private Map<String, Object> episodeDetails;
     private Set<UUID> observations = new HashSet<>();
     private FeatureCollection geometries;
+    private Boolean forecasted;
 
     public void addUrlIfNotExists(String url) {
         if (isNotBlank(url) && !this.urls.contains(url)) {

--- a/src/main/java/io/kontur/eventapi/job/FeedCompositionJob.java
+++ b/src/main/java/io/kontur/eventapi/job/FeedCompositionJob.java
@@ -182,6 +182,9 @@ public class FeedCompositionJob extends AbstractJob {
                 .max(comparing(NormalizedObservation::getSourceUpdatedAt))
                 .map(NormalizedObservation::getAutoExpire)
                 .orElse(null));
+
+        feedData.setForecasted(episodes.stream()
+                .allMatch(ep -> Boolean.TRUE.equals(ep.getForecasted())));
     }
 
     private void fillEpisodes(List<NormalizedObservation> observations, FeedData feedData) {
@@ -217,6 +220,7 @@ public class FeedCompositionJob extends AbstractJob {
         checkNotNull(episode.getEndedAt());
         checkState(!episode.getStartedAt().isAfter(episode.getEndedAt()));
 
+        episode.setForecasted(GeometryUtil.isForecasted(episode.getGeometries()));
         feedData.addEpisode(episode);
     }
 

--- a/src/main/java/io/kontur/eventapi/resource/EventResource.java
+++ b/src/main/java/io/kontur/eventapi/resource/EventResource.java
@@ -110,11 +110,13 @@ public class EventResource {
                     "<li>LATEST - the latest episode</li>" +
                     "<li>NONE - no episodes</li></ul>")
             @RequestParam(value = "episodeFilterType", defaultValue = "NONE")
-            EpisodeFilterType episodeFilterType) {
+            EpisodeFilterType episodeFilterType,
+            @RequestParam(value = "forecasted", required = false)
+            Boolean forecasted) {
         Optional<String> dataOpt = eventResourceService.searchEvents(feed, eventTypes,
                 datetime != null && datetime.getFrom() != null ? datetime.getFrom() : null,
                 datetime != null && datetime.getTo() != null ? datetime.getTo() : null,
-                updatedAfter, limit, severities, sortOrder, bbox, episodeFilterType);
+                updatedAfter, limit, severities, sortOrder, bbox, episodeFilterType, forecasted);
         if (dataOpt.isEmpty()) {
             return ResponseEntity.noContent().build();
         }
@@ -198,11 +200,13 @@ public class EventResource {
                     "<li>LATEST - the latest episode</li>" +
                     "<li>NONE - no episodes</li></ul>")
             @RequestParam(value = "episodeFilterType", defaultValue = "ANY")
-            EpisodeFilterType episodeFilterType) {
+            EpisodeFilterType episodeFilterType,
+            @RequestParam(value = "forecasted", required = false)
+            Boolean forecasted) {
         Optional<String> geoJsonOpt = eventResourceService.searchEventsGeoJson(feed, eventTypes,
                 datetime != null && datetime.getFrom() != null ? datetime.getFrom() : null,
                 datetime != null && datetime.getTo() != null ? datetime.getTo() : null,
-                updatedAfter, limit, severities, sortOrder, bbox, episodeFilterType);
+                updatedAfter, limit, severities, sortOrder, bbox, episodeFilterType, forecasted);
         if (geoJsonOpt.isEmpty()) {
             return ResponseEntity.noContent().build();
         }
@@ -252,8 +256,10 @@ public class EventResource {
                     "<li>LATEST - the latest episode</li>" +
                     "<li>NONE - no episodes</li></ul>")
             @RequestParam(value = "episodeFilterType", defaultValue = "NONE")
-            EpisodeFilterType episodeFilterType) {
-        return eventResourceService.getEventByEventIdAndByVersionOrLast(eventId, feed, version, episodeFilterType)
+            EpisodeFilterType episodeFilterType,
+            @RequestParam(value = "forecasted", required = false)
+            Boolean forecasted) {
+        return eventResourceService.getEventByEventIdAndByVersionOrLast(eventId, feed, version, episodeFilterType, forecasted)
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.noContent().build());
     }

--- a/src/main/java/io/kontur/eventapi/service/EventResourceService.java
+++ b/src/main/java/io/kontur/eventapi/service/EventResourceService.java
@@ -44,23 +44,26 @@ public class EventResourceService {
     public Optional<String> searchEvents(String feedAlias, List<EventType> eventTypes, OffsetDateTime from,
                                        OffsetDateTime to, OffsetDateTime updatedAfter, int limit,
                                        List<Severity> severities, SortOrder sortOrder, List<BigDecimal> bbox,
-                                       EpisodeFilterType episodeFilterType) {
+                                       EpisodeFilterType episodeFilterType,
+                                       Boolean forecasted) {
         String data = apiDao.searchForEvents(feedAlias, eventTypes, from, to, updatedAfter,
-                limit, severities, sortOrder, bbox, episodeFilterType);
+                limit, severities, sortOrder, bbox, episodeFilterType, forecasted);
         return data == null ? Optional.empty() : Optional.of(data);
     }
 
     @Cacheable(cacheNames = EVENT_CACHE_NAME, cacheManager = "longCacheManager", condition = "#root.target.isCacheEnabled()")
-    public Optional<String> getEventByEventIdAndByVersionOrLast(UUID eventId, String feed, Long version, EpisodeFilterType episodeFilterType) {
-        return apiDao.getEventByEventIdAndByVersionOrLast(eventId, feed, version, episodeFilterType);
+    public Optional<String> getEventByEventIdAndByVersionOrLast(UUID eventId, String feed, Long version, EpisodeFilterType episodeFilterType,
+                                                               Boolean forecasted) {
+        return apiDao.getEventByEventIdAndByVersionOrLast(eventId, feed, version, episodeFilterType, forecasted);
     }
 
     public Optional<String> searchEventsGeoJson(String feedAlias, List<EventType> eventTypes, OffsetDateTime from,
                                                 OffsetDateTime to, OffsetDateTime updatedAfter, int limit,
                                                 List<Severity> severities, SortOrder sortOrder, List<BigDecimal> bbox,
-                                                EpisodeFilterType episodeFilterType) {
+                                                EpisodeFilterType episodeFilterType,
+                                                Boolean forecasted) {
         String geoJson = apiDao.searchForEventsGeoJson(feedAlias, eventTypes, from, to,
-                updatedAfter, limit, severities, sortOrder, bbox, episodeFilterType);
+                updatedAfter, limit, severities, sortOrder, bbox, episodeFilterType, forecasted);
         return geoJson == null ? Optional.empty() : Optional.of(geoJson);
     }
 }

--- a/src/main/java/io/kontur/eventapi/util/GeometryUtil.java
+++ b/src/main/java/io/kontur/eventapi/util/GeometryUtil.java
@@ -94,4 +94,20 @@ public class GeometryUtil {
         }
         return true;
     }
+
+    public static boolean isForecasted(FeatureCollection fc) {
+        if (fc == null || fc.getFeatures() == null) {
+            return false;
+        }
+        for (Feature feature : fc.getFeatures()) {
+            Map<String, Object> props = feature.getProperties();
+            if (props != null) {
+                Object observed = props.get(IS_OBSERVED_PROPERTY);
+                if (observed instanceof Boolean && (Boolean) observed) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
 }

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -70,3 +70,6 @@ databaseChangeLog:
 - include:
     relativeToChangelogFile: true
     file: v1.21.0/v1.21.0.yaml
+- include:
+    relativeToChangelogFile: true
+    file: v1.22.0/v1.22.0.yaml

--- a/src/main/resources/db/changelog/v1.22.0/add-forecasted-column.sql
+++ b/src/main/resources/db/changelog/v1.22.0/add-forecasted-column.sql
@@ -1,0 +1,4 @@
+--liquibase formatted sql
+
+--changeset event-api-migrations:v1.22.0/add-forecasted-column.sql runOnChange:false
+alter table feed_data add column if not exists forecasted boolean default false;

--- a/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
+++ b/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
@@ -1,0 +1,4 @@
+databaseChangeLog:
+  - include:
+      relativeToChangelogFile: true
+      file: add-forecasted-column.sql

--- a/src/main/resources/db/mappers/ApiMapper.xml
+++ b/src/main/resources/db/mappers/ApiMapper.xml
@@ -18,6 +18,7 @@
             select
                 fd.event_id, fd.version, fd.name, fd.proper_name, fd.description, fd.type, sv.severity, fd.active,
                 fd.started_at, fd.ended_at, fd.updated_at, fd.location, fd.urls, fd.loss, fd.severity_data, fd.event_details, fd.observations, fd.geometries,
+                fd.forecasted,
                 jsonb_array_length(fd.episodes) as episode_count,
                 <choose>
                     <when test='"LATEST".equalsIgnoreCase(episodeFilterType)'>
@@ -35,6 +36,8 @@
             left join severities sv on fd.severity_id = sv.severity_id
             where fd.feed_id = ( select feed_id from feeds where alias = #{feedAlias} )
                 and fd.is_latest_version and fd.enriched
+                <if test='forecasted != null'>and fd.forecasted = #{forecasted}</if>
+                <if test='forecasted != null'>and fd.forecasted = #{forecasted}</if>
                 <if test="eventTypes!=null &amp;&amp; !eventTypes.isEmpty" >
                     <foreach item="eventType" collection="eventTypes" separator="," open="and fd.type in (" close=")">
                         #{eventType}::text
@@ -88,6 +91,7 @@
                 'observations', observations,
                 'geometries', geometries,
                 'episodes', episodes,
+                'forecasted', forecasted,
                 'episodeCount', episode_count,
                 'bbox', array[st_xmin(bbox), st_ymin(bbox), st_xmax(bbox),st_ymax(bbox)],
                 'centroid', array[st_x(centroid), st_y(centroid)]
@@ -101,6 +105,7 @@
             select
                 fd.event_id, fd.feed_id, fd.version, fd.name, fd.proper_name, fd.description, fd.type, sv.severity, fd.active,
                 fd.started_at, fd.ended_at, fd.updated_at, fd.location, fd.urls, fd.loss, fd.severity_data, fd.event_details, fd.observations, fd.geometries,
+                fd.forecasted,
                 jsonb_array_length(fd.episodes) as episode_count,
                 <choose>
                     <when test='"LATEST".equalsIgnoreCase(episodeFilterType)'>
@@ -124,6 +129,7 @@
                     <when test="version != null">and fd.version = #{version}</when>
                     <otherwise>and fd.is_latest_version</otherwise>
                 </choose>
+                <if test='forecasted != null'>and fd.forecasted = #{forecasted}</if>
         )
         select
             json_build_object(
@@ -146,6 +152,7 @@
                 'observations', observations,
                 'geometries', geometries,
                 'episodes', episodes,
+                'forecasted', forecasted,
                 'episodeCount', episode_count,
                 'bbox', array[st_xmin(bbox), st_ymin(bbox), st_xmax(bbox),st_ymax(bbox)],
                 'centroid', array[st_x(centroid), st_y(centroid)]
@@ -156,7 +163,7 @@
     <select id="searchForEventsGeoJson" resultType="java.lang.String">
         with events as (
             select
-                fd.event_id, fd.updated_at,
+                fd.event_id, fd.updated_at, fd.forecasted,
                 <choose>
                     <when test='"LATEST".equalsIgnoreCase(episodeFilterType)'>
                         jsonb_build_array((select episode from jsonb_array_elements(fd.episodes) episode
@@ -223,6 +230,7 @@
                 episode -> 'severityData' as "episode_severityData",
                 episode -> 'episodeDetails' as "episode_episodeDetails",
                 episode -> 'observations' as episode_observations,
+                episode -> 'forecasted' as episode_forecasted,
                 feature -> 'properties' -> 'isObserved' as "feature_isObserved",
                 feature -> 'properties' -> 'forecastHrs' as "feature_forecastHrs",
                 feature -> 'properties' -> 'timestamp' as feature_timestamp,

--- a/src/main/resources/db/mappers/FeedMapper.xml
+++ b/src/main/resources/db/mappers/FeedMapper.xml
@@ -20,7 +20,7 @@
                                active, started_at, ended_at, updated_at, location, urls,
                                <if test='loss != null'>loss,</if>
                                <if test='severityData != null'>severity_data,</if>
-                               observations, geometries, episodes, enriched, auto_expire)
+                               observations, geometries, episodes, enriched, auto_expire, forecasted)
         values (#{eventId}, #{feedId}, #{version}, #{name}, #{properName}, #{description}, #{type},
                 (select severity_id from severities where severity = #{severity}),
                 #{active}, #{startedAt}, #{endedAt}, #{updatedAt}, #{location},
@@ -36,7 +36,7 @@
                         collectEventGeometries(#{episodes}::jsonb),
                     </otherwise>
                 </choose>
-                #{episodes}::jsonb, #{enriched}, #{autoExpire})
+                #{episodes}::jsonb, #{enriched}, #{autoExpire}, #{forecasted})
     </insert>
 
     <update id="markOutdatedEventsVersions">
@@ -157,5 +157,6 @@
         <result property="composedAt" column="composed_at"/>
         <result property="enrichedAt" column="enriched_at"/>
         <result property="autoExpire" column="auto_expire"/>
+        <result property="forecasted" column="forecasted"/>
     </resultMap>
 </mapper>


### PR DESCRIPTION
## Summary
- add `forecasted` field for episodes and events
- support filtering events by forecast flag
- document new database column and API parameter
- add liquibase migration for `forecasted` column

Refs: https://kontur.fibery.io/Tasks/Task/10335


------
https://chatgpt.com/codex/tasks/task_e_6851b41c8228832481f3e5447dc3f6d2