### PR TITLE
feat(pipelineDisabled): allow disabling ETL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Available profiles:
 - For local use:
   - `jwtAuthDisabled` - Disables JWT authorization
   - `awsSqsDisabled` - Disables AWS SQS integration
+  - `pipelineDisabled` - Disables all scheduled ETL jobs
 - For external use:
   - `dev` - for DEV environment
   - `test` - for TEST environment

--- a/docs/pipeline-separation.md
+++ b/docs/pipeline-separation.md
@@ -1,0 +1,18 @@
+# Separating REST API from ETL Pipeline
+
+The application ships with multiple scheduled jobs responsible for data import,
+normalization and enrichment. These jobs run by default whenever the application
+starts and are part of the ETL pipeline.
+
+To run the REST API without starting the ETL pipeline set the `pipelineDisabled`
+Spring profile. When this profile is active the scheduler beans are not created
+and no jobs will be executed.
+
+Example:
+
+```bash
+SPRING_PROFILES_ACTIVE=pipelineDisabled,dev ./run.sh
+```
+
+This allows deploying the API service separately from the pipeline if needed.
+

--- a/src/main/java/io/kontur/eventapi/config/SchedulerConfiguration.java
+++ b/src/main/java/io/kontur/eventapi/config/SchedulerConfiguration.java
@@ -8,6 +8,7 @@ import io.kontur.eventapi.pdc.converter.PdcDataLakeConverter;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.SchedulingConfigurer;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
@@ -18,6 +19,7 @@ import java.util.concurrent.ThreadFactory;
 
 @Configuration
 @EnableScheduling
+@Profile("!pipelineDisabled")
 public class SchedulerConfiguration implements SchedulingConfigurer {
 
     @Override

--- a/src/main/java/io/kontur/eventapi/config/WorkerScheduler.java
+++ b/src/main/java/io/kontur/eventapi/config/WorkerScheduler.java
@@ -28,9 +28,11 @@ import io.kontur.eventapi.tornadojapanma.job.TornadoJapanMaImportJob;
 import io.kontur.eventapi.uhc.job.HumanitarianCrisisImportJob;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
+@Profile("!pipelineDisabled")
 public class WorkerScheduler {
 
     private final HpSrvSearchJob hpSrvSearchJob;


### PR DESCRIPTION
## Summary
- allow disabling scheduled ETL jobs with a `pipelineDisabled` profile
- document how to run the API without the ETL pipeline

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851b5045d84832489c51a309efb9c44