### PR TITLE
chore(config): 17722 include gdacs feed in composition

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -57,6 +57,9 @@ List of available feeds.
 
 ## `feed_data`
 Stores event versions for each feed. Table was redesigned in version 1.15.
+GDACS observations are now combined into episodes during feed composition,
+so GDACS events retrieved from the API contain timelines built from these
+episodes.
 
 | Column | Type | Notes |
 | ------ | ---- | ----- |

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -192,7 +192,7 @@ scheduler:
     enable: true
     initialDelay: 1000
     fixedDelay: 1000
-    alias: kontur-public, kontur-private, pdc, wildfires, micglobal
+    alias: kontur-public, kontur-private, pdc, wildfires, micglobal, test-gdacs
   enrichment:
     enable: false
     initialDelay: 1000


### PR DESCRIPTION
## Summary
- include `test-gdacs` in `feedComposition.alias`
- note on GDACS episodes in the schema docs

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851b5abc7308324b7248f9535f7f00b