### PR TITLE
feat(enrichment): 7322 update insights api integration

### DIFF
--- a/docs/insights.md
+++ b/docs/insights.md
@@ -1,0 +1,15 @@
+# Insights API Integration
+
+Event API obtains analytics data from Insights API using a GraphQL query. The request body now follows the standard GraphQL structure:
+
+```json
+{
+  "query": "query ($polygon: String!) { polygonStatistic(polygonStatisticRequest: { polygon: $polygon }) { analytics { ... } } }",
+  "variables": {
+    "polygon": "<GeoJSON geometry>"
+  }
+}
+```
+
+Requests are sent to `/insights/graphql` endpoint of the Kontur Apps service.
+

--- a/pom.xml
+++ b/pom.xml
@@ -202,11 +202,16 @@
 			<artifactId>jaxb-runtime</artifactId>
 			<version>3.0.2</version>
 		</dependency>
-		<dependency>
-			<groupId>jakarta.activation</groupId>
-			<artifactId>jakarta.activation-api</artifactId>
-			<version>2.0.1</version>
-		</dependency>
+                <dependency>
+                        <groupId>jakarta.activation</groupId>
+                        <artifactId>jakarta.activation-api</artifactId>
+                        <version>2.0.1</version>
+                </dependency>
+                <dependency>
+                        <groupId>com.graphql-java</groupId>
+                        <artifactId>graphql-java</artifactId>
+                        <version>17.3</version>
+                </dependency>
 
 		<!-- Tools -->
 		<dependency>

--- a/src/main/java/io/kontur/eventapi/client/KonturAppsClient.java
+++ b/src/main/java/io/kontur/eventapi/client/KonturAppsClient.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @Qualifier("konturAppsClient")
 @FeignClient(value = "konturAppsClient", url = "${konturApps.host}")
 public interface KonturAppsClient {
-    @PostMapping(value = "/insights-api/graphql", headers = "Content-Type=application/json")
+    @PostMapping(value = "/insights/graphql", headers = "Content-Type=application/json")
     @ResponseBody
     InsightsApiResponse graphql(@RequestBody InsightsApiRequest request);
 }

--- a/src/main/java/io/kontur/eventapi/enrichment/EventEnrichmentTask.java
+++ b/src/main/java/io/kontur/eventapi/enrichment/EventEnrichmentTask.java
@@ -21,7 +21,6 @@ import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
 import static io.kontur.eventapi.enrichment.InsightsApiResponseHandler.processResponse;
-import static java.lang.String.format;
 import static org.apache.commons.lang3.RegExUtils.replaceAll;
 
 public class EventEnrichmentTask {
@@ -109,8 +108,10 @@ public class EventEnrichmentTask {
                     .map(geometry -> new Feature(geometry, new HashMap<>()))
                     .toArray(Feature[]::new);
             FeatureCollection geom = new FeatureCollection(features);
-            String query = format(enrichmentRequest, replaceAll(geom.toString(), "\"", "\\\\\\\""));
-            InsightsApiRequest request = new InsightsApiRequest(query);
+            String polygon = replaceAll(geom.toString(), "\"", "\\\\\\\"");
+            InsightsApiRequest request = new InsightsApiRequest();
+            request.setQuery(enrichmentRequest);
+            request.setVariables(Map.of("polygon", polygon));
             InsightsApiResponse response = konturAppsClient.graphql(request);
             return Optional.of(processResponse(response, enrichmentFields));
         } catch (Exception e) {

--- a/src/main/java/io/kontur/eventapi/enrichment/dto/InsightsApiRequest.java
+++ b/src/main/java/io/kontur/eventapi/enrichment/dto/InsightsApiRequest.java
@@ -2,9 +2,12 @@ package io.kontur.eventapi.enrichment.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class InsightsApiRequest {
     private String query;
+    private Object variables;
 }

--- a/src/test/java/io/kontur/eventapi/job/EnrichmentJobTest.java
+++ b/src/test/java/io/kontur/eventapi/job/EnrichmentJobTest.java
@@ -46,7 +46,7 @@ public class EnrichmentJobTest {
         feedWithEnrichment.setFeedId(UUID.randomUUID());
         feedWithEnrichment.setAlias("feedWithEnrichment");
         feedWithEnrichment.setEnrichment(List.of(POPULATION, OSM_GAPS_PERCENTAGE));
-        feedWithEnrichment.setEnrichmentRequest("{polygonStatistic (polygonStatisticRequest: {polygon: \"%s\"}){analytics {population {population}}}}");
+        feedWithEnrichment.setEnrichmentRequest("query ($polygon: String!) { polygonStatistic(polygonStatisticRequest: {polygon: $polygon}){analytics {population {population}}}}");
     }
 
     private static final Feed feedWithoutEnrichment;

--- a/src/test/java/io/kontur/eventapi/job/ReEnrichmentJobTest.java
+++ b/src/test/java/io/kontur/eventapi/job/ReEnrichmentJobTest.java
@@ -50,7 +50,7 @@ class ReEnrichmentJobTest {
         feedWithEnrichment.setFeedId(UUID.randomUUID());
         feedWithEnrichment.setAlias("feedWithEnrichment");
         feedWithEnrichment.setEnrichment(List.of(POPULATION, OSM_GAPS_PERCENTAGE));
-        feedWithEnrichment.setEnrichmentRequest("{polygonStatistic (polygonStatisticRequest: {polygon: \"%s\"}){analytics {population {population}}}}");
+        feedWithEnrichment.setEnrichmentRequest("query ($polygon: String!) { polygonStatistic(polygonStatisticRequest: {polygon: $polygon}){analytics {population {population}}}}");
     }
 
     private static final Feed feedWithoutEnrichment;


### PR DESCRIPTION
## Summary
- update request to Insights API to include query variables
- use new `/insights/graphql` endpoint
- document Insights API integration

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851ccb1535883248f2a6f81206effa4