### PR TITLE
fix(api): allow filtering by multiple severities

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -8,7 +8,8 @@ Search for events within a feed.
 **Parameters**
 - `feed` – feed name (required).
 - `types` – list of event types.
-- `severities` – list of severity values.
+- `severities` – list of severity values (`UNKNOWN`, `TERMINATION`, `MINOR`, `MODERATE`, `SEVERE`, `EXTREME`).
+  When several values are provided, events matching any of them are returned.
 - `after` – return events updated after this timestamp.
 - `datetime` – interval filter. Accepts single RFC3339 timestamp or open/closed interval.
 - `bbox` – bounding box defined as `minLon,minLat,maxLon,maxLat`.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -95,6 +95,15 @@ Reference table of possible severity levels.
 | `severity_id` | `smallserial` primary key |
 | `severity` | `text` |
 
+Possible severities are:
+
+- `UNKNOWN`
+- `TERMINATION`
+- `MINOR`
+- `MODERATE`
+- `SEVERE`
+- `EXTREME`
+
 ## `feed_event_status`
 Tracks current events per feed.
 

--- a/src/main/java/io/kontur/eventapi/resource/EventResource.java
+++ b/src/main/java/io/kontur/eventapi/resource/EventResource.java
@@ -66,7 +66,8 @@ public class EventResource {
             @Parameter(description = "Filters events by type. More than one can be chosen at once")
             @RequestParam(value = "types", defaultValue = "")
             List<EventType> eventTypes,
-            @Parameter(description = "Filters events by severity. More than one can be chosen at once")
+            @Parameter(description = "Filters events by severity. Allowed values: UNKNOWN, TERMINATION, MINOR, MODERATE, SEVERE, EXTREME. " +
+                    "Multiple values select events matching any of them.")
             @RequestParam(value = "severities", defaultValue = "")
             List<Severity> severities,
             @Parameter(description = "Includes events that were updated after this time. `updatedAt` property is used for selection. A date-time in ISO8601 format (e.g. \\\"2020-04-12T23:20:50.52Z\\\")")
@@ -151,7 +152,8 @@ public class EventResource {
             @Parameter(description = "Filters events by type. More than one can be chosen at once")
             @RequestParam(value = "types", defaultValue = "")
             List<EventType> eventTypes,
-            @Parameter(description = "Filters events by severity. More than one can be chosen at once")
+            @Parameter(description = "Filters events by severity. Allowed values: UNKNOWN, TERMINATION, MINOR, MODERATE, SEVERE, EXTREME. " +
+                    "Multiple values select events matching any of them.")
             @RequestParam(value = "severities", defaultValue = "")
             List<Severity> severities,
             @Parameter(description = "Includes events that were updated after this time. " +

--- a/src/main/resources/db/mappers/ApiMapper.xml
+++ b/src/main/resources/db/mappers/ApiMapper.xml
@@ -41,12 +41,12 @@
                     </foreach>
                 </if>
                 <if test="severities!=null &amp;&amp; !severities.isEmpty"  >
-                    <foreach item="severity" collection="severities" separator="," open="and fd.severity_id &gt;= (select min(severity_id) from severities where severity in (" close="))">
-                        #{severity}::text
-                    </foreach>
-                    <foreach item="severity" collection="severities" separator="," open="and fd.severity_id &lt;= (select max(severity_id) from severities where severity in (" close="))">
-                        #{severity}::text
-                    </foreach>
+                    and fd.severity_id in (
+                        select severity_id from severities where severity in
+                        <foreach item="severity" collection="severities" separator="," open="(" close=")">
+                            #{severity}::text
+                        </foreach>
+                    )
                 </if>
                 <if test='from != null'><![CDATA[and (fd.ended_at >= #{from})]]></if>
                 <if test='to != null'><![CDATA[and (fd.started_at <= #{to})]]></if>
@@ -178,12 +178,12 @@
                     </foreach>
                 </if>
                 <if test="severities!=null &amp;&amp; !severities.isEmpty"  >
-                    <foreach item="severity" collection="severities" separator="," open="and fd.severity_id &gt;= (select min(severity_id) from severities where severity in (" close="))">
-                        #{severity}::text
-                    </foreach>
-                    <foreach item="severity" collection="severities" separator="," open="and fd.severity_id &lt;= (select max(severity_id) from severities where severity in (" close="))">
-                        #{severity}::text
-                    </foreach>
+                    and fd.severity_id in (
+                        select severity_id from severities where severity in
+                        <foreach item="severity" collection="severities" separator="," open="(" close=")">
+                            #{severity}::text
+                        </foreach>
+                    )
                 </if>
                 <if test='from != null'><![CDATA[and (fd.ended_at >= #{from})]]></if>
                 <if test='to != null'><![CDATA[and (fd.started_at <= #{to})]]></if>


### PR DESCRIPTION
## Summary
- filter events by exact severities instead of a range
- document possible severities
- clarify API docs and parameter description

## Testing
- `mvn -q -DskipTests=false test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851ccf3be948324bf57b590ce5200ac