### PR TITLE
feat(logging): log incoming HTTP requests

### DIFF
--- a/docs/http_tracing.md
+++ b/docs/http_tracing.md
@@ -1,0 +1,8 @@
+# HTTP Request Logging
+
+The application records HTTP requests to aid debugging and monitoring. Logs are written using the `httptrace` logger to two points in the request lifecycle:
+
+1. **Request received** – emitted by `IncomingRequestLoggingFilter` as soon as the server accepts the request.
+2. **Request completed** – emitted when response processing finishes via `LogHttpTraceRepository`.
+
+Both logs contain the HTTP method, path, headers and client address. Completion logs additionally include response status and request duration in milliseconds. Slow requests over one second are logged with an extra `[slow_request]` marker.

--- a/src/main/java/io/kontur/eventapi/resource/logging/IncomingRequestLoggingFilter.java
+++ b/src/main/java/io/kontur/eventapi/resource/logging/IncomingRequestLoggingFilter.java
@@ -1,0 +1,47 @@
+package io.kontur.eventapi.resource.logging;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.lang.String.format;
+import static java.util.Collections.list;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class IncomingRequestLoggingFilter extends OncePerRequestFilter {
+
+    private static final Logger LOG = LoggerFactory.getLogger("httptrace");
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String message = format("[received] [%s] [%s] [HEADERS: %s] [ADDRESS: %s]",
+                request.getMethod(), request.getRequestURI(), headers(request), request.getRemoteAddr());
+        LOG.info(message);
+        filterChain.doFilter(request, response);
+    }
+
+    private Map<String, List<String>> headers(HttpServletRequest request) {
+        Map<String, List<String>> headers = new LinkedHashMap<>();
+        Enumeration<String> names = request.getHeaderNames();
+        while (names.hasMoreElements()) {
+            String name = names.nextElement();
+            headers.put(name, list(request.getHeaders(name)));
+        }
+        return headers;
+    }
+}

--- a/src/main/java/io/kontur/eventapi/resource/logging/TraceConfig.java
+++ b/src/main/java/io/kontur/eventapi/resource/logging/TraceConfig.java
@@ -17,4 +17,9 @@ public class TraceConfig {
     public LogHttpTraceRepository traceRepository() {
         return new LogHttpTraceRepository();
     }
+
+    @Bean
+    public IncomingRequestLoggingFilter incomingRequestLoggingFilter() {
+        return new IncomingRequestLoggingFilter();
+    }
 }


### PR DESCRIPTION
## Summary
- add filter logging incoming requests via httptrace
- wire filter via TraceConfig
- document HTTP request logging

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851cbe6d60c832482d90f67929774bc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced HTTP request logging, capturing detailed information when requests are received and after they are processed.
  - Requests taking longer than one second are now flagged as slow.
- **Documentation**
  - Added new documentation explaining the HTTP request logging mechanism and its logged details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->