### PR TITLE
feat(gdacs): 7705 add history import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 #### Added
+- GDACS history import job
 
 #### Changed
 

--- a/src/main/java/io/kontur/eventapi/config/WorkerScheduler.java
+++ b/src/main/java/io/kontur/eventapi/config/WorkerScheduler.java
@@ -21,6 +21,7 @@ import io.kontur.eventapi.stormsnoaa.job.StormsNoaaImportJob;
 import io.kontur.eventapi.staticdata.job.StaticImportJob;
 import io.kontur.eventapi.emdat.jobs.EmDatImportJob;
 import io.kontur.eventapi.gdacs.job.GdacsSearchJob;
+import io.kontur.eventapi.gdacs.job.GdacsHistoryImportJob;
 import io.kontur.eventapi.pdc.job.HpSrvMagsJob;
 import io.kontur.eventapi.pdc.job.HpSrvSearchJob;
 import io.kontur.eventapi.tornadojapanma.job.HistoricalTornadoJapanMaImportJob;
@@ -36,6 +37,7 @@ public class WorkerScheduler {
     private final HpSrvSearchJob hpSrvSearchJob;
     private final HpSrvMagsJob hpSrvMagsJob;
     private final GdacsSearchJob gdacsSearchJob;
+    private final GdacsHistoryImportJob gdacsHistoryImportJob;
     private final FirmsImportModisJob firmsImportModisJob;
     private final FirmsImportNoaaJob firmsImportNoaaJob;
     private final FirmsImportSuomiJob firmsImportSuomiJob;
@@ -67,6 +69,8 @@ public class WorkerScheduler {
     private String hpSrvMagsImportEnabled;
     @Value("${scheduler.gdacsImport.enable}")
     private String gdacsImportEnabled;
+    @Value("${scheduler.gdacsHistoryImport.enable}")
+    private String gdacsHistoryImportEnabled;
     @Value("${scheduler.firmsModisImport.enable}")
     private String firmsModisImportEnabled;
     @Value("${scheduler.firmsNoaaImport.enable}")
@@ -116,7 +120,8 @@ public class WorkerScheduler {
 
 
     public WorkerScheduler(HpSrvSearchJob hpSrvSearchJob, HpSrvMagsJob hpSrvMagsJob,
-                           GdacsSearchJob gdacsSearchJob, NormalizationJob normalizationJob,
+                           GdacsSearchJob gdacsSearchJob, GdacsHistoryImportJob gdacsHistoryImportJob,
+                           NormalizationJob normalizationJob,
                            EventCombinationJob eventCombinationJob, FirmsEventCombinationJob firmsEventCombinationJob,
                            FeedCompositionJob feedCompositionJob, FirmsImportModisJob firmsImportModisJob,
                            FirmsImportNoaaJob firmsImportNoaaJob, FirmsImportSuomiJob firmsImportSuomiJob,
@@ -131,6 +136,7 @@ public class WorkerScheduler {
         this.hpSrvSearchJob = hpSrvSearchJob;
         this.hpSrvMagsJob = hpSrvMagsJob;
         this.gdacsSearchJob = gdacsSearchJob;
+        this.gdacsHistoryImportJob = gdacsHistoryImportJob;
         this.normalizationJob = normalizationJob;
         this.eventCombinationJob = eventCombinationJob;
         this.firmsEventCombinationJob = firmsEventCombinationJob;
@@ -188,6 +194,13 @@ public class WorkerScheduler {
     public void startGdacsImport() {
         if (Boolean.parseBoolean(gdacsImportEnabled)) {
             gdacsSearchJob.run();
+        }
+    }
+
+    @Scheduled(initialDelayString = "${scheduler.gdacsHistoryImport.initialDelay}", fixedDelay = Integer.MAX_VALUE)
+    public void startGdacsHistoryImport() {
+        if (Boolean.parseBoolean(gdacsHistoryImportEnabled)) {
+            gdacsHistoryImportJob.run();
         }
     }
 

--- a/src/main/java/io/kontur/eventapi/gdacs/job/GdacsHistoryImportJob.java
+++ b/src/main/java/io/kontur/eventapi/gdacs/job/GdacsHistoryImportJob.java
@@ -1,0 +1,30 @@
+package io.kontur.eventapi.gdacs.job;
+
+import io.kontur.eventapi.dao.DataLakeDao;
+import io.kontur.eventapi.gdacs.converter.GdacsAlertXmlParser;
+import io.kontur.eventapi.gdacs.service.GdacsService;
+import io.kontur.eventapi.cap.job.CapImportJob;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GdacsHistoryImportJob extends CapImportJob {
+
+    @Autowired
+    public GdacsHistoryImportJob(GdacsService gdacsService, GdacsAlertXmlParser gdacsAlertParser,
+                                 DataLakeDao dataLakeDao, MeterRegistry meterRegistry) {
+        super(gdacsService, gdacsAlertParser, dataLakeDao, meterRegistry,
+                null, null);
+    }
+
+    @Override
+    public String getName() {
+        return "gdacsHistoryImport";
+    }
+
+    @Override
+    protected String getProvider() {
+        return "GDACS";
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -112,6 +112,9 @@ scheduler:
   gdacsImport:
     enable: true
     cron: 0 1/5 * * * * # every five minutes after hh:01:00
+  gdacsHistoryImport:
+    enable: false
+    initialDelay: 1000
   firmsModisImport:
     enable: false
     initialDelay: 1000

--- a/src/test/java/io/kontur/eventapi/config/WorkerSchedulerTest.java
+++ b/src/test/java/io/kontur/eventapi/config/WorkerSchedulerTest.java
@@ -8,6 +8,7 @@ import io.kontur.eventapi.firms.jobs.FirmsImportModisJob;
 import io.kontur.eventapi.firms.jobs.FirmsImportNoaaJob;
 import io.kontur.eventapi.firms.jobs.FirmsImportSuomiJob;
 import io.kontur.eventapi.gdacs.job.GdacsSearchJob;
+import io.kontur.eventapi.gdacs.job.GdacsHistoryImportJob;
 import io.kontur.eventapi.inciweb.job.InciWebImportJob;
 import io.kontur.eventapi.job.EnrichmentJob;
 import io.kontur.eventapi.job.ReEnrichmentJob;
@@ -48,6 +49,7 @@ class WorkerSchedulerTest {
     private final EventCombinationJob eventCombinationJob = mock(EventCombinationJob.class);
     private final FeedCompositionJob feedCompositionJob = mock(FeedCompositionJob.class);
     private final GdacsSearchJob gdacsSearchJob = mock(GdacsSearchJob.class);
+    private final GdacsHistoryImportJob gdacsHistoryImportJob = mock(GdacsHistoryImportJob.class);
     private final FirmsImportModisJob firmsImportModisJob = mock(FirmsImportModisJob.class);
     private final FirmsImportNoaaJob firmsImportNoaaJob = mock(FirmsImportNoaaJob.class);
     private final FirmsImportSuomiJob firmsImportSuomiJob = mock(FirmsImportSuomiJob.class);
@@ -71,7 +73,7 @@ class WorkerSchedulerTest {
     private final ReEnrichmentJob reEnrichmentJob = mock(ReEnrichmentJob.class);
     private final EventExpirationJob eventExpirationJob = mock(EventExpirationJob.class);
 
-    private final WorkerScheduler scheduler = new WorkerScheduler(hpSrvSearchJob, hpSrvMagsJob, gdacsSearchJob, normalizationJob,
+    private final WorkerScheduler scheduler = new WorkerScheduler(hpSrvSearchJob, hpSrvMagsJob, gdacsSearchJob, gdacsHistoryImportJob, normalizationJob,
             eventCombinationJob, firmsEventCombinationJob, feedCompositionJob, firmsImportModisJob, firmsImportNoaaJob,
             firmsImportSuomiJob, emDatImportJob, staticImportJob, stormsNoaaImportJob, tornadoJapanMaImportJob,
             historicalTornadoJapanMaImportJob, pdcMapSrvSearchJobs, enrichmentJob, calFireSearchJob,
@@ -83,6 +85,7 @@ class WorkerSchedulerTest {
         Mockito.reset(hpSrvSearchJob);
         Mockito.reset(hpSrvMagsJob);
         Mockito.reset(gdacsSearchJob);
+        Mockito.reset(gdacsHistoryImportJob);
         Mockito.reset(firmsImportModisJob);
         Mockito.reset(firmsImportNoaaJob);
         Mockito.reset(firmsImportSuomiJob);
@@ -170,6 +173,22 @@ class WorkerSchedulerTest {
         scheduler.startGdacsImport();
 
         verify(gdacsSearchJob, times(1)).run();
+    }
+
+    @Test
+    public void startGdacsHistoryImportJob() {
+        ReflectionTestUtils.setField(scheduler, "gdacsHistoryImportEnabled", "true");
+        scheduler.startGdacsHistoryImport();
+
+        verify(gdacsHistoryImportJob, times(1)).run();
+    }
+
+    @Test
+    public void skipGdacsHistoryImportJob() {
+        ReflectionTestUtils.setField(scheduler, "gdacsHistoryImportEnabled", "false");
+        scheduler.startGdacsHistoryImport();
+
+        verify(gdacsHistoryImportJob, never()).run();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add GDACS history import job
- schedule the new job in WorkerScheduler
- expose scheduler config in `application.yml`
- test the scheduler behaviour

## Testing
- `mvn -q -Dtest=WorkerSchedulerTest test` *(fails: Could not transfer artifact spring-boot-starter-parent due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6851ceec205c832481422c72d8f6bf3d