### PR TITLE
feat(api): 14477 add endpoint to fetch event episodes

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -37,5 +37,14 @@ Return a single event by feed alias, event ID and optional version. When the ver
 - `version` – event version number (optional).
 - `episodeFilterType` – `ANY`, `LATEST` or `NONE`.
 
+## `GET /v1/events/{feed}/{eventId}/episodes`
+Return all episodes of the specified event from the provided feed. Episodes are returned from the latest event version.
+
+**Path parameters**
+- `feed` – feed name.
+- `eventId` – event UUID.
+
+Responds with a JSON array of episodes or `204 No Content` if none found.
+
 ## `GET /v1/user_feeds`
 Return the list of feeds available for the authenticated user. The list is built from the roles present in the JWT token.

--- a/src/main/java/io/kontur/eventapi/dao/ApiDao.java
+++ b/src/main/java/io/kontur/eventapi/dao/ApiDao.java
@@ -26,9 +26,13 @@ public class ApiDao {
 		return mapper.getFeeds();
 	}
 
-	public Optional<String> findDataByObservationId(UUID observationId) {
-		return mapper.findDataByObservationId(observationId);
-	}
+        public Optional<String> findDataByObservationId(UUID observationId) {
+                return mapper.findDataByObservationId(observationId);
+        }
+
+        public Optional<String> getEpisodesByEventId(UUID eventId, String feedAlias) {
+                return mapper.getEpisodesByEventId(eventId, feedAlias);
+        }
 
 	public String searchForEvents(String feedAlias, List<EventType> eventTypes, OffsetDateTime from,
 	                                      OffsetDateTime to, OffsetDateTime updatedAfter, int limit,

--- a/src/main/java/io/kontur/eventapi/dao/mapper/ApiMapper.java
+++ b/src/main/java/io/kontur/eventapi/dao/mapper/ApiMapper.java
@@ -17,7 +17,10 @@ public interface ApiMapper {
 
 	List<FeedDto> getFeeds();
 
-	Optional<String> findDataByObservationId(@Param("observationId") UUID observationId);
+    Optional<String> findDataByObservationId(@Param("observationId") UUID observationId);
+
+    Optional<String> getEpisodesByEventId(@Param("eventId") UUID eventId,
+                                           @Param("feedAlias") String feedAlias);
 
 	String searchForEvents(@Param("feedAlias") String feedAlias,
 	                       @Param("eventTypes") List<EventType> eventTypes,

--- a/src/main/java/io/kontur/eventapi/resource/EventResource.java
+++ b/src/main/java/io/kontur/eventapi/resource/EventResource.java
@@ -258,6 +258,22 @@ public class EventResource {
                 .orElseGet(() -> ResponseEntity.noContent().build());
     }
 
+    @GetMapping(path = "/events/{feed}/{eventId}/episodes", produces = {MediaType.APPLICATION_JSON_VALUE})
+    @Operation(
+            tags = "Events",
+            summary = "Returns episodes for an event",
+            description = "Returns all episodes of the latest event version from the specified feed.")
+    @PreAuthorize("hasAuthority('read:feed:'+#feed)")
+    public ResponseEntity<String> getEventEpisodes(
+            @Parameter(description = "Feed name")
+            @PathVariable String feed,
+            @Parameter(description = "Event UUID")
+            @PathVariable UUID eventId) {
+        return eventResourceService.getEpisodesByEventId(eventId, feed)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.noContent().build());
+    }
+
 
     @GetMapping(path = "/user_feeds", produces = {MediaType.APPLICATION_JSON_VALUE})
     @Operation(

--- a/src/main/java/io/kontur/eventapi/service/EventResourceService.java
+++ b/src/main/java/io/kontur/eventapi/service/EventResourceService.java
@@ -36,6 +36,10 @@ public class EventResourceService {
         return apiDao.findDataByObservationId(observationId);
     }
 
+    public Optional<String> getEpisodesByEventId(UUID eventId, String feedAlias) {
+        return apiDao.getEpisodesByEventId(eventId, feedAlias);
+    }
+
     public boolean isCacheEnabled() {
         return !Arrays.asList(environment.getActiveProfiles()).contains("cacheDisabled");
     }

--- a/src/main/resources/db/mappers/ApiMapper.xml
+++ b/src/main/resources/db/mappers/ApiMapper.xml
@@ -7,6 +7,14 @@
         from feeds
     </select>
 
+    <select id="getEpisodesByEventId" resultType="java.lang.String">
+        select fd.episodes::text
+        from feed_data fd
+        where fd.event_id = #{eventId}
+          and fd.feed_id = (select feed_id from feeds where alias = #{feedAlias})
+          and fd.is_latest_version
+    </select>
+
     <select id="findDataByObservationId" resultType="java.lang.String">
         select data
         from data_lake

--- a/src/test/java/io/kontur/eventapi/resource/EventResourceTest.java
+++ b/src/test/java/io/kontur/eventapi/resource/EventResourceTest.java
@@ -16,6 +16,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -86,6 +87,26 @@ public class EventResourceTest {
         assertTrue(second.isPresent());
         assertEquals(SECOND_DESCRIPTION, second.get().getDescription());
 
+    }
+
+    @Test
+    public void getEventEpisodesReturnsData() {
+        UUID eventId = UUID.randomUUID();
+        when(apiDao.getEpisodesByEventId(eventId, FIRST_ALIAS)).thenReturn(Optional.of("[]"));
+
+        String body = eventResource.getEventEpisodes(FIRST_ALIAS, eventId).getBody();
+
+        assertEquals("[]", body);
+    }
+
+    @Test
+    public void getEventEpisodesNoContent() {
+        UUID eventId = UUID.randomUUID();
+        when(apiDao.getEpisodesByEventId(eventId, FIRST_ALIAS)).thenReturn(Optional.empty());
+
+        var response = eventResource.getEventEpisodes(FIRST_ALIAS, eventId);
+
+        assertEquals(204, response.getStatusCodeValue());
     }
 
     private void mockAuthWithRoles(List<String> roles) {


### PR DESCRIPTION
## Summary
- implement `/events/{feed}/{eventId}/episodes` endpoint
- support DAO and mapper methods for retrieving episodes
- document the new endpoint
- cover controller logic with unit tests

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.6.1)*

------
https://chatgpt.com/codex/tasks/task_e_6851cebf3a9c8324aa9e5bcfed1e3035