### PR TITLE
feat(api): add text search endpoint

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -39,3 +39,12 @@ Return a single event by feed alias, event ID and optional version. When the ver
 
 ## `GET /v1/user_feeds`
 Return the list of feeds available for the authenticated user. The list is built from the roles present in the JWT token.
+
+## `GET /v1/search`
+Search events by text across all feeds.
+
+**Parameters**
+- `query` – substring to search in `name`, `proper_name` and `description` fields.
+- `limit` – maximum number of returned records (default `20`).
+
+Returns a list of matching events sorted by latest update time.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -85,7 +85,7 @@ Stores event versions for each feed. Table was redesigned in version 1.15.
 | `location` | `text` |
 | `collected_geometry` | `geometry` generated from episodes |
 
-Unique key: (`event_id`, `version`, `feed_id`). Several GIST and BTREE indexes exist for geometry and timestamps.
+Unique key: (`event_id`, `version`, `feed_id`). Several GIST and BTREE indexes exist for geometry and timestamps. Trigram indexes on `name`, `proper_name` and `description` speed up text searches.
 
 ## `severities`
 Reference table of possible severity levels.

--- a/src/main/java/io/kontur/eventapi/dao/ApiDao.java
+++ b/src/main/java/io/kontur/eventapi/dao/ApiDao.java
@@ -62,7 +62,11 @@ public class ApiDao {
 				null, null, null, null, episodeFilterType);
 	}
 
-	public Optional<String> getEventByEventIdAndByVersionOrLast(UUID eventId, String feed, Long version, EpisodeFilterType episodeFilterType) {
-		return mapper.getEventByEventIdAndByVersionOrLast(eventId, feed, version, episodeFilterType);
-	}
+        public Optional<String> getEventByEventIdAndByVersionOrLast(UUID eventId, String feed, Long version, EpisodeFilterType episodeFilterType) {
+                return mapper.getEventByEventIdAndByVersionOrLast(eventId, feed, version, episodeFilterType);
+        }
+
+        public String searchEventsByText(String query, Integer limit) {
+                return mapper.searchEventsByText(query, limit);
+        }
 }

--- a/src/main/java/io/kontur/eventapi/dao/mapper/ApiMapper.java
+++ b/src/main/java/io/kontur/eventapi/dao/mapper/ApiMapper.java
@@ -47,8 +47,10 @@ public interface ApiMapper {
 	                              @Param("yMax") BigDecimal yMax,
 	                              @Param("episodeFilterType") EpisodeFilterType episodeFilterType);
 
-	Optional<String> getEventByEventIdAndByVersionOrLast(@Param("eventId") UUID eventId,
-	                                                     @Param("feedAlias") String feedAlias,
-	                                                     @Param("version") Long version,
-	                                                     @Param("episodeFilterType") EpisodeFilterType episodeFilterType);
+        Optional<String> getEventByEventIdAndByVersionOrLast(@Param("eventId") UUID eventId,
+                                                             @Param("feedAlias") String feedAlias,
+                                                             @Param("version") Long version,
+                                                             @Param("episodeFilterType") EpisodeFilterType episodeFilterType);
+
+        String searchEventsByText(@Param("query") String query, @Param("limit") Integer limit);
 }

--- a/src/main/java/io/kontur/eventapi/resource/EventResource.java
+++ b/src/main/java/io/kontur/eventapi/resource/EventResource.java
@@ -209,6 +209,24 @@ public class EventResource {
         return ResponseEntity.ok(geoJsonOpt.get());
     }
 
+    @GetMapping(path = "/search", produces = {APPLICATION_JSON_VALUE})
+    @Operation(
+            tags = "Events",
+            summary = "Search events by text",
+            description = "Full text search across all feeds in name, proper name and description fields."
+    )
+    public ResponseEntity<String> searchEventsByText(
+            @Parameter(description = "Search query")
+            @RequestParam("query")
+            String query,
+            @Parameter(description = "Maximum number of results", example = "20")
+            @RequestParam(value = "limit", required = false)
+            Integer limit
+    ) {
+        Optional<String> result = eventResourceService.searchEventsByText(query, limit);
+        return result.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.noContent().build());
+    }
+
     @GetMapping(path = "/observations/{observationId}", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
     @Operation(
             tags = "Raw Data",

--- a/src/main/java/io/kontur/eventapi/service/EventResourceService.java
+++ b/src/main/java/io/kontur/eventapi/service/EventResourceService.java
@@ -63,4 +63,9 @@ public class EventResourceService {
                 updatedAfter, limit, severities, sortOrder, bbox, episodeFilterType);
         return geoJson == null ? Optional.empty() : Optional.of(geoJson);
     }
+
+    public Optional<String> searchEventsByText(String query, Integer limit) {
+        String data = apiDao.searchEventsByText(query, limit);
+        return data == null ? Optional.empty() : Optional.of(data);
+    }
 }

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -70,3 +70,6 @@ databaseChangeLog:
 - include:
     relativeToChangelogFile: true
     file: v1.21.0/v1.21.0.yaml
+- include:
+    relativeToChangelogFile: true
+    file: v1.22.0/v1.22.0.yaml

--- a/src/main/resources/db/changelog/v1.22.0/add-trgm-indexes.sql
+++ b/src/main/resources/db/changelog/v1.22.0/add-trgm-indexes.sql
@@ -1,0 +1,14 @@
+--liquibase formatted sql
+
+--changeset event-api-migrations:v1.22.0/add-trgm-indexes.sql runOnChange:false
+
+create extension if not exists pg_trgm;
+
+create index if not exists feed_data_name_trgm_idx
+    on feed_data using gist (name gist_trgm_ops);
+
+create index if not exists feed_data_proper_name_trgm_idx
+    on feed_data using gist (proper_name gist_trgm_ops);
+
+create index if not exists feed_data_description_trgm_idx
+    on feed_data using gist (description gist_trgm_ops);

--- a/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
+++ b/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
@@ -1,0 +1,5 @@
+## Database Changelog
+databaseChangeLog:
+  - include:
+      relativeToChangelogFile: true
+      file: add-trgm-indexes.sql

--- a/src/main/resources/db/mappers/ApiMapper.xml
+++ b/src/main/resources/db/mappers/ApiMapper.xml
@@ -252,4 +252,55 @@
         <result property="description" column="description"/>
     </resultMap>
 
+    <select id="searchEventsByText" resultType="java.lang.String">
+        with events as (
+            select
+                fd.event_id, f.alias as feed_alias, fd.version, fd.name, fd.proper_name, fd.description,
+                fd.type, sv.severity, fd.active,
+                fd.started_at, fd.ended_at, fd.updated_at, fd.location, fd.urls, fd.loss,
+                fd.severity_data, fd.event_details, fd.observations, fd.geometries,
+                jsonb_array_length(fd.episodes) as episode_count,
+                fd.episodes,
+                box2d(fd.collected_geometry) as bbox,
+                st_pointonsurface(fd.collected_geometry) as centroid
+            from feed_data fd
+            join feeds f on fd.feed_id = f.feed_id
+            left join severities sv on fd.severity_id = sv.severity_id
+            where fd.is_latest_version and fd.enriched
+                and (
+                    fd.name ilike '%' || #{query} || '%'
+                    or fd.proper_name ilike '%' || #{query} || '%'
+                    or fd.description ilike '%' || #{query} || '%'
+                )
+            order by fd.updated_at desc
+            limit coalesce(#{limit}, 20)
+        )
+        select case when count(*) > 0 then json_agg(json_build_object(
+                'eventId', event_id,
+                'feed', feed_alias,
+                'version', version,
+                'name', name,
+                'properName', proper_name,
+                'description', description,
+                'type', type,
+                'severity', severity,
+                'active', active,
+                'startedAt', started_at,
+                'endedAt', ended_at,
+                'updatedAt', updated_at,
+                'location', location,
+                'urls', urls,
+                'loss', loss,
+                'severityData', severity_data,
+                'eventDetails', event_details,
+                'observations', observations,
+                'geometries', geometries,
+                'episodes', episodes,
+                'episodeCount', episode_count,
+                'bbox', array[st_xmin(bbox), st_ymin(bbox), st_xmax(bbox), st_ymax(bbox)],
+                'centroid', array[st_x(centroid), st_y(centroid)]
+            )) end
+        from events
+    </select>
+
 </mapper>

--- a/src/test/java/io/kontur/eventapi/resource/EventResourceTest.java
+++ b/src/test/java/io/kontur/eventapi/resource/EventResourceTest.java
@@ -116,4 +116,25 @@ public class EventResourceTest {
         second.setDescription(SECOND_DESCRIPTION);
         return List.of(first, second);
     }
+
+    @Test
+    public void searchEventsByTextNoContentTest() {
+        EventResourceService mockService = mock(EventResourceService.class);
+        when(mockService.searchEventsByText("quake", null)).thenReturn(Optional.empty());
+        EventResource resource = new EventResource(mockService);
+
+        var response = resource.searchEventsByText("quake", null);
+        assertEquals(204, response.getStatusCodeValue());
+    }
+
+    @Test
+    public void searchEventsByTextOkTest() {
+        EventResourceService mockService = mock(EventResourceService.class);
+        when(mockService.searchEventsByText("quake", 5)).thenReturn(Optional.of("[]"));
+        EventResource resource = new EventResource(mockService);
+
+        var response = resource.searchEventsByText("quake", 5);
+        assertEquals(200, response.getStatusCodeValue());
+        assertEquals("[]", response.getBody());
+    }
 }


### PR DESCRIPTION
## Summary
- implement `/v1/search` endpoint for full text search across all feeds
- add database indexes for pg_trgm search
- document new endpoint and indexes
- cover controller logic with tests

## Testing
- `mvn test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent from https://nexus.kontur.io)*

------
https://chatgpt.com/codex/tasks/task_e_6851b5dafa408324be618b41ce9193cc