### PR TITLE
fix(gdacs): improve feature severity details

### DIFF
--- a/src/main/java/io/kontur/eventapi/gdacs/converter/GdacsPropertiesConverter.java
+++ b/src/main/java/io/kontur/eventapi/gdacs/converter/GdacsPropertiesConverter.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 import static io.kontur.eventapi.util.GeometryUtil.*;
 import static io.kontur.eventapi.util.GeometryUtil.IS_OBSERVED_PROPERTY;
+import static io.kontur.eventapi.util.SeverityUtil.*;
 import static java.lang.Integer.parseInt;
 import static java.time.temporal.ChronoField.YEAR;
 import static java.time.temporal.ChronoUnit.HOURS;
@@ -59,9 +60,18 @@ public class GdacsPropertiesConverter {
     );
 
     private final Map<String, Map<String, Object>> severityDataMap = Map.ofEntries(
-            entry("Poly_Green", singletonMap(WIND_SPEED_KPH, 60)),
-            entry("Poly_Orange", singletonMap(WIND_SPEED_KPH, 90)),
-            entry("Poly_Red", singletonMap(WIND_SPEED_KPH, 120))
+            entry("Poly_Green", Map.of(
+                    WIND_SPEED_KPH, 60,
+                    CATEGORY_SAFFIR_SIMPSON, getCycloneCategory(60d)
+            )),
+            entry("Poly_Orange", Map.of(
+                    WIND_SPEED_KPH, 90,
+                    CATEGORY_SAFFIR_SIMPSON, getCycloneCategory(90d)
+            )),
+            entry("Poly_Red", Map.of(
+                    WIND_SPEED_KPH, 120,
+                    CATEGORY_SAFFIR_SIMPSON, getCycloneCategory(120d)
+            ))
     );
 
 

--- a/src/test/java/io/kontur/eventapi/gdacs/converter/GdacsPropertiesConverterTest.java
+++ b/src/test/java/io/kontur/eventapi/gdacs/converter/GdacsPropertiesConverterTest.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static io.kontur.eventapi.util.GeometryUtil.*;
+import static io.kontur.eventapi.util.SeverityUtil.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class GdacsPropertiesConverterTest {
@@ -149,21 +150,30 @@ public class GdacsPropertiesConverterTest {
         assertEquals(3, props.size());
         assertEquals(ALERT_AREA, props.get(AREA_TYPE_PROPERTY));
         assertEquals(false, props.get(IS_OBSERVED_PROPERTY));
-        assertEquals(Map.of(WIND_SPEED_KPH, 60), props.get(SEVERITY_DATA_PROPERTY));
+        assertEquals(Map.of(
+                WIND_SPEED_KPH, 60,
+                CATEGORY_SAFFIR_SIMPSON, CATEGORY_TD
+        ), props.get(SEVERITY_DATA_PROPERTY));
 
         props = converter.convertProperties("Poly_Orange", polygonDate, polygonLabel, false);
 
         assertEquals(3, props.size());
         assertEquals(ALERT_AREA, props.get(AREA_TYPE_PROPERTY));
         assertEquals(false, props.get(IS_OBSERVED_PROPERTY));
-        assertEquals(Map.of(WIND_SPEED_KPH, 90), props.get(SEVERITY_DATA_PROPERTY));
+        assertEquals(Map.of(
+                WIND_SPEED_KPH, 90,
+                CATEGORY_SAFFIR_SIMPSON, CATEGORY_TS
+        ), props.get(SEVERITY_DATA_PROPERTY));
 
         props = converter.convertProperties("Poly_Red", polygonDate, polygonLabel, false);
 
         assertEquals(3, props.size());
         assertEquals(ALERT_AREA, props.get(AREA_TYPE_PROPERTY));
         assertEquals(false, props.get(IS_OBSERVED_PROPERTY));
-        assertEquals(Map.of(WIND_SPEED_KPH, 120), props.get(SEVERITY_DATA_PROPERTY));
+        assertEquals(Map.of(
+                WIND_SPEED_KPH, 120,
+                CATEGORY_SAFFIR_SIMPSON, CATEGORY_1
+        ), props.get(SEVERITY_DATA_PROPERTY));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- include Saffir–Simpson category when mapping GDACS polygon severity
- update tests for new severityData format

## Testing
- `mvn -q test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_6851cc1260f48324b958193cb71e7636

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Severity data now includes both wind speed and Saffir-Simpson cyclone category for improved classification.

- **Tests**
  - Updated tests to verify the presence of cyclone category information alongside wind speed in severity data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->