### PR TITLE
docs(feed): 21825 document event feed sources

### DIFF
--- a/docs/feed_sources.md
+++ b/docs/feed_sources.md
@@ -1,0 +1,37 @@
+# Event Feed Sources
+
+The system ingests data from multiple providers. Each provider name reflects its origin or the organization maintaining the dataset.
+
+| Provider ID | Description |
+| ----------- | ----------- |
+| `hpSrvSearch` | Hazard search API of the Pacific Disaster Center |
+| `hpSrvMag` | Exposure information from PDC Hazard service |
+| `pdcSqs` | Real-time messages from PDC via AWS SQS |
+| `pdcMapSrv` | Exposure layers from PDC Map Service |
+| `pdcSqsNasa` | NASA related SQS messages from PDC |
+| `pdcMapSrvNasa` | NASA related layers from PDC Map Service |
+| `gdacsAlert` | Alerts from the Global Disaster Alert and Coordination System |
+| `gdacsAlertGeometry` | Geometry data for GDACS alerts |
+| `em-dat` | Historical events from the EM-DAT database |
+| `kontur.events` | Humanitarian crisis events maintained by Kontur |
+| `firms.modis-c6` | Wildfire detections from NASA MODIS |
+| `firms.suomi-npp-viirs-c2` | Wildfire detections from NASA Suomi NPP VIIRS |
+| `firms.noaa-20-viirs-c2` | Wildfire detections from NOAA-20 VIIRS |
+| `wildfire.calfire` | California wildfire feed |
+| `wildfire.inciweb` | InciWeb incidents feed |
+| `wildfire.perimeters.nifc` | Wildfire perimeters from NIFC |
+| `wildfire.locations.nifc` | Wildfire locations from NIFC |
+| `wildfire.frap.cal` | California FRAP wildfire history |
+| `wildfire.sa-gov` | Wildfire reports from South Australia government |
+| `wildfire.qld-des-gov` | Queensland Department of Environment data |
+| `wildfire.victoria-gov` | Victoria State wildfire feed |
+| `wildfire.nsw-gov` | New South Wales wildfire feed |
+| `tornado.canada-gov` | Tornado history from Government of Canada |
+| `tornado.australian-bm` | Tornado reports from Australian Bureau of Meteorology |
+| `tornado.osm-wiki` | Historical tornado data from OpenStreetMap wiki |
+| `tornado.des-inventar-sendai` | Disaster inventory data from DesInventar Sendai |
+| `tornado.japan-ma` | Tornado cases from the Japan Meteorological Agency |
+| `storms.noaa` | NOAA Storm Events Database |
+| `cyclones.nhc-at.noaa` | Atlantic cyclone advisories from NHC |
+| `cyclones.nhc-cp.noaa` | Central Pacific cyclone advisories from NHC |
+| `cyclones.nhc-ep.noaa` | Eastern Pacific cyclone advisories from NHC |

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -52,7 +52,7 @@ List of available feeds.
 | `feed_id` | `uuid` | primary key |
 | `description` | `text` | |
 | `alias` | `text` | unique identifier used in API |
-| `providers` | `text[]` | source providers associated with the feed |
+| `providers` | `text[]` | source providers associated with the feed. See [feed_sources.md](feed_sources.md) |
 | `roles` | `text[]` | roles allowed to read the feed |
 
 ## `feed_data`


### PR DESCRIPTION
## Summary
- list event feed providers and descriptions
- reference the new table from schema docs

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851ce6314c48324b94f76fe19ef4ea9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new document listing and describing all integrated event feed data providers.
  - Updated schema documentation to include a reference link to the new feed sources document for more information about data providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->