### PR TITLE
feat(12370): UPS store user feed settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 #### Added
+- Endpoints and database table to store per-user feed settings
 
 #### Changed
 

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -39,3 +39,28 @@ Return a single event by feed alias, event ID and optional version. When the ver
 
 ## `GET /v1/user_feeds`
 Return the list of feeds available for the authenticated user. The list is built from the roles present in the JWT token.
+
+## `GET /v1/user_feed_settings`
+Return stored feed settings for the authenticated user. Response contains `userName`, list of `feeds` and `defaultFeed`.
+
+## `PUT /v1/user_feed_settings/default`
+Set default feed for the authenticated user. Body example:
+
+```json
+{
+  "defaultFeed": "micglobal"
+}
+```
+
+## `GET /v1/admin/user_feed_settings/{user}`
+Return feed settings for a specified user.
+
+## `PUT /v1/admin/user_feed_settings/{user}`
+Update feeds available for a user. Body example:
+
+```json
+{
+  "feeds": ["micglobal", "kontur-public"],
+  "defaultFeed": "micglobal"
+}
+```

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -105,3 +105,12 @@ Tracks current events per feed.
 | `actual` | `boolean` |
 
 Unique on (`feed_id`, `event_id`).
+
+## `user_feed_settings`
+User specific feeds configuration.
+
+| Column | Type | Notes |
+| ------ | ---- | ----- |
+| `user_name` | `text` primary key |
+| `feeds` | `text[]` | available feed aliases |
+| `default_feed` | `text` | alias used by default |

--- a/src/main/java/io/kontur/eventapi/dao/UserFeedSettingsDao.java
+++ b/src/main/java/io/kontur/eventapi/dao/UserFeedSettingsDao.java
@@ -1,0 +1,29 @@
+package io.kontur.eventapi.dao;
+
+import io.kontur.eventapi.dao.mapper.UserFeedSettingsMapper;
+import io.kontur.eventapi.entity.UserFeedSettings;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+public class UserFeedSettingsDao {
+    private final UserFeedSettingsMapper mapper;
+
+    public UserFeedSettingsDao(UserFeedSettingsMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    public Optional<UserFeedSettings> getUserFeedSettings(String userName) {
+        return mapper.getUserFeedSettings(userName);
+    }
+
+    public void upsertUserFeedSettings(String userName, List<String> feeds, String defaultFeed) {
+        mapper.upsertUserFeedSettings(userName, feeds, defaultFeed);
+    }
+
+    public void updateDefaultFeed(String userName, String defaultFeed) {
+        mapper.updateDefaultFeed(userName, defaultFeed);
+    }
+}

--- a/src/main/java/io/kontur/eventapi/dao/mapper/UserFeedSettingsMapper.java
+++ b/src/main/java/io/kontur/eventapi/dao/mapper/UserFeedSettingsMapper.java
@@ -1,0 +1,21 @@
+package io.kontur.eventapi.dao.mapper;
+
+import io.kontur.eventapi.entity.UserFeedSettings;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.Optional;
+import java.util.List;
+
+@Mapper
+public interface UserFeedSettingsMapper {
+
+    Optional<UserFeedSettings> getUserFeedSettings(@Param("userName") String userName);
+
+    void upsertUserFeedSettings(@Param("userName") String userName,
+                                @Param("feeds") List<String> feeds,
+                                @Param("defaultFeed") String defaultFeed);
+
+    void updateDefaultFeed(@Param("userName") String userName,
+                           @Param("defaultFeed") String defaultFeed);
+}

--- a/src/main/java/io/kontur/eventapi/entity/UserFeedSettings.java
+++ b/src/main/java/io/kontur/eventapi/entity/UserFeedSettings.java
@@ -1,0 +1,12 @@
+package io.kontur.eventapi.entity;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class UserFeedSettings {
+    private String userName;
+    private List<String> feeds;
+    private String defaultFeed;
+}

--- a/src/main/java/io/kontur/eventapi/resource/UserFeedSettingsResource.java
+++ b/src/main/java/io/kontur/eventapi/resource/UserFeedSettingsResource.java
@@ -1,0 +1,58 @@
+package io.kontur.eventapi.resource;
+
+import io.kontur.eventapi.entity.UserFeedSettings;
+import io.kontur.eventapi.service.UserFeedSettingsService;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/v1")
+public class UserFeedSettingsResource {
+
+    private final UserFeedSettingsService service;
+
+    public UserFeedSettingsResource(UserFeedSettingsService service) {
+        this.service = service;
+    }
+
+    @GetMapping(path = "/user_feed_settings", produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(tags = "Feeds", summary = "Get feeds settings for current user")
+    public ResponseEntity<UserFeedSettings> getUserSettings(Authentication authentication) {
+        String user = authentication.getName();
+        Optional<UserFeedSettings> settings = service.getUserFeedSettings(user);
+        return settings.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.ok(new UserFeedSettings()));
+    }
+
+    @PutMapping(path = "/user_feed_settings/default", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(tags = "Feeds", summary = "Set default feed for current user")
+    public ResponseEntity<Void> setDefaultFeed(Authentication authentication, @RequestBody Map<String, String> body) {
+        String user = authentication.getName();
+        service.updateDefaultFeed(user, body.get("defaultFeed"));
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping(path = "/admin/user_feed_settings/{user}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(tags = "Feeds", summary = "Get feeds settings for specified user")
+    public ResponseEntity<UserFeedSettings> adminGetUserSettings(@PathVariable("user") String user) {
+        return service.getUserFeedSettings(user)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.ok(new UserFeedSettings()));
+    }
+
+    @PutMapping(path = "/admin/user_feed_settings/{user}", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(tags = "Feeds", summary = "Update feeds available for user")
+    public ResponseEntity<Void> adminSetUserFeeds(@PathVariable("user") String user, @RequestBody Map<String, Object> body) {
+        @SuppressWarnings("unchecked")
+        List<String> feeds = (List<String>) body.get("feeds");
+        String defaultFeed = (String) body.get("defaultFeed");
+        service.upsertUserFeedSettings(user, feeds, defaultFeed);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/io/kontur/eventapi/service/UserFeedSettingsService.java
+++ b/src/main/java/io/kontur/eventapi/service/UserFeedSettingsService.java
@@ -1,0 +1,29 @@
+package io.kontur.eventapi.service;
+
+import io.kontur.eventapi.dao.UserFeedSettingsDao;
+import io.kontur.eventapi.entity.UserFeedSettings;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class UserFeedSettingsService {
+    private final UserFeedSettingsDao dao;
+
+    public UserFeedSettingsService(UserFeedSettingsDao dao) {
+        this.dao = dao;
+    }
+
+    public Optional<UserFeedSettings> getUserFeedSettings(String userName) {
+        return dao.getUserFeedSettings(userName);
+    }
+
+    public void upsertUserFeedSettings(String userName, List<String> feeds, String defaultFeed) {
+        dao.upsertUserFeedSettings(userName, feeds, defaultFeed);
+    }
+
+    public void updateDefaultFeed(String userName, String defaultFeed) {
+        dao.updateDefaultFeed(userName, defaultFeed);
+    }
+}

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -70,3 +70,6 @@ databaseChangeLog:
 - include:
     relativeToChangelogFile: true
     file: v1.21.0/v1.21.0.yaml
+- include:
+    relativeToChangelogFile: true
+    file: v1.22.0/v1.22.0.yaml

--- a/src/main/resources/db/changelog/v1.22.0/create-user-feed-settings.sql
+++ b/src/main/resources/db/changelog/v1.22.0/create-user-feed-settings.sql
@@ -1,0 +1,11 @@
+--liquibase formatted sql
+
+--changeset event-api-migrations:v1.22.0/create-user-feed-settings.sql runOnChange:true
+
+create table if not exists user_feed_settings (
+    user_name text primary key,
+    feeds text[] default '{}'::text[],
+    default_feed text
+);
+
+create index if not exists user_feed_settings_default_feed_idx on user_feed_settings (default_feed);

--- a/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
+++ b/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
@@ -1,0 +1,4 @@
+databaseChangeLog:
+  - include:
+      relativeToChangelogFile: true
+      file: create-user-feed-settings.sql

--- a/src/main/resources/db/mappers/UserFeedSettingsMapper.xml
+++ b/src/main/resources/db/mappers/UserFeedSettingsMapper.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.kontur.eventapi.dao.mapper.UserFeedSettingsMapper">
+
+    <select id="getUserFeedSettings" resultType="io.kontur.eventapi.entity.UserFeedSettings">
+        select user_name, feeds, default_feed
+        from user_feed_settings
+        where user_name = #{userName}
+    </select>
+
+    <insert id="upsertUserFeedSettings">
+        insert into user_feed_settings (user_name, feeds, default_feed)
+        values (#{userName}, #{feeds, typeHandler=io.kontur.eventapi.typehandler.StringArrayTypeHandler}, #{defaultFeed})
+        on conflict (user_name) do update
+            set feeds = EXCLUDED.feeds,
+                default_feed = EXCLUDED.default_feed
+    </insert>
+
+    <update id="updateDefaultFeed">
+        update user_feed_settings
+        set default_feed = #{defaultFeed}
+        where user_name = #{userName}
+    </update>
+</mapper>

--- a/src/test/java/io/kontur/eventapi/resource/UserFeedSettingsResourceTest.java
+++ b/src/test/java/io/kontur/eventapi/resource/UserFeedSettingsResourceTest.java
@@ -1,0 +1,41 @@
+package io.kontur.eventapi.resource;
+
+import io.kontur.eventapi.entity.UserFeedSettings;
+import io.kontur.eventapi.service.UserFeedSettingsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+public class UserFeedSettingsResourceTest {
+    private UserFeedSettingsService service = mock(UserFeedSettingsService.class);
+    private UserFeedSettingsResource resource;
+
+    @BeforeEach
+    public void setUp() {
+        resource = new UserFeedSettingsResource(service);
+    }
+
+    @Test
+    public void adminSetUserFeedsTest() {
+        resource.adminSetUserFeeds("alice", Map.of("feeds", List.of("f1", "f2"), "defaultFeed", "f1"));
+        verify(service, times(1)).upsertUserFeedSettings("alice", List.of("f1", "f2"), "f1");
+    }
+
+    @Test
+    public void adminGetUserSettingsTest() {
+        UserFeedSettings settings = new UserFeedSettings();
+        settings.setUserName("bob");
+        settings.setFeeds(List.of("feed"));
+        when(service.getUserFeedSettings("bob")).thenReturn(Optional.of(settings));
+        UserFeedSettings result = resource.adminGetUserSettings("bob").getBody();
+        assertEquals("bob", result.getUserName());
+        assertEquals(1, result.getFeeds().size());
+    }
+}


### PR DESCRIPTION
## Summary
- add migrations for user_feed_settings table
- document new REST endpoints and schema table
- provide UserFeedSettings DAO, mapper and service
- expose UserFeedSettingsResource with admin endpoints
- cover UserFeedSettingsResource with tests

## Testing
- `mvn -q -DskipTests compile` *(fails: Non-resolvable parent POM)*
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851b45bb2b48324908899c0840323e2