### PR TITLE
feat(config): 7058 set user agent

### DIFF
--- a/docs/user-agent.md
+++ b/docs/user-agent.md
@@ -1,0 +1,3 @@
+# User-Agent Header
+
+All HTTP requests sent to external services include a `User-Agent` header. The value comes from the `userAgent` property in the application configuration. Each environment sets its own identifier (for example `Event API DEV` or `Event API PROD`).

--- a/src/main/java/io/kontur/eventapi/config/UserAgentFeignConfig.java
+++ b/src/main/java/io/kontur/eventapi/config/UserAgentFeignConfig.java
@@ -1,0 +1,18 @@
+package io.kontur.eventapi.config;
+
+import feign.RequestInterceptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class UserAgentFeignConfig {
+
+    @Value("${userAgent:Event API}")
+    private String userAgent;
+
+    @Bean
+    public RequestInterceptor userAgentInterceptor() {
+        return template -> template.header("User-Agent", userAgent);
+    }
+}

--- a/src/main/java/io/kontur/eventapi/stormsnoaa/service/StormsNoaaImportService.java
+++ b/src/main/java/io/kontur/eventapi/stormsnoaa/service/StormsNoaaImportService.java
@@ -13,12 +13,16 @@ public class StormsNoaaImportService {
     @Value("${stormsNoaa.host}")
     private String URL;
 
+    @Value("${userAgent:Event API}")
+    private String userAgent;
+
     private static final String tmpDir = System.getProperty("java.io.tmpdir");
     private static final String separator = System.getProperty("file.separator");
 
     public void downloadFile(String filename, String tmpFilePath) throws Exception {
         File file = new File(tmpFilePath);
         URLConnection conn = new URI(URL + filename).toURL().openConnection();
+        conn.setRequestProperty("User-Agent", userAgent);
         transferData(conn, file);
     }
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -26,11 +26,13 @@ aws:
   sqs:
     enabled: true
 
+userAgent: Event API DEV
+
 feign:
   client:
     config:
       default:
         defaultRequestHeaders:
-          User-Agent: Event API DEV
+          User-Agent: ${userAgent}
       auth:
         logger-level: HEADERS

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -26,9 +26,11 @@ aws:
   sqs:
     enabled: true
 
+userAgent: Event API PROD
+
 feign:
   client:
     config:
       default:
         defaultRequestHeaders:
-          User-Agent: Event API PROD
+          User-Agent: ${userAgent}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -26,9 +26,11 @@ aws:
   sqs:
     enabled: true
 
+userAgent: Event API TEST
+
 feign:
   client:
     config:
       default:
         defaultRequestHeaders:
-          User-Agent: Event API TEST
+          User-Agent: ${userAgent}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -210,6 +210,8 @@ scheduler:
     initialDelay: 1000
     fixedDelay: PT3H
 
+userAgent: Event API
+
 
 feign:
   client:
@@ -218,6 +220,8 @@ feign:
         connectTimeout: 60000
         readTimeout: 60000
         loggerLevel: headers
+        defaultRequestHeaders:
+          User-Agent: ${userAgent}  
       longKonturAppsClient:
         connectTimeout: 600000
         readTimeout: 600000


### PR DESCRIPTION
## Summary
- add global interceptor to set `User-Agent`
- allow StormsNoaa downloads to send the same header
- specify `userAgent` property for each environment
- document the header configuration

## Testing
- `mvn -q test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_6851cc8fcdf483248799f20ccd508c88