### PR TITLE
feat(service): 14681 cache user feed list

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -38,4 +38,4 @@ Return a single event by feed alias, event ID and optional version. When the ver
 - `episodeFilterType` – `ANY`, `LATEST` or `NONE`.
 
 ## `GET /v1/user_feeds`
-Return the list of feeds available for the authenticated user. The list is built from the roles present in the JWT token.
+Returns the list of feeds available for the authenticated user. The list is built from the roles present in the JWT token and is cached for one hour to improve response time.

--- a/src/main/java/io/kontur/eventapi/service/EventResourceService.java
+++ b/src/main/java/io/kontur/eventapi/service/EventResourceService.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static io.kontur.eventapi.util.CacheUtil.EVENT_CACHE_NAME;
+import static io.kontur.eventapi.util.CacheUtil.FEED_CACHE_NAME;
 
 @Service
 public class EventResourceService {
@@ -28,6 +29,7 @@ public class EventResourceService {
         this.environment = environment;
     }
 
+    @Cacheable(cacheNames = FEED_CACHE_NAME, condition = "#root.target.isCacheEnabled()")
     public List<FeedDto> getFeeds() {
         return apiDao.getFeeds();
     }

--- a/src/main/java/io/kontur/eventapi/util/CacheUtil.java
+++ b/src/main/java/io/kontur/eventapi/util/CacheUtil.java
@@ -16,6 +16,7 @@ public class CacheUtil {
 
     public static final String EVENT_LIST_CACHE_NAME_PREFIX = "feed:";
     public static final String EVENT_CACHE_NAME = "events";
+    public static final String FEED_CACHE_NAME = "feeds";
     public static final String CACHED_TARGET = "EventResourceService";
     public static final String EVENT_LIST_CACHED_METHOD = "searchEvents";
 


### PR DESCRIPTION
## Summary
- cache list of feeds to speed up `/v1/user_feeds`
- document caching behaviour

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent from https://nexus.kontur.io)*

------
https://chatgpt.com/codex/tasks/task_e_6851cd96fc5483248d4677254be39128