### PR TITLE
feat(wildfire): skip duplicate episodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Added
 
 #### Changed
+ - CalFire and NIFC episode combinators skip episodes if nothing significant changed
 
 #### Removed
 

--- a/docs/wildfire_providers.md
+++ b/docs/wildfire_providers.md
@@ -1,0 +1,6 @@
+# Wildfire providers specifics
+
+Episodes from CalFire and NIFC feeds may arrive frequently with minor updates.
+To reduce noise the episode combinators for these providers create a new episode
+only when something important changes. Two consecutive observations form one
+episode if their name, severity, location and geometry remain the same.

--- a/src/main/java/io/kontur/eventapi/calfire/episodecomposition/CalFireEpisodeCombinator.java
+++ b/src/main/java/io/kontur/eventapi/calfire/episodecomposition/CalFireEpisodeCombinator.java
@@ -6,9 +6,13 @@ import io.kontur.eventapi.entity.NormalizedObservation;
 import io.kontur.eventapi.episodecomposition.WildfireEpisodeCombinator;
 import org.springframework.stereotype.Component;
 
-import java.util.*;
+import java.util.List;
+import java.util.Set;
 
 import static io.kontur.eventapi.calfire.converter.CalFireDataLakeConverter.CALFIRE_PROVIDER;
+import static io.kontur.eventapi.util.GeometryUtil.isEqualGeometries;
+import static java.util.Collections.emptyList;
+import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 
 @Component
 public class CalFireEpisodeCombinator extends WildfireEpisodeCombinator {
@@ -20,6 +24,18 @@ public class CalFireEpisodeCombinator extends WildfireEpisodeCombinator {
 
     @Override
     public List<FeedEpisode> processObservation(NormalizedObservation observation, FeedData feedData, Set<NormalizedObservation> eventObservations) {
-        return List.of(createDefaultEpisode(observation));
+        FeedEpisode episode = createDefaultEpisode(observation);
+        List<FeedEpisode> existing = feedData.getEpisodes();
+        if (!existing.isEmpty() && sameEpisode(existing.get(existing.size() - 1), episode)) {
+            return emptyList();
+        }
+        return List.of(episode);
+    }
+
+    private boolean sameEpisode(FeedEpisode ep1, FeedEpisode ep2) {
+        return equalsIgnoreCase(ep1.getName(), ep2.getName())
+                && ep1.getSeverity() == ep2.getSeverity()
+                && equalsIgnoreCase(ep1.getLocation(), ep2.getLocation())
+                && isEqualGeometries(ep1.getGeometries(), ep2.getGeometries());
     }
 }

--- a/src/main/java/io/kontur/eventapi/nifc/episodecomposition/NifcEpisodeCombinator.java
+++ b/src/main/java/io/kontur/eventapi/nifc/episodecomposition/NifcEpisodeCombinator.java
@@ -14,7 +14,9 @@ import java.util.Set;
 
 import static io.kontur.eventapi.nifc.converter.NifcDataLakeConverter.NIFC_LOCATIONS_PROVIDER;
 import static io.kontur.eventapi.nifc.converter.NifcDataLakeConverter.NIFC_PERIMETERS_PROVIDER;
+import static io.kontur.eventapi.util.GeometryUtil.isEqualGeometries;
 import static java.util.Collections.emptyList;
+import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 
 @Component
 public class NifcEpisodeCombinator extends WildfireEpisodeCombinator {
@@ -37,6 +39,10 @@ public class NifcEpisodeCombinator extends WildfireEpisodeCombinator {
         episode.setObservations(mapObservationsToIDs(episodeObservations));
         episode.setGeometries(computeEpisodeGeometries(episodeObservations));
         episode.setDescription(latestObservation.getDescription());
+        List<FeedEpisode> existing = feedData.getEpisodes();
+        if (!existing.isEmpty() && sameEpisode(existing.get(existing.size() - 1), episode)) {
+            return emptyList();
+        }
         return List.of(episode);
     }
 
@@ -47,6 +53,13 @@ public class NifcEpisodeCombinator extends WildfireEpisodeCombinator {
                 .distinct()
                 .toArray(Feature[]::new);
         return new FeatureCollection(features);
+    }
+
+    private boolean sameEpisode(FeedEpisode ep1, FeedEpisode ep2) {
+        return equalsIgnoreCase(ep1.getName(), ep2.getName())
+                && ep1.getSeverity() == ep2.getSeverity()
+                && equalsIgnoreCase(ep1.getLocation(), ep2.getLocation())
+                && isEqualGeometries(ep1.getGeometries(), ep2.getGeometries());
     }
 
 }

--- a/src/test/java/io/kontur/eventapi/calfire/episodecomposition/CalFireEpisodeCombinatorTest.java
+++ b/src/test/java/io/kontur/eventapi/calfire/episodecomposition/CalFireEpisodeCombinatorTest.java
@@ -1,0 +1,64 @@
+package io.kontur.eventapi.calfire.episodecomposition;
+
+import io.kontur.eventapi.entity.FeedData;
+import io.kontur.eventapi.entity.FeedEpisode;
+import io.kontur.eventapi.entity.NormalizedObservation;
+import io.kontur.eventapi.entity.Severity;
+import org.junit.jupiter.api.Test;
+import org.wololo.geojson.Feature;
+import org.wololo.geojson.FeatureCollection;
+import org.wololo.geojson.Point;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static io.kontur.eventapi.calfire.converter.CalFireDataLakeConverter.CALFIRE_PROVIDER;
+import static org.junit.jupiter.api.Assertions.*;
+
+class CalFireEpisodeCombinatorTest {
+
+    private final CalFireEpisodeCombinator combinator = new CalFireEpisodeCombinator();
+
+    @Test
+    void testProcessObservationSkipsDuplicate() {
+        NormalizedObservation obs1 = createObservation("Fire1");
+        NormalizedObservation obs2 = createObservation("Fire1");
+        FeedData feedData = new FeedData(UUID.randomUUID(), UUID.randomUUID(), 1L);
+
+        List<FeedEpisode> first = combinator.processObservation(obs1, feedData, Set.of(obs1));
+        feedData.addEpisode(first.get(0));
+
+        List<FeedEpisode> second = combinator.processObservation(obs2, feedData, Set.of(obs1, obs2));
+
+        assertEquals(1, first.size());
+        assertTrue(second.isEmpty());
+    }
+
+    @Test
+    void testProcessObservationCreatesNewEpisodeWhenDifferent() {
+        NormalizedObservation obs1 = createObservation("Fire1");
+        NormalizedObservation obs2 = createObservation("Fire2");
+        FeedData feedData = new FeedData(UUID.randomUUID(), UUID.randomUUID(), 1L);
+
+        feedData.addEpisode(combinator.processObservation(obs1, feedData, Set.of(obs1)).get(0));
+
+        List<FeedEpisode> episodes = combinator.processObservation(obs2, feedData, Set.of(obs1, obs2));
+
+        assertFalse(episodes.isEmpty());
+    }
+
+    private NormalizedObservation createObservation(String name) {
+        NormalizedObservation observation = new NormalizedObservation();
+        observation.setObservationId(UUID.randomUUID());
+        observation.setProvider(CALFIRE_PROVIDER);
+        observation.setName(name);
+        observation.setEventSeverity(Severity.MINOR);
+        observation.setSourceUpdatedAt(OffsetDateTime.now());
+        observation.setLoadedAt(OffsetDateTime.now());
+        Feature feature = new Feature(new Point(new double[]{0, 0}), java.util.Collections.emptyMap());
+        observation.setGeometries(new FeatureCollection(new Feature[]{feature}));
+        return observation;
+    }
+}

--- a/src/test/java/io/kontur/eventapi/nifc/episodecomposition/NifcEpisodeCombinatorTest.java
+++ b/src/test/java/io/kontur/eventapi/nifc/episodecomposition/NifcEpisodeCombinatorTest.java
@@ -1,0 +1,65 @@
+package io.kontur.eventapi.nifc.episodecomposition;
+
+import io.kontur.eventapi.entity.FeedData;
+import io.kontur.eventapi.entity.FeedEpisode;
+import io.kontur.eventapi.entity.NormalizedObservation;
+import io.kontur.eventapi.entity.Severity;
+import org.junit.jupiter.api.Test;
+import org.wololo.geojson.Feature;
+import org.wololo.geojson.FeatureCollection;
+import org.wololo.geojson.Point;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static io.kontur.eventapi.nifc.converter.NifcDataLakeConverter.NIFC_LOCATIONS_PROVIDER;
+import static org.junit.jupiter.api.Assertions.*;
+
+class NifcEpisodeCombinatorTest {
+
+    private final NifcEpisodeCombinator combinator = new NifcEpisodeCombinator();
+
+    @Test
+    void testProcessObservationSkipsDuplicate() {
+        NormalizedObservation obs1 = createObservation("Fire1");
+        NormalizedObservation obs2 = createObservation("Fire1");
+        FeedData feedData = new FeedData(UUID.randomUUID(), UUID.randomUUID(), 1L);
+
+        List<FeedEpisode> first = combinator.processObservation(obs1, feedData, Set.of(obs1));
+        feedData.addEpisode(first.get(0));
+
+        List<FeedEpisode> second = combinator.processObservation(obs2, feedData, Set.of(obs1, obs2));
+
+        assertEquals(1, first.size());
+        assertTrue(second.isEmpty());
+    }
+
+    @Test
+    void testProcessObservationCreatesNewEpisodeWhenDifferent() {
+        NormalizedObservation obs1 = createObservation("Fire1");
+        NormalizedObservation obs2 = createObservation("Fire2");
+        FeedData feedData = new FeedData(UUID.randomUUID(), UUID.randomUUID(), 1L);
+
+        feedData.addEpisode(combinator.processObservation(obs1, feedData, Set.of(obs1)).get(0));
+
+        List<FeedEpisode> episodes = combinator.processObservation(obs2, feedData, Set.of(obs1, obs2));
+
+        assertFalse(episodes.isEmpty());
+    }
+
+    private NormalizedObservation createObservation(String name) {
+        NormalizedObservation observation = new NormalizedObservation();
+        observation.setObservationId(UUID.randomUUID());
+        observation.setProvider(NIFC_LOCATIONS_PROVIDER);
+        observation.setName(name);
+        observation.setEventSeverity(Severity.MINOR);
+        OffsetDateTime now = OffsetDateTime.now();
+        observation.setSourceUpdatedAt(now);
+        observation.setLoadedAt(now);
+        Feature feature = new Feature(new Point(new double[]{0, 0}), java.util.Collections.emptyMap());
+        observation.setGeometries(new FeatureCollection(new Feature[]{feature}));
+        return observation;
+    }
+}


### PR DESCRIPTION
## Summary
- avoid duplicate CalFire episodes
- avoid duplicate NIFC episodes
- document wildfire providers deduplication
- add tests for wildfire episode combinators
- note change in changelog

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851b5f0c7ec83249b108d89acfc1178