### PR TITLE
feat(db): 13578 add index for event lookup

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -37,5 +37,11 @@ Return a single event by feed alias, event ID and optional version. When the ver
 - `version` – event version number (optional).
 - `episodeFilterType` – `ANY`, `LATEST` or `NONE`.
 
+## `GET /v1/events/{feed}/{eventId}`
+Return the latest event by feed alias and event ID.
+
+**Parameters**
+- `episodeFilterType` – `ANY`, `LATEST` or `NONE`.
+
 ## `GET /v1/user_feeds`
 Return the list of feeds available for the authenticated user. The list is built from the roles present in the JWT token.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -86,6 +86,7 @@ Stores event versions for each feed. Table was redesigned in version 1.15.
 | `collected_geometry` | `geometry` generated from episodes |
 
 Unique key: (`event_id`, `version`, `feed_id`). Several GIST and BTREE indexes exist for geometry and timestamps.
+Additional index: (`feed_id`, `event_id`) where `is_latest_version` is `true`.
 
 ## `severities`
 Reference table of possible severity levels.

--- a/src/main/java/io/kontur/eventapi/resource/EventResource.java
+++ b/src/main/java/io/kontur/eventapi/resource/EventResource.java
@@ -258,6 +258,28 @@ public class EventResource {
                 .orElseGet(() -> ResponseEntity.noContent().build());
     }
 
+    @GetMapping(path = "/events/{feed}/{eventId}", produces = {MediaType.APPLICATION_JSON_VALUE})
+    @Operation(
+            tags = "Events",
+            summary = "Returns the latest event",
+            description = "Returns latest event version by feed alias and event id.")
+    @PreAuthorize("hasAuthority('read:feed:'+#feed)")
+    public ResponseEntity<String> getLastEventByPath(
+            @Parameter(description = "Feed name")
+            @PathVariable String feed,
+            @Parameter(description = "Event UUID")
+            @PathVariable UUID eventId,
+            @Parameter(description = "How many event episodes to select: " +
+                    "<ul><li>ANY - all episodes</li>" +
+                    "<li>LATEST - the latest episode</li>" +
+                    "<li>NONE - no episodes</li></ul>")
+            @RequestParam(value = "episodeFilterType", defaultValue = "NONE")
+            EpisodeFilterType episodeFilterType) {
+        return eventResourceService.getEventByEventIdAndByVersionOrLast(eventId, feed, null, episodeFilterType)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.noContent().build());
+    }
+
 
     @GetMapping(path = "/user_feeds", produces = {MediaType.APPLICATION_JSON_VALUE})
     @Operation(

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -70,3 +70,6 @@ databaseChangeLog:
 - include:
     relativeToChangelogFile: true
     file: v1.21.0/v1.21.0.yaml
+- include:
+    relativeToChangelogFile: true
+    file: v1.22.0/v1.22.0.yaml

--- a/src/main/resources/db/changelog/v1.22.0/add-index-feed-event.sql
+++ b/src/main/resources/db/changelog/v1.22.0/add-index-feed-event.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+
+--changeset event-api-migrations:v1.22.0/add-index-feed-event.sql runOnChange:false
+
+create index feed_data_feed_id_event_id_idx
+    on feed_data(feed_id, event_id)
+    where is_latest_version;

--- a/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
+++ b/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
@@ -1,0 +1,4 @@
+databaseChangeLog:
+  - include:
+      relativeToChangelogFile: true
+      file: add-index-feed-event.sql


### PR DESCRIPTION
## Summary
- add BTree index on `feed_data` for feed/event lookup
- expose `/v1/events/{feed}/{eventId}` endpoint to fetch latest event
- document the new endpoint and DB index

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851cd7be9788324882a313ef0fd46b6