### PR TITLE
feat(pdc): 3286 handle products from sqs

### DIFF
--- a/docs/pdc_products.md
+++ b/docs/pdc_products.md
@@ -1,0 +1,11 @@
+# PDC Products Handling
+
+The API receives `PRODUCT` messages from the PDC SQS queue. Each message is stored
+as JSON in an AWS S3 bucket configured by `pdcProduct.s3Bucket` and
+`pdcProduct.s3Folder`. The filename is based on the product UUID contained in the
+SQS payload.
+
+If a file with the same UUID already exists in the bucket it is not overwritten.
+This prevents duplicates when the same product arrives from both SQS and the
+HpSrv service.
+

--- a/docs/sketchy_issues.md
+++ b/docs/sketchy_issues.md
@@ -2,8 +2,6 @@
 
 During review a few areas looked unclear or potentially problematic. They may require further clarification:
 
-## `PdcSqsMessageListener`
-The listener contains a TODO comment to "skip products until it is clear how to handle them". It is not documented what kind of SQS messages are ignored and whether products will be supported in the future.
 
 ## Caching behaviour
 `EventResourceService` enables caching unless the `cacheDisabled` profile is active. There is no documentation describing cache invalidation rules or expected time to live.

--- a/src/main/java/io/kontur/eventapi/pdc/service/PdcProductS3Service.java
+++ b/src/main/java/io/kontur/eventapi/pdc/service/PdcProductS3Service.java
@@ -1,0 +1,40 @@
+package io.kontur.eventapi.pdc.service;
+
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Save PDC products to S3 bucket avoiding duplicates.
+ */
+@Component
+public class PdcProductS3Service {
+
+    @Value("${pdcProduct.s3Bucket}")
+    private String bucket;
+
+    @Value("${pdcProduct.s3Folder}")
+    private String folder;
+
+    private static final AmazonS3 s3 = AmazonS3ClientBuilder.standard().withRegion(Regions.EU_CENTRAL_1).build();
+
+    /**
+     * Store product JSON if it is not present yet.
+     */
+    public void saveProduct(String productId, String data) {
+        String key = folder + productId + ".json";
+        if (!s3.doesObjectExist(bucket, key)) {
+            byte[] bytes = data.getBytes(StandardCharsets.UTF_8);
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentLength(bytes.length);
+            s3.putObject(new PutObjectRequest(bucket, key, new ByteArrayInputStream(bytes), metadata));
+        }
+    }
+}

--- a/src/main/java/io/kontur/eventapi/pdc/service/PdcSqsService.java
+++ b/src/main/java/io/kontur/eventapi/pdc/service/PdcSqsService.java
@@ -3,18 +3,24 @@ package io.kontur.eventapi.pdc.service;
 import io.kontur.eventapi.dao.DataLakeDao;
 import io.kontur.eventapi.entity.DataLake;
 import io.kontur.eventapi.pdc.converter.PdcDataLakeConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
 public class PdcSqsService {
 
+    private final static Logger LOG = LoggerFactory.getLogger(PdcSqsService.class);
     private final DataLakeDao dataLakeDao;
     private final PdcDataLakeConverter pdcDataLakeConverter;
+    private final PdcProductS3Service productS3Service;
 
     public PdcSqsService(DataLakeDao dataLakeDao,
-                         PdcDataLakeConverter pdcDataLakeConverter) {
+                         PdcDataLakeConverter pdcDataLakeConverter,
+                         PdcProductS3Service productS3Service) {
         this.dataLakeDao = dataLakeDao;
         this.pdcDataLakeConverter = pdcDataLakeConverter;
+        this.productS3Service = productS3Service;
     }
 
     public  void saveMessage(String sqsMessage, String type, String messageId) {
@@ -22,6 +28,11 @@ public class PdcSqsService {
             DataLake dataLake = pdcDataLakeConverter.convertSQSMessage(sqsMessage, type, messageId);
             dataLakeDao.storeEventData(dataLake);
         }
+    }
+
+    public void saveProduct(String productId, String sqsMessage) {
+        LOG.debug("Storing product {}", productId);
+        productS3Service.saveProduct(productId, sqsMessage);
     }
 
 }

--- a/src/main/java/io/kontur/eventapi/pdc/sqs/PdcSqsMessageListener.java
+++ b/src/main/java/io/kontur/eventapi/pdc/sqs/PdcSqsMessageListener.java
@@ -29,10 +29,11 @@ public class PdcSqsMessageListener {
         JsonNode sns = JsonUtil.readTree(sqsMessage).get("Sns");
 
         String type = getProductType(sns);
-        // TODO: skip products until it is clear how to handle them
         if ("PING".equals(type)) {
             return;
         } else if ("PRODUCT".equals(type)) {
+            String productId = getProductUuid(sns);
+            sqsService.saveProduct(productId, sqsMessage);
             return;
         }
 
@@ -50,6 +51,13 @@ public class PdcSqsMessageListener {
 
     private String getMessageId(JsonNode sns) {
         return sns.get("MessageId").asText();
+    }
+
+    private String getProductUuid(JsonNode sns) {
+        JsonNode message = JsonUtil.readTree(sns.get("Message").asText());
+        JsonNode event = JsonUtil.readTree(message.get("event").asText());
+        JsonNode masterSyncEvents = event.get("syncDa").get("masterSyncEvents");
+        return masterSyncEvents.get("uuid").asText();
     }
 
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -19,6 +19,9 @@ pdc:
 humanitarianCrisis:
   s3Folder: 'kontur_events/TEST DEV/'
 
+pdcProduct:
+  s3Folder: 'products/TEST DEV/'
+
 staticdata:
   s3Folder: 'TEST DEV/'
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -22,6 +22,9 @@ staticdata:
 humanitarianCrisis:
   s3Folder: 'kontur_events/PROD/'
 
+pdcProduct:
+  s3Folder: 'products/PROD/'
+
 aws:
   sqs:
     enabled: true

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -22,6 +22,9 @@ staticdata:
 humanitarianCrisis:
   s3Folder: 'kontur_events/TEST QA/'
 
+pdcProduct:
+  s3Folder: 'products/TEST QA/'
+
 aws:
   sqs:
     enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -76,6 +76,10 @@ humanitarianCrisis:
   s3Bucket: 'event-api-locker01'
   s3Folder: 'kontur_events/EXP/'
 
+pdcProduct:
+  s3Bucket: 'event-api-locker01'
+  s3Folder: 'products/EXP/'
+
 tornadoJapanMa:
   host: 'https://www.data.jma.go.jp/obd/stats/data/bosai/tornado/'
 

--- a/src/test/java/io/kontur/eventapi/pdc/sqs/PdcSqsMessageListenerTest.java
+++ b/src/test/java/io/kontur/eventapi/pdc/sqs/PdcSqsMessageListenerTest.java
@@ -70,7 +70,7 @@ class PdcSqsMessageListenerTest {
         String json = readMessageFromFile("testproduct01.json");
         messageListener.read(json);
 
-        verify(sqsService, never()).saveMessage(anyString(), anyString(), anyString());
+        verify(sqsService, times(1)).saveProduct("12776eb9-2585-4d93-9001-944cc7d9d022", json);
     }
 
     private String readMessageFromFile(String fileName) throws IOException {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -29,6 +29,10 @@ humanitarianCrisis:
   s3Bucket: 'event-api-locker01'
   s3Folder: 'kontur_events/EXP/'
 
+pdcProduct:
+  s3Bucket: 'event-api-locker01'
+  s3Folder: 'products/EXP/'
+
 tornadoJapanMa:
   host: 'https://www.data.jma.go.jp/obd/stats/data/bosai/tornado/'
 


### PR DESCRIPTION
## Summary
- support PRODUCT messages in `PdcSqsMessageListener`
- upload product JSONs to S3 via new `PdcProductS3Service`
- expose configuration keys `pdcProduct.s3Bucket` and `pdcProduct.s3Folder`
- update listener tests
- document product processing

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*
- `mvn -DskipTests compile` *(fails: Non-resolvable parent POM)*

Task: https://kontur.fibery.io/Tasks/Task/3286

------
https://chatgpt.com/codex/tasks/task_e_6851cc1d337c8324a724ccaabfc391ff