### PR TITLE
feat(api): add root ping endpoint

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -1,6 +1,11 @@
 # Event API Endpoints
 
-This document describes all available REST endpoints exposed by the application. All paths are prefixed with `/v1`.
+This document describes all available REST endpoints exposed by the application.
+
+## `GET /`
+Simple service check endpoint. Returns plain `OK` text.
+
+All paths below are prefixed with `/v1`.
 
 ## `GET /v1/`
 Search for events within a feed.

--- a/src/main/java/io/kontur/eventapi/resource/RootResource.java
+++ b/src/main/java/io/kontur/eventapi/resource/RootResource.java
@@ -1,0 +1,19 @@
+package io.kontur.eventapi.resource;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class RootResource {
+
+    @GetMapping(path = "/", produces = MediaType.TEXT_PLAIN_VALUE)
+    @Operation(tags = "Service", summary = "Simple service check")
+    @ApiResponse(responseCode = "200", description = "Service is up")
+    public ResponseEntity<String> index() {
+        return ResponseEntity.ok("OK");
+    }
+}

--- a/src/test/java/io/kontur/eventapi/resource/RootResourceTest.java
+++ b/src/test/java/io/kontur/eventapi/resource/RootResourceTest.java
@@ -1,0 +1,25 @@
+package io.kontur.eventapi.resource;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RootResourceTest {
+
+    private RootResource rootResource;
+
+    @BeforeEach
+    public void setUp() {
+        rootResource = new RootResource();
+    }
+
+    @Test
+    public void pingReturnsOk() {
+        ResponseEntity<String> resp = rootResource.index();
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+        assertEquals("OK", resp.getBody());
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple controller for `/` that returns `OK`
- document the new endpoint
- cover it with a unit test

Fibery task: https://kontur.fibery.io/Tasks/Task/14303

------
https://chatgpt.com/codex/tasks/task_e_6851ceb033208324b13a15efd63cdc0e