### PR TITLE
feat(19541): geocode missing wildfire locations

### DIFF
--- a/src/main/java/io/kontur/eventapi/nifc/normalization/LocationsNifcNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/nifc/normalization/LocationsNifcNormalizer.java
@@ -2,6 +2,7 @@ package io.kontur.eventapi.nifc.normalization;
 
 import io.kontur.eventapi.entity.DataLake;
 import io.kontur.eventapi.entity.NormalizedObservation;
+import io.kontur.eventapi.service.LocationService;
 import org.springframework.stereotype.Component;
 import org.wololo.geojson.Feature;
 
@@ -17,6 +18,10 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 
 @Component
 public class LocationsNifcNormalizer extends NifcNormalizer {
+
+    public LocationsNifcNormalizer(LocationService locationService) {
+        super(locationService);
+    }
 
     @Override
     public boolean isApplicable(DataLake dataLakeDto) {
@@ -44,6 +49,7 @@ public class LocationsNifcNormalizer extends NifcNormalizer {
         Double lon = readDouble(props, "InitialLongitude");
         Double lat = readDouble(props, "InitialLatitude");
         observation.setPoint(makeWktPoint(lon, lat));
+        observation.setRegion(locationService.getLocation(lon, lat));
 
         Double calculatedAcres = readDouble(props, "CalculatedAcres");
         Double incidentSize = readDouble(props, "IncidentSize");

--- a/src/main/java/io/kontur/eventapi/nifc/normalization/NifcNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/nifc/normalization/NifcNormalizer.java
@@ -4,6 +4,7 @@ import io.kontur.eventapi.entity.DataLake;
 import io.kontur.eventapi.entity.EventType;
 import io.kontur.eventapi.entity.NormalizedObservation;
 import io.kontur.eventapi.normalization.Normalizer;
+import io.kontur.eventapi.service.LocationService;
 
 import java.util.Map;
 
@@ -13,8 +14,14 @@ public abstract class NifcNormalizer extends Normalizer {
 
     private static final double acresInSqKm = 247.105;
 
+    protected final LocationService locationService;
+
     protected static final Map<String, Object> LOCATIONS_PROPERTIES = Map.of(AREA_TYPE_PROPERTY, START_POINT, IS_OBSERVED_PROPERTY, true);
     protected static final Map<String, Object> PERIMETERS_PROPERTIES = Map.of(AREA_TYPE_PROPERTY, EXPOSURE, IS_OBSERVED_PROPERTY, true);
+
+    protected NifcNormalizer(LocationService locationService) {
+        this.locationService = locationService;
+    }
 
     protected NormalizedObservation createObservationFromDataLake(DataLake dataLake) {
         NormalizedObservation observation = new NormalizedObservation();

--- a/src/main/java/io/kontur/eventapi/nifc/normalization/PerimetersNifcNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/nifc/normalization/PerimetersNifcNormalizer.java
@@ -2,6 +2,7 @@ package io.kontur.eventapi.nifc.normalization;
 
 import io.kontur.eventapi.entity.DataLake;
 import io.kontur.eventapi.entity.NormalizedObservation;
+import io.kontur.eventapi.service.LocationService;
 import org.springframework.stereotype.Component;
 import org.wololo.geojson.Feature;
 import java.util.Map;
@@ -16,6 +17,10 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 
 @Component
 public class PerimetersNifcNormalizer extends NifcNormalizer {
+
+    public PerimetersNifcNormalizer(LocationService locationService) {
+        super(locationService);
+    }
 
     @Override
     public boolean isApplicable(DataLake dataLakeDto) {
@@ -48,6 +53,7 @@ public class PerimetersNifcNormalizer extends NifcNormalizer {
         Double lon = selectFirstNotNull(readDouble(props, "attr_InitialLongitude"), readDouble(props, "irwin_InitialLongitude"));
         Double lat = selectFirstNotNull(readDouble(props, "attr_InitialLatitude"), readDouble(props, "irwin_InitialLatitude"));
         observation.setPoint(makeWktPoint(lon, lat));
+        observation.setRegion(locationService.getLocation(lon, lat));
 
         double areaSqKm2 = convertAcresToSqKm(readDouble(props, "poly_GISAcres"));
         long durationHours = between(observation.getStartedAt(), observation.getEndedAt()).toHours();

--- a/src/main/java/io/kontur/eventapi/service/LocationService.java
+++ b/src/main/java/io/kontur/eventapi/service/LocationService.java
@@ -1,0 +1,68 @@
+package io.kontur.eventapi.service;
+
+import io.kontur.eventapi.client.KonturApiClient;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Coordinate;
+import org.springframework.stereotype.Service;
+import org.wololo.geojson.Feature;
+import org.wololo.geojson.FeatureCollection;
+import org.wololo.jts2geojson.GeoJSONWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+public class LocationService {
+    private static final Logger LOG = LoggerFactory.getLogger(LocationService.class);
+
+    private final KonturApiClient konturApiClient;
+    private final GeoJSONWriter geoJSONWriter = new GeoJSONWriter();
+    private final GeometryFactory geometryFactory = new GeometryFactory();
+
+    public LocationService(KonturApiClient konturApiClient) {
+        this.konturApiClient = konturApiClient;
+    }
+
+    public String getLocation(Double lon, Double lat) {
+        if (lon == null || lat == null) {
+            return null;
+        }
+        Point point = geometryFactory.createPoint(new Coordinate(lon, lat));
+        Map<String, Object> params = new HashMap<>();
+        params.put("geometry", geoJSONWriter.write(point));
+        params.put("limit", 10);
+
+        FeatureCollection adminBoundaries = null;
+        try {
+            adminBoundaries = konturApiClient.adminBoundaries(params);
+        } catch (Exception e) {
+            LOG.warn("Failed to call admin boundaries service: {}", e.getMessage());
+        }
+        if (adminBoundaries == null || adminBoundaries.getFeatures() == null) {
+            return null;
+        }
+        return Stream.of(adminBoundaries.getFeatures())
+                .map(Feature::getProperties)
+                .filter(p -> NumberUtils.isCreatable(String.valueOf(p.get("admin_level"))))
+                .sorted(Comparator.comparing(p -> Double.parseDouble(String.valueOf(p.get("admin_level")))))
+                .limit(3)
+                .map(p -> (Map<String, String>) p.get("tags"))
+                .map(tags -> {
+                    if (tags.containsKey("name:en")) {
+                        return tags.get("name:en");
+                    } else if (tags.containsKey("int_name")) {
+                        return tags.get("int_name");
+                    } else {
+                        return tags.get("name");
+                    }
+                })
+                .collect(Collectors.joining(", "));
+    }
+}

--- a/src/test/java/io/kontur/eventapi/calfire/normalization/CalFireNormalizationTest.java
+++ b/src/test/java/io/kontur/eventapi/calfire/normalization/CalFireNormalizationTest.java
@@ -5,9 +5,11 @@ import io.kontur.eventapi.entity.DataLake;
 import io.kontur.eventapi.entity.EventType;
 import io.kontur.eventapi.entity.NormalizedObservation;
 import io.kontur.eventapi.entity.Severity;
+import io.kontur.eventapi.service.LocationService;
 import io.kontur.eventapi.util.DateTimeUtil;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.mock;
 import org.wololo.geojson.Feature;
 import org.wololo.geojson.FeatureCollection;
 import org.wololo.geojson.GeoJSONFactory;
@@ -24,7 +26,8 @@ class CalFireNormalizationTest {
     @Test
     public void testIsApplicable() throws Exception {
         DataLake dataLake = createDataLake();
-        assertTrue(new CalFireNormalizer().isApplicable(dataLake));
+        CalFireNormalizer normalizer = new CalFireNormalizer(mock(LocationService.class));
+        assertTrue(normalizer.isApplicable(dataLake));
     }
 
     @Test
@@ -33,7 +36,7 @@ class CalFireNormalizationTest {
         DataLake dataLake = createDataLake();
 
         //when
-        NormalizedObservation observation = new CalFireNormalizer().normalize(dataLake);
+        NormalizedObservation observation = new CalFireNormalizer(mock(LocationService.class)).normalize(dataLake);
 
         //then
         assertEquals(dataLake.getObservationId(), observation.getObservationId());

--- a/src/test/java/io/kontur/eventapi/nifc/normalization/LocationsNifcNormalizerTest.java
+++ b/src/test/java/io/kontur/eventapi/nifc/normalization/LocationsNifcNormalizerTest.java
@@ -4,9 +4,11 @@ import io.kontur.eventapi.entity.DataLake;
 import io.kontur.eventapi.entity.EventType;
 import io.kontur.eventapi.entity.NormalizedObservation;
 import io.kontur.eventapi.entity.Severity;
+import io.kontur.eventapi.service.LocationService;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.time.OffsetDateTime;
@@ -20,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class LocationsNifcNormalizerTest {
 
-    private final LocationsNifcNormalizer normalizer = new LocationsNifcNormalizer();
+    private final LocationsNifcNormalizer normalizer = new LocationsNifcNormalizer(mock(LocationService.class));
 
     @Test
     void testNormalize() throws IOException {
@@ -44,7 +46,7 @@ class LocationsNifcNormalizerTest {
         assertNull(observation.getEpisodeDescription());
         assertNull(observation.getActive());
         assertNull(observation.getCost());
-        assertNull(observation.getRegion());
+        assertNotNull(observation.getRegion());
         assertTrue(observation.getUrls().isEmpty());
         assertNull(observation.getExternalEpisodeId());
 

--- a/src/test/java/io/kontur/eventapi/nifc/normalization/PerimetersNifcNormalizerTest.java
+++ b/src/test/java/io/kontur/eventapi/nifc/normalization/PerimetersNifcNormalizerTest.java
@@ -4,9 +4,11 @@ import io.kontur.eventapi.entity.DataLake;
 import io.kontur.eventapi.entity.EventType;
 import io.kontur.eventapi.entity.NormalizedObservation;
 import io.kontur.eventapi.entity.Severity;
+import io.kontur.eventapi.service.LocationService;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.time.OffsetDateTime;
@@ -20,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class PerimetersNifcNormalizerTest {
 
-    private final PerimetersNifcNormalizer normalizer = new PerimetersNifcNormalizer();
+    private final PerimetersNifcNormalizer normalizer = new PerimetersNifcNormalizer(mock(LocationService.class));
 
     @Test
     void testNormalize() throws IOException {
@@ -44,7 +46,7 @@ class PerimetersNifcNormalizerTest {
         assertNull(observation.getEpisodeDescription());
         assertNull(observation.getActive());
         assertNull(observation.getCost());
-        assertNull(observation.getRegion());
+        assertNotNull(observation.getRegion());
         assertTrue(observation.getUrls().isEmpty());
         assertNull(observation.getExternalEpisodeId());
 


### PR DESCRIPTION
## Summary
- add `LocationService` to fetch admin boundary names
- fall back to geocoder for CalFire/NIFC observations
- adjust tests for new service usage

## Testing
- `mvn -q test` *(fails: Could not transfer artifact due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6851b60ba6e8832483f2f8be1f71b979

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic region detection for observations based on geographic coordinates when region information is missing.
  - Introduced a new service that fetches and formats administrative boundary data for improved location accuracy.

- **Bug Fixes**
  - Enhanced normalization process to ensure region fields are populated when possible.

- **Tests**
  - Updated tests to validate the new region detection logic and ensure observations now include region information when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->