### PR TITLE
feat(service): 20037 add configurable feed whitelist

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -38,4 +38,6 @@ Return a single event by feed alias, event ID and optional version. When the ver
 - `episodeFilterType` – `ANY`, `LATEST` or `NONE`.
 
 ## `GET /v1/user_feeds`
-Return the list of feeds available for the authenticated user. The list is built from the roles present in the JWT token.
+Return the list of feeds available for the authenticated user. The list is built
+from the roles present in the JWT token and limited by the `app.enabledFeeds`
+configuration option.

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,9 @@ spring:
   profiles:
     active: awsSqsDisabled, jwtAuthDisabled, cacheDisabled
 
+app:
+  enabledFeeds: kontur-public, kontur-private, pdc, wildfires, micglobal
+
 konturApi:
   host: 'https://test-api02.konturlabs.com/'
 

--- a/src/test/java/io/kontur/eventapi/resource/EventResourceTest.java
+++ b/src/test/java/io/kontur/eventapi/resource/EventResourceTest.java
@@ -12,6 +12,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Collection;
 import java.util.List;
@@ -41,6 +42,7 @@ public class EventResourceTest {
     @BeforeEach
     public void before() {
         eventResource = new EventResource(eventResourceService);
+        ReflectionTestUtils.setField(eventResourceService, "enabledFeeds", new String[]{FIRST_ALIAS, SECOND_ALIAS});
     }
 
     @Test


### PR DESCRIPTION
## Summary
- filter feeds via `app.enabledFeeds`
- document feed filtering on `/v1/user_feeds`
- test feed filtering logic

[Task URL](https://kontur.fibery.io/Tasks/Task/20037)

------
https://chatgpt.com/codex/tasks/task_e_6851b615dd7c8324aad46fde1416b1a0