### PR TITLE
feat(swagger): enable keycloak login

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -39,3 +39,8 @@ Return a single event by feed alias, event ID and optional version. When the ver
 
 ## `GET /v1/user_feeds`
 Return the list of feeds available for the authenticated user. The list is built from the roles present in the JWT token.
+
+## Swagger UI authentication
+The API documentation at `/doc` uses Swagger UI. It supports the OAuth2 `authorizationCode` flow
+with Keycloak. Use the **Authorize** button and sign in with your Keycloak account
+to obtain a token automatically.


### PR DESCRIPTION
## Summary
- support OAuth2 login flow in Swagger using Keycloak
- document how to use Keycloak login in Swagger UI

## Testing
- `mvn -q test` *(fails: Could not transfer artifact spring-boot-starter-parent because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6851cefb1b4083249af88b5c86c6ddce