### PR TITLE
refactor(db): delete obsolete point column

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -24,7 +24,6 @@ Normalized information extracted from `data_lake`.
 | `observation_id` | `uuid` (references `data_lake`)
 | `external_id` | `text`
 | `provider` | `text`
-| `point` | `geometry`
 | `geometries` | `jsonb`
 | `event_severity` | `text`
 | `name` | `text`

--- a/src/main/java/io/kontur/eventapi/calfire/normalization/CalFireNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/calfire/normalization/CalFireNormalizer.java
@@ -45,7 +45,6 @@ public class CalFireNormalizer extends Normalizer {
         Feature feature = (Feature) GeoJSONFactory.create(dataLakeDto.getData());
         Geometry geometry = feature.getGeometry();
         normalizedObservation.setGeometries(convertGeometryToFeatureCollection(geometry, CALFIRE_PROPERTIES));
-        normalizedObservation.setPoint(GeometryUtil.getCentroid(geometry, normalizedObservation.getObservationId()));
 
         Map<String, Object> properties = feature.getProperties();
         normalizedObservation.setObservationId(dataLakeDto.getObservationId());

--- a/src/main/java/io/kontur/eventapi/dao/NormalizedObservationsDao.java
+++ b/src/main/java/io/kontur/eventapi/dao/NormalizedObservationsDao.java
@@ -30,7 +30,7 @@ public class NormalizedObservationsDao {
                 obs.getProvider(), obs.getOrigin(), obs.getName(), obs.getProperName(), obs.getDescription(),
                 obs.getEpisodeDescription(), obs.getType(), obs.getEventSeverity(), obs.getActive(), obs.getLoadedAt(),
                 obs.getStartedAt(), obs.getEndedAt(), obs.getSourceUpdatedAt(), obs.getRegion(), obs.getUrls(),
-                obs.getCost(), obs.getLoss(), obs.getSeverityData(), obs.getPoint(), geometries, obs.getAutoExpire(), obs.getRecombined());
+                obs.getCost(), obs.getLoss(), obs.getSeverityData(), geometries, obs.getAutoExpire(), obs.getRecombined());
     }
 
     public void markAsRecombined(UUID observationId) {

--- a/src/main/java/io/kontur/eventapi/dao/mapper/NormalizedObservationsMapper.java
+++ b/src/main/java/io/kontur/eventapi/dao/mapper/NormalizedObservationsMapper.java
@@ -35,7 +35,6 @@ public interface NormalizedObservationsMapper {
                @Param("cost") BigDecimal cost,
                @Param("loss") Map<String, Object> loss,
                @Param("severityData") Map<String, Object> severityData,
-               @Param("point") String point,
                @Param("geometries") String geometries,
                @Param("autoExpire") Boolean autoExpire,
                @Param("recombined") boolean recombined);

--- a/src/main/java/io/kontur/eventapi/emdat/normalization/EmDatNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/emdat/normalization/EmDatNormalizer.java
@@ -94,13 +94,13 @@ public class EmDatNormalizer extends Normalizer {
         }
 
         Point point = null;
+        String wktPoint = null;
         if (!StringUtils.isEmpty(csvData.get("Latitude")) && !StringUtils.isEmpty(csvData.get("Longitude"))) {
             try {
                 Double lon = parseDouble(csvData.get("Longitude"));
                 Double lat = parseDouble(csvData.get("Latitude"));
-                String wktPoint = makeWktPoint(lon, lat);
+                wktPoint = makeWktPoint(lon, lat);
                 wktReader.read(wktPoint); //validate coordinates
-                obs.setPoint(wktPoint);
                 point = new Point(new double[]{lon, lat});
             } catch (NumberFormatException | ParseException e) {
                 LOG.debug(String.format("'%s' for observation %s", e.getMessage(), obs.getObservationId()));
@@ -109,7 +109,7 @@ public class EmDatNormalizer extends Normalizer {
 
         Geometry geom = normalizationService
                 .obtainGeometries(csvData.get("Country"), csvData.get("Location"))
-                .or(() -> normalizationService.convertWktPointIntoGeometry(obs.getPoint()))
+                .or(() -> normalizationService.convertWktPointIntoGeometry(wktPoint))
                 .orElse(null);
         obs.setGeometries(geometryConverter.convertGeometry(geom, point, csvData.get("Dis Mag Scale"), csvData.get("Dis Mag Value")));
 

--- a/src/main/java/io/kontur/eventapi/entity/NormalizedObservation.java
+++ b/src/main/java/io/kontur/eventapi/entity/NormalizedObservation.java
@@ -31,7 +31,6 @@ public class NormalizedObservation {
     private BigDecimal cost;
     private Map<String, Object> loss = new HashMap<>();
     private Map<String, Object> severityData = new HashMap<>();
-    private String point;
     private FeatureCollection geometries;
     private Boolean autoExpire;
     private Boolean recombined = false;

--- a/src/main/java/io/kontur/eventapi/firms/normalization/FirmsNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/firms/normalization/FirmsNormalizer.java
@@ -64,7 +64,6 @@ public class FirmsNormalizer extends Normalizer {
             Double longitude = csvData.getLongitude();
             Double latitude = csvData.getLatitude();
 
-            normalizedObservation.setPoint(makeWktPoint(longitude, latitude));
 
             String wktPolygon = createWktPolygon(longitude, latitude);
             normalizedObservation.setGeometries(createGeometry(wktPolygon));

--- a/src/main/java/io/kontur/eventapi/inciweb/normalization/InciWebNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/inciweb/normalization/InciWebNormalizer.java
@@ -55,7 +55,6 @@ public class InciWebNormalizer extends Normalizer {
 
             Point point = new Point(new double[] {parsedItem.get().getLongitude(), parsedItem.get().getLatitude()});
             normalizedObservation.setGeometries(convertGeometryToFeatureCollection(point, INCIWEB_PROPERTIES));
-            normalizedObservation.setPoint(
                     makeWktPoint(parsedItem.get().getLongitude(), parsedItem.get().getLatitude()));
 
             return normalizedObservation;

--- a/src/main/java/io/kontur/eventapi/nhc/normalization/NhcNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/nhc/normalization/NhcNormalizer.java
@@ -56,7 +56,6 @@ public class NhcNormalizer extends Normalizer {
             normalizedObservation.setLoadedAt(dataLakeDto.getLoadedAt());
             normalizedObservation.setSourceUpdatedAt(dataLakeDto.getUpdatedAt());
             normalizedObservation.setUrls(parsedItem.get().getLink() != null ? List.of(parsedItem.get().getLink()) : null);
-            normalizedObservation.setPoint(null);
             normalizedObservation.setActive(null);
 
             Map<Integer, Map<Integer, String>> mainMatchers = parser.parseDescription(description);

--- a/src/main/java/io/kontur/eventapi/nifc/normalization/LocationsNifcNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/nifc/normalization/LocationsNifcNormalizer.java
@@ -43,7 +43,6 @@ public class LocationsNifcNormalizer extends NifcNormalizer {
 
         Double lon = readDouble(props, "InitialLongitude");
         Double lat = readDouble(props, "InitialLatitude");
-        observation.setPoint(makeWktPoint(lon, lat));
 
         Double calculatedAcres = readDouble(props, "CalculatedAcres");
         Double incidentSize = readDouble(props, "IncidentSize");

--- a/src/main/java/io/kontur/eventapi/nifc/normalization/PerimetersNifcNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/nifc/normalization/PerimetersNifcNormalizer.java
@@ -47,7 +47,6 @@ public class PerimetersNifcNormalizer extends NifcNormalizer {
 
         Double lon = selectFirstNotNull(readDouble(props, "attr_InitialLongitude"), readDouble(props, "irwin_InitialLongitude"));
         Double lat = selectFirstNotNull(readDouble(props, "attr_InitialLatitude"), readDouble(props, "irwin_InitialLatitude"));
-        observation.setPoint(makeWktPoint(lon, lat));
 
         double areaSqKm2 = convertAcresToSqKm(readDouble(props, "poly_GISAcres"));
         long durationHours = between(observation.getStartedAt(), observation.getEndedAt()).toHours();

--- a/src/main/java/io/kontur/eventapi/pdc/normalization/HpSrvMagsNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/pdc/normalization/HpSrvMagsNormalizer.java
@@ -48,7 +48,6 @@ public class HpSrvMagsNormalizer extends PdcHazardNormalizer {
             normalizedDto.setEndedAt(readDateTime(props, "hazard.endDate"));
             normalizedDto.setSourceUpdatedAt(readDateTime(props, "updateDate"));
 
-            normalizedDto.setPoint(makeWktPoint(readDouble(props, "hazard.longitude"),
                     readDouble(props, "hazard.latitude")));
         }
 

--- a/src/main/java/io/kontur/eventapi/pdc/normalization/HpSrvSearchNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/pdc/normalization/HpSrvSearchNormalizer.java
@@ -62,7 +62,6 @@ public class HpSrvSearchNormalizer extends PdcHazardNormalizer {
         normalizedDto.setEndedAt(endedAt != null ? endedAt : startedAt);
 
         String pointWkt = makeWktPoint(readDouble(props, "longitude"), readDouble(props, "latitude"));
-        normalizedDto.setPoint(pointWkt);
 
         try {
             normalizedDto.setGeometries(convertGeometry(pointWkt, props));

--- a/src/main/java/io/kontur/eventapi/pdc/normalization/PdcMapSrvNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/pdc/normalization/PdcMapSrvNormalizer.java
@@ -50,7 +50,6 @@ public class PdcMapSrvNormalizer extends PdcHazardNormalizer {
 
         normalizedObservation.setType(defineType(readString(properties, "type_id")));
         normalizedObservation.setGeometries(convertGeometries(geometry));
-        normalizedObservation.setPoint(GeometryUtil.getCentroid(geometry, normalizedObservation.getObservationId()));
         return normalizedObservation;
     }
 

--- a/src/main/java/io/kontur/eventapi/pdc/normalization/PdcSqsMessageNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/pdc/normalization/PdcSqsMessageNormalizer.java
@@ -112,7 +112,6 @@ public class PdcSqsMessageNormalizer extends PdcHazardNormalizer {
             normalizedDto.setUrls(List.of(url));
         }
         String pointWkt = makeWktPoint(readDouble(props, "longitude"), readDouble(props, "latitude"));
-        normalizedDto.setPoint(pointWkt);
 
         if(normalizedDto.getExternalEpisodeId() == null) {
             normalizedDto.setExternalEpisodeId(readString(props, "uuid"));

--- a/src/main/java/io/kontur/eventapi/staticdata/normalization/AustraliaWildfireNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/staticdata/normalization/AustraliaWildfireNormalizer.java
@@ -39,7 +39,6 @@ public class AustraliaWildfireNormalizer extends StaticNormalizer {
         Feature feature = (Feature) GeoJSONFactory.create(dataLake.getData());
 
         Point point = reader.read(feature.getGeometry()).getCentroid();
-        normalizedObservation.setPoint(makeWktPoint(point.getX(), point.getY()));
 
         normalizedObservation.setGeometries(convertGeometryToFeatureCollection(feature.getGeometry(), WILDFIRE_PROPERTIES));
 

--- a/src/main/java/io/kontur/eventapi/staticdata/normalization/CommonStaticNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/staticdata/normalization/CommonStaticNormalizer.java
@@ -29,7 +29,6 @@ public class CommonStaticNormalizer extends StaticNormalizer {
 
         Double lon = readDouble(properties, "longitude");
         Double lat = readDouble(properties, "latitude");
-        normalizedObservation.setPoint(makeWktPoint(lon, lat));
         normalizedObservation.setGeometries(convertGeometryToFeatureCollection(feature.getGeometry(), TORNADO_PROPERTIES));
 
         String name = readString(properties, "name");

--- a/src/main/java/io/kontur/eventapi/staticdata/normalization/FrapCalStaticNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/staticdata/normalization/FrapCalStaticNormalizer.java
@@ -37,7 +37,6 @@ public class FrapCalStaticNormalizer extends StaticNormalizer {
 
         MultiPolygon multiPolygon = (MultiPolygon) reader.read(feature.getGeometry());
         Point point = multiPolygon.getCentroid();
-        normalizedObservation.setPoint(makeWktPoint(point.getX(), point.getY()));
         normalizedObservation.setGeometries(convertGeometryToFeatureCollection(feature.getGeometry(), WILDFIRE_PROPERTIES));
 
         String state = readString(properties, "STATE");

--- a/src/main/java/io/kontur/eventapi/stormsnoaa/normalization/StormsNoaaNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/stormsnoaa/normalization/StormsNoaaNormalizer.java
@@ -163,7 +163,6 @@ public class StormsNoaaNormalizer extends Normalizer {
         boolean startPointPresent = x1 != null && y1 != null;
         boolean endPointPresent = x2 != null && y2 != null;
         String point = startPointPresent ? makeWktPoint(x1, y1) : endPointPresent ? makeWktPoint(x2, y2) : null;
-        normalizedObservation.setPoint(point);
         try {
             if (startPointPresent && endPointPresent) {
                 Geometry geometry = geoJsonWriter.write(wktReader.read(makeWktLine(x1, y1, x2, y2)));

--- a/src/main/java/io/kontur/eventapi/tornadojapanma/normalizer/TornadoJapanMaNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/tornadojapanma/normalizer/TornadoJapanMaNormalizer.java
@@ -97,7 +97,6 @@ public class TornadoJapanMaNormalizer extends Normalizer {
         boolean endPointPresent = x2 != null && y2 != null;
         String point = startPointPresent ? makeWktPoint(x1, y1) : endPointPresent ? makeWktPoint(x2, y2) : null;
         String geom = startPointPresent && endPointPresent ? makeWktLine(x1, y1, x2, y2) : point;
-        normalizedObservation.setPoint(point);
         try {
             Geometry geometry = geom == null ? null : geoJsonWriter.write(wktReader.read(geom));
             Feature feature = new Feature(geometry, Collections.emptyMap());

--- a/src/main/java/io/kontur/eventapi/uhc/normalization/HumanitarianCrisisNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/uhc/normalization/HumanitarianCrisisNormalizer.java
@@ -48,7 +48,6 @@ public class HumanitarianCrisisNormalizer extends Normalizer {
         normalizedObservation.setProvider(dataLakeDto.getProvider());
         Geometry geometry = feature.getGeometry();
         normalizedObservation.setGeometries(convertGeometryToFeatureCollection(geometry, UHC_PROPERTIES));
-        normalizedObservation.setPoint(GeometryUtil.getCentroid(geometry, normalizedObservation.getObservationId()));
         try {
             String severity = readString(properties, "severity");
             normalizedObservation.setEventSeverity(Severity.valueOf(severity.toUpperCase()));

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -70,3 +70,6 @@ databaseChangeLog:
 - include:
     relativeToChangelogFile: true
     file: v1.21.0/v1.21.0.yaml
+- include:
+    relativeToChangelogFile: true
+    file: v1.22.0/v1.22.0.yaml

--- a/src/main/resources/db/changelog/v1.22.0/drop-point-column.sql
+++ b/src/main/resources/db/changelog/v1.22.0/drop-point-column.sql
@@ -1,0 +1,1 @@
+alter table if exists normalized_observations drop column if exists point;

--- a/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
+++ b/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
@@ -1,0 +1,4 @@
+databaseChangeLog:
+  - include:
+      relativeToChangelogFile: true
+      file: drop-point-column.sql

--- a/src/main/resources/db/mappers/NormalizedObservationsMapper.xml
+++ b/src/main/resources/db/mappers/NormalizedObservationsMapper.xml
@@ -10,7 +10,6 @@
             ended_at, source_updated_at, region, urls, cost,
             <if test='loss != null'>loss,</if>
             <if test='severityData != null'>severity_data,</if>
-            <if test='point != null'>point,</if>
             <if test='geometries != null'>geometries,</if>
             auto_expire, recombined
         ) values (
@@ -20,7 +19,6 @@
             #{cost},
             <if test='loss != null'>#{loss,typeHandler=io.kontur.eventapi.typehandler.MapTypeHandler}::jsonb,</if>
             <if test='severityData != null'>#{severityData,typeHandler=io.kontur.eventapi.typehandler.MapTypeHandler}::jsonb,</if>
-            <if test='point != null'>'SRID=4326;${point}'::geometry,</if>
             <if test='geometries != null'>#{geometries}::jsonb,</if>
             #{autoExpire}, #{recombined}
         )
@@ -33,7 +31,6 @@
             urls = #{urls, typeHandler=io.kontur.eventapi.typehandler.StringArrayTypeHandler}, cost = #{cost},
             <if test='loss != null'>loss = #{loss,typeHandler=io.kontur.eventapi.typehandler.MapTypeHandler}::jsonb,</if>
             <if test='severityData != null'>severity_data = #{severityData,typeHandler=io.kontur.eventapi.typehandler.MapTypeHandler}::jsonb,</if>
-            <if test='point != null'>point = 'SRID=4326;${point}'::geometry,</if>
             <if test='geometries != null'>geometries = #{geometries}::jsonb,</if>
             auto_expire = #{autoExpire}, recombined = #{recombined}
     </insert>
@@ -136,7 +133,6 @@
         <result property="cost" column="cost"/>
         <result property="loss" column="loss" typeHandler="io.kontur.eventapi.typehandler.MapTypeHandler"/>
         <result property="severityData" column="severity_data" typeHandler="io.kontur.eventapi.typehandler.MapTypeHandler"/>
-        <result property="point" column="point"/>
         <result property="geometries" column="geometries" typeHandler="io.kontur.eventapi.typehandler.FeatureCollectionTypeHandler"/>
         <result property="autoExpire" column="auto_expire"/>
         <result property="recombined" column="recombined"/>

--- a/src/test/java/io/kontur/eventapi/calfire/normalization/CalFireNormalizationTest.java
+++ b/src/test/java/io/kontur/eventapi/calfire/normalization/CalFireNormalizationTest.java
@@ -50,7 +50,6 @@ class CalFireNormalizationTest {
         assertEquals(1611582312000L, observation.getSourceUpdatedAt().toInstant().toEpochMilli());
         assertEquals(dataLake.getLoadedAt(), observation.getLoadedAt());
         assertEquals(List.of("https://www.fire.ca.gov"), observation.getUrls());
-        assertEquals("POINT(-100.12345 30.12345)", observation.getPoint());
         checkGeometriesValue(observation.getGeometries());
     }
 

--- a/src/test/java/io/kontur/eventapi/firms/normalization/FirmsNormalizerIT.java
+++ b/src/test/java/io/kontur/eventapi/firms/normalization/FirmsNormalizerIT.java
@@ -59,7 +59,6 @@ public class FirmsNormalizerIT extends AbstractCleanableIntegrationTest {
         assertEquals(dataLake.getUpdatedAt(), observation.getStartedAt());
         assertEquals(FirmsUtil.MODIS_PROVIDER, observation.getProvider());
         assertEquals(EventType.THERMAL_ANOMALY, observation.getType());
-        assertEquals("POINT(133.141 -2.443)", observation.getPoint());
         assertEquals(readFile(this, "firms.geometries.json"), observation.getGeometries().getFeatures()[0].getGeometry().toString());
         assertEquals(FIRMS_PROPERTIES, observation.getGeometries().getFeatures()[0].getProperties());
 

--- a/src/test/java/io/kontur/eventapi/gdacs/normalization/GdacsNormalizerIT.java
+++ b/src/test/java/io/kontur/eventapi/gdacs/normalization/GdacsNormalizerIT.java
@@ -119,7 +119,6 @@ public class GdacsNormalizerIT extends AbstractIntegrationTest {
         assertEquals(toDate, observation.getEndedAt());
 
         assertTrue(observation.getActive());
-        assertNull(observation.getPoint());
         assertNull(observation.getCost());
         assertNotNull(observation.getRegion());
 
@@ -150,7 +149,6 @@ public class GdacsNormalizerIT extends AbstractIntegrationTest {
         assertNull(observation.getName());
         assertNull(observation.getDescription());
         assertNull(observation.getEpisodeDescription());
-        assertNull(observation.getPoint());
         assertNull(observation.getCost());
         assertNotNull(observation.getRegion());
     }

--- a/src/test/java/io/kontur/eventapi/inciweb/normalization/InciWebNormalizationTest.java
+++ b/src/test/java/io/kontur/eventapi/inciweb/normalization/InciWebNormalizationTest.java
@@ -55,7 +55,6 @@ class InciWebNormalizationTest {
         assertEquals(dataLake.getUpdatedAt(), observation.getSourceUpdatedAt());
         assertEquals(dataLake.getLoadedAt(), observation.getLoadedAt());
         assertEquals(List.of("http://example.com/incident/1/"), observation.getUrls());
-        assertEquals("POINT(-110.111 10.111)", observation.getPoint());
         checkGeometriesValue(observation.getGeometries());
     }
 

--- a/src/test/java/io/kontur/eventapi/nhc/normalization/NhcNormalizationTest.java
+++ b/src/test/java/io/kontur/eventapi/nhc/normalization/NhcNormalizationTest.java
@@ -60,7 +60,6 @@ public class NhcNormalizationTest {
         assertEquals(dataLake.getUpdatedAt(), observation.getSourceUpdatedAt());
         assertEquals(dataLake.getLoadedAt(), observation.getLoadedAt());
         assertEquals(List.of("https://www.nhc.noaa.gov/text/refresh/MIATCMEP5+shtml/112045.shtml"), observation.getUrls());
-        assertNull(observation.getPoint());
         checkGeometriesValue(observation.getGeometries(), 9);
     }
 
@@ -86,7 +85,6 @@ public class NhcNormalizationTest {
         assertEquals(dataLake.getUpdatedAt(), observation.getSourceUpdatedAt());
         assertEquals(dataLake.getLoadedAt(), observation.getLoadedAt());
         assertEquals(List.of("https://www.nhc.noaa.gov/text/refresh/MIATCMAT2+shtml/272045.shtml"), observation.getUrls());
-        assertNull(observation.getPoint());
         checkGeometriesValue(observation.getGeometries(), 9);
     }
 
@@ -112,7 +110,6 @@ public class NhcNormalizationTest {
         assertEquals(dataLake.getUpdatedAt(), observation.getSourceUpdatedAt());
         assertEquals(dataLake.getLoadedAt(), observation.getLoadedAt());
         assertEquals(List.of("https://www.nhc.noaa.gov/text/refresh/MIATCMAT2+shtml/DDHHMM.shtml"), observation.getUrls());
-        assertNull(observation.getPoint());
         checkGeometriesValue(observation.getGeometries(), 9);
     }
 
@@ -138,7 +135,6 @@ public class NhcNormalizationTest {
         assertEquals(dataLake.getUpdatedAt(), observation.getSourceUpdatedAt());
         assertEquals(dataLake.getLoadedAt(), observation.getLoadedAt());
         assertEquals(List.of("https://www.nhc.noaa.gov/text/refresh/MIATCMEP3+shtml/DDHHMM.shtml"), observation.getUrls());
-        assertNull(observation.getPoint());
         checkGeometriesValue(observation.getGeometries(), 9);
     }
 
@@ -164,7 +160,6 @@ public class NhcNormalizationTest {
         assertEquals(dataLake.getUpdatedAt(), observation.getSourceUpdatedAt());
         assertEquals(dataLake.getLoadedAt(), observation.getLoadedAt());
         assertEquals(List.of("https://www.nhc.noaa.gov/text/refresh/MIATCMEP3+shtml/270852.shtml"), observation.getUrls());
-        assertNull(observation.getPoint());
         checkGeometriesValue(observation.getGeometries(), 6);
     }
 

--- a/src/test/java/io/kontur/eventapi/nifc/normalization/LocationsNifcNormalizerTest.java
+++ b/src/test/java/io/kontur/eventapi/nifc/normalization/LocationsNifcNormalizerTest.java
@@ -34,7 +34,6 @@ class LocationsNifcNormalizerTest {
         assertEquals(dataLake.getUpdatedAt(), observation.getEndedAt());
         assertEquals(dataLake.getProvider(), observation.getProvider());
         assertEquals("2021-IDIPF-000504", observation.getExternalEventId());
-        assertEquals("POINT(-115.354225 47.128143)", observation.getPoint());
         assertEquals(Severity.MINOR, observation.getEventSeverity());
         assertEquals("Wildfire Stateline Complex", observation.getName());
         assertEquals("Stateline Complex", observation.getProperName());

--- a/src/test/java/io/kontur/eventapi/nifc/normalization/PerimetersNifcNormalizerTest.java
+++ b/src/test/java/io/kontur/eventapi/nifc/normalization/PerimetersNifcNormalizerTest.java
@@ -34,7 +34,6 @@ class PerimetersNifcNormalizerTest {
         assertEquals(dataLake.getUpdatedAt(), observation.getEndedAt());
         assertEquals(dataLake.getProvider(), observation.getProvider());
         assertEquals("2021-ALALF-210222", observation.getExternalEventId());
-        assertEquals("POINT(-85.82526 33.48939)", observation.getPoint());
         assertEquals(Severity.MINOR, observation.getEventSeverity());
         assertEquals("Wildfire TL DUCK NEST", observation.getName());
         assertEquals("TL DUCK NEST", observation.getProperName());

--- a/src/test/java/io/kontur/eventapi/pdc/normalization/PdcMapSrvNormalizerTest.java
+++ b/src/test/java/io/kontur/eventapi/pdc/normalization/PdcMapSrvNormalizerTest.java
@@ -33,7 +33,6 @@ class PdcMapSrvNormalizerTest {
         assertEquals(dataLake.getObservationId(), observation.getObservationId());
         assertEquals(dataLake.getExternalId(), observation.getExternalEventId());
         assertEquals(dataLake.getProvider(), observation.getProvider());
-        assertNotNull(observation.getPoint());
         assertEquals(getGeometries(), observation.getGeometries().getFeatures()[0].getGeometry().toString());
         assertEquals(EXPOSURE_PROPERTIES, observation.getGeometries().getFeatures()[0].getProperties());
         assertEquals(Severity.UNKNOWN, observation.getEventSeverity());

--- a/src/test/java/io/kontur/eventapi/pdc/normalization/PdcSqsMessageNormalizerTest.java
+++ b/src/test/java/io/kontur/eventapi/pdc/normalization/PdcSqsMessageNormalizerTest.java
@@ -38,7 +38,6 @@ class PdcSqsMessageNormalizerTest {
         assertEquals(dataLake.getProvider(), observation.getProvider());
         assertEquals(dataLake.getLoadedAt(), observation.getLoadedAt());
 
-        assertEquals("POINT(10.0 10.0)", observation.getPoint());
 
         assertEquals(1, observation.getGeometries().getFeatures().length);
         assertEquals(geoJSONWriter.write(wktReader.read("POINT(10.0 10.0)")).toString(),
@@ -76,7 +75,6 @@ class PdcSqsMessageNormalizerTest {
         assertEquals(dataLake.getProvider(), observation.getProvider());
         assertEquals(dataLake.getLoadedAt(), observation.getLoadedAt());
 
-        assertEquals("POINT(10.0 10.0)", observation.getPoint());
 
         assertEquals(1, observation.getGeometries().getFeatures().length);
         assertEquals(geoJSONWriter.write(wktReader.read("POINT(10.0 10.0)")).toString(),
@@ -114,7 +112,6 @@ class PdcSqsMessageNormalizerTest {
         assertEquals(dataLake.getProvider(), observation.getProvider());
         assertEquals(dataLake.getLoadedAt(), observation.getLoadedAt());
 
-        assertEquals("POINT(10.0 10.0)", observation.getPoint());
 
         assertEquals(1, observation.getGeometries().getFeatures().length);
         assertEquals(geoJSONWriter.write(wktReader.read("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))")).toString(),

--- a/src/test/java/io/kontur/eventapi/staticdata/normalization/AustraliaWildfireNormalizerTest.java
+++ b/src/test/java/io/kontur/eventapi/staticdata/normalization/AustraliaWildfireNormalizerTest.java
@@ -66,7 +66,6 @@ class AustraliaWildfireNormalizerTest {
     }
 
     private void assertDefault(DataLake dataLake, NormalizedObservation observation) {
-        assertEquals("POINT(0.5 0.5)", observation.getPoint());
         assertEquals(1, observation.getGeometries().getFeatures().length);
         assertEquals(WILDFIRE_PROPERTIES, observation.getGeometries().getFeatures()[0].getProperties());
         assertEquals(UNKNOWN, observation.getEventSeverity());

--- a/src/test/java/io/kontur/eventapi/staticdata/normalization/CommonStaticNormalizerIT.java
+++ b/src/test/java/io/kontur/eventapi/staticdata/normalization/CommonStaticNormalizerIT.java
@@ -52,7 +52,6 @@ class CommonStaticNormalizerIT extends AbstractCleanableIntegrationTest {
         assertEquals(Severity.MINOR, normalizedObservation.getEventSeverity());
         assertEquals("tornado", normalizedObservation.getDescription());
         assertEquals(EventType.TORNADO, normalizedObservation.getType());
-        assertNotNull(normalizedObservation.getPoint());
         assertNotNull(normalizedObservation.getGeometries());
 
         OffsetDateTime date = OffsetDateTime.parse("1980-05-06T00:00:00Z");

--- a/src/test/java/io/kontur/eventapi/staticdata/normalization/FrapCalStaticNormalizerIT.java
+++ b/src/test/java/io/kontur/eventapi/staticdata/normalization/FrapCalStaticNormalizerIT.java
@@ -46,7 +46,6 @@ class FrapCalStaticNormalizerIT extends AbstractCleanableIntegrationTest {
         assertEquals(dataLake.getProvider(), normalizedObservation.getProvider());
         assertFalse(normalizedObservation.getActive());
         assertEquals(EventType.WILDFIRE, normalizedObservation.getType());
-        assertNotNull(normalizedObservation.getPoint());
         assertNotNull(normalizedObservation.getGeometries());
         assertEquals(WILDFIRE_PROPERTIES, normalizedObservation.getGeometries().getFeatures()[0].getProperties());
         assertEquals("Wildfire - Los Angeles County, California, USA", normalizedObservation.getName());

--- a/src/test/java/io/kontur/eventapi/stormsnoaa/normalization/StormsNoaaNormalizerIT.java
+++ b/src/test/java/io/kontur/eventapi/stormsnoaa/normalization/StormsNoaaNormalizerIT.java
@@ -55,7 +55,6 @@ class StormsNoaaNormalizerIT extends AbstractCleanableIntegrationTest {
         assertEquals(OffsetDateTime.parse("1950-04-29T14:45:00Z"), normalizedObservation.getEndedAt());
         assertEquals(Severity.SEVERE, normalizedObservation.getEventSeverity());
         assertEquals("Tornado - WASHITA, OKLAHOMA, USA", normalizedObservation.getName());
-        assertNotNull(normalizedObservation.getPoint());
         assertNotNull(normalizedObservation.getGeometries());
         assertEquals(1, normalizedObservation.getGeometries().getFeatures().length);
         assertEquals(STORMS_NOAA_TRACK_PROPERTIES, normalizedObservation.getGeometries().getFeatures()[0].getProperties());

--- a/src/test/java/io/kontur/eventapi/tornadojapanma/normalizer/TornadoJapanMaNormalizerIT.java
+++ b/src/test/java/io/kontur/eventapi/tornadojapanma/normalizer/TornadoJapanMaNormalizerIT.java
@@ -43,7 +43,6 @@ class TornadoJapanMaNormalizerIT extends AbstractCleanableIntegrationTest {
         assertEquals(dataLake.getLoadedAt(), normalizedObservation.getLoadedAt());
         assertEquals(dataLake.getProvider(), normalizedObservation.getProvider());
 
-        assertNull(normalizedObservation.getPoint());
         assertNull(normalizedObservation.getGeometries());
         assertNull(normalizedObservation.getDescription());
         assertNull(normalizedObservation.getEpisodeDescription());

--- a/src/test/java/io/kontur/eventapi/uhc/normalization/UHCNormalizationTest.java
+++ b/src/test/java/io/kontur/eventapi/uhc/normalization/UHCNormalizationTest.java
@@ -63,7 +63,6 @@ class UHCNormalizationTest {
         assertEquals(1645671600000L, observation.getEndedAt().toInstant().toEpochMilli());
         assertEquals(1647820800000L, observation.getSourceUpdatedAt().toInstant().toEpochMilli());
         assertEquals(dataLake.getLoadedAt(), observation.getLoadedAt());
-        assertEquals("POINT(1.0 1.0)", observation.getPoint());
     }
 
     private DataLake createDataLake() throws Exception {


### PR DESCRIPTION
## Summary
- drop `point` column from normalized_observations
- update changelog with new migration
- remove `point` property from NormalizedObservation and mappers
- clean up normalizers and tests
- update documentation

## Testing
- `mvn -q -DskipITs test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_6851cce75d9083248e458bb159fd1780

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the point geometry field from normalized observations and all related processing, storage, and mapping logic.
- **Database**
  - Dropped the point column from the normalized observations table; updated migration scripts accordingly.
- **Documentation**
  - Updated schema documentation to reflect the removal of the point column.
- **Tests**
  - Removed test assertions related to the point field in normalized observations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->