### PR TITLE
feat: store normalized costs as json

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -39,7 +39,7 @@ Normalized information extracted from `data_lake`.
 | `source_updated_at` | `timestamptz`
 | `region` | `text`
 | `urls` | `text[]`
-| `cost` | `numeric`
+| `cost` | `jsonb` | provider specific cost information
 | `loss` | `jsonb`
 | `severity_data` | `jsonb`
 | `point` | `geometry`

--- a/src/main/java/io/kontur/eventapi/dao/mapper/NormalizedObservationsMapper.java
+++ b/src/main/java/io/kontur/eventapi/dao/mapper/NormalizedObservationsMapper.java
@@ -6,7 +6,6 @@ import io.kontur.eventapi.entity.Severity;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
-import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.*;
@@ -32,7 +31,7 @@ public interface NormalizedObservationsMapper {
                @Param("sourceUpdatedAt") OffsetDateTime sourceUpdatedAt,
                @Param("region") String region,
                @Param("urls") List<String> urls,
-               @Param("cost") BigDecimal cost,
+               @Param("cost") List<Map<String, Object>> cost,
                @Param("loss") Map<String, Object> loss,
                @Param("severityData") Map<String, Object> severityData,
                @Param("point") String point,

--- a/src/main/java/io/kontur/eventapi/emdat/normalization/EmDatNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/emdat/normalization/EmDatNormalizer.java
@@ -85,12 +85,33 @@ public class EmDatNormalizer extends Normalizer {
         obs.setName(makeName(csvData));
         obs.setProperName(csvData.get("Event Name"));
         obs.setRegion(csvData.get("ISO") + " " + csvData.get("Location"));
-        if (!StringUtils.isEmpty(csvData.get("Total Damages ('000 US$)"))) {
-            try {
-                obs.setCost(new BigDecimal(csvData.get("Total Damages ('000 US$)")).multiply(BigDecimal.valueOf(1000)));
-            } catch (NumberFormatException e) {
-                LOG.debug(String.format("'%s' for observation %s", e.getMessage(), obs.getObservationId()));
+        List<Map<String, Object>> costs = new ArrayList<>();
+        try {
+            String recon = csvData.get("Reconstruction Costs ('000 US$)");
+            if (StringUtils.isNotBlank(recon)) {
+                costs.add(Map.of("reconstruction_cost", new BigDecimal(recon).multiply(BigDecimal.valueOf(1000))));
             }
+        } catch (NumberFormatException e) {
+            LOG.debug("{} for observation {}", e.getMessage(), obs.getObservationId());
+        }
+        try {
+            String insured = csvData.get("Insured Damages ('000 US$)");
+            if (StringUtils.isNotBlank(insured)) {
+                costs.add(Map.of("insured_damages_cost", new BigDecimal(insured).multiply(BigDecimal.valueOf(1000))));
+            }
+        } catch (NumberFormatException e) {
+            LOG.debug("{} for observation {}", e.getMessage(), obs.getObservationId());
+        }
+        try {
+            String total = csvData.get("Total Damages ('000 US$)");
+            if (StringUtils.isNotBlank(total)) {
+                costs.add(Map.of("total_damage_cost", new BigDecimal(total).multiply(BigDecimal.valueOf(1000))));
+            }
+        } catch (NumberFormatException e) {
+            LOG.debug("{} for observation {}", e.getMessage(), obs.getObservationId());
+        }
+        if (!costs.isEmpty()) {
+            obs.setCost(costs);
         }
 
         Point point = null;

--- a/src/main/java/io/kontur/eventapi/entity/NormalizedObservation.java
+++ b/src/main/java/io/kontur/eventapi/entity/NormalizedObservation.java
@@ -3,7 +3,6 @@ package io.kontur.eventapi.entity;
 import lombok.Data;
 import org.wololo.geojson.FeatureCollection;
 
-import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.*;
 
@@ -28,7 +27,7 @@ public class NormalizedObservation {
     private OffsetDateTime sourceUpdatedAt;
     private String region;
     private List<String> urls = new ArrayList<>();
-    private BigDecimal cost;
+    private List<Map<String, Object>> cost;
     private Map<String, Object> loss = new HashMap<>();
     private Map<String, Object> severityData = new HashMap<>();
     private String point;

--- a/src/main/java/io/kontur/eventapi/nifc/normalization/LocationsNifcNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/nifc/normalization/LocationsNifcNormalizer.java
@@ -30,6 +30,11 @@ public class LocationsNifcNormalizer extends NifcNormalizer {
         Feature feature = readFeature(dataLakeDto.getData());
         Map<String, Object> props = feature.getProperties();
 
+        Double suppressionCost = readDouble(props, "EstimatedCostToDate");
+        if (suppressionCost != null) {
+            observation.setCost(List.of(Map.of("suppression_cost", suppressionCost)));
+        }
+
         observation.setGeometries(convertGeometryToFeatureCollection(feature.getGeometry(), LOCATIONS_PROPERTIES));
         observation.setDescription(readString(props, "IncidentShortDescription"));
 

--- a/src/main/java/io/kontur/eventapi/nifc/normalization/PerimetersNifcNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/nifc/normalization/PerimetersNifcNormalizer.java
@@ -29,6 +29,13 @@ public class PerimetersNifcNormalizer extends NifcNormalizer {
         Feature feature = readFeature(dataLakeDto.getData());
         Map<String, Object> props = feature.getProperties();
 
+        Double suppressionCost = selectFirstNotNull(
+                readDouble(props, "attr_EstimatedCostToDate"),
+                readDouble(props, "irwin_EstimatedCostToDate"));
+        if (suppressionCost != null) {
+            observation.setCost(List.of(Map.of("suppression_cost", suppressionCost)));
+        }
+
         observation.setGeometries(convertGeometryToFeatureCollection(feature.getGeometry(), PERIMETERS_PROPERTIES));
         observation.setDescription(selectFirstNotNull(
                 readString(props, "attr_IncidentShortDescription"),

--- a/src/main/java/io/kontur/eventapi/staticdata/normalization/CommonStaticNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/staticdata/normalization/CommonStaticNormalizer.java
@@ -41,7 +41,10 @@ public class CommonStaticNormalizer extends StaticNormalizer {
         normalizedObservation.setStartedAt(date);
         normalizedObservation.setEndedAt(date);
 
-        normalizedObservation.setCost(NumberUtils.createBigDecimal(readString(properties, "damage_property")));
+        String damage = readString(properties, "damage_property");
+        if (!damage.isEmpty()) {
+            normalizedObservation.setCost(List.of(Map.of("damage_property_cost", NumberUtils.createBigDecimal(damage))));
+        }
         normalizedObservation.setEventSeverity(convertFujitaScale(readString(properties, "fujita_scale")));
         normalizedObservation.setDescription(readString(properties, "comments"));
         normalizedObservation.setType(EventType.TORNADO);

--- a/src/main/java/io/kontur/eventapi/stormsnoaa/normalization/StormsNoaaNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/stormsnoaa/normalization/StormsNoaaNormalizer.java
@@ -133,12 +133,21 @@ public class StormsNoaaNormalizer extends Normalizer {
         normalizedObservation.setDescription(parseString(data, "EPISODE_NARRATIVE"));
         normalizedObservation.setEpisodeDescription(parseString(data, "EVENT_NARRATIVE"));
         BigDecimal propertyDamage = getCost(parseString(data, "DAMAGE_PROPERTY"));
-        normalizedObservation.setCost(propertyDamage);
+        BigDecimal cropsDamage = getCost(parseString(data, "DAMAGE_CROPS"));
+        List<Map<String, Object>> costs = new ArrayList<>();
+        if (propertyDamage != null) {
+            costs.add(Map.of("damage_property_cost", propertyDamage));
+        }
+        if (cropsDamage != null) {
+            costs.add(Map.of("damage_crops_cost", cropsDamage));
+        }
+        if (!costs.isEmpty()) {
+            normalizedObservation.setCost(costs);
+        }
         Map<String, Object> loss = new HashMap<>();
         if (propertyDamage != null) {
             loss.put(LossUtil.PROPERTY_DAMAGE, propertyDamage);
         }
-        BigDecimal cropsDamage = getCost(parseString(data, "DAMAGE_CROPS"));
         if (cropsDamage != null) {
             loss.put(LossUtil.CROPS_DAMAGE, cropsDamage);
         }

--- a/src/main/java/io/kontur/eventapi/typehandler/MapListTypeHandler.java
+++ b/src/main/java/io/kontur/eventapi/typehandler/MapListTypeHandler.java
@@ -1,0 +1,51 @@
+package io.kontur.eventapi.typehandler;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static io.kontur.eventapi.util.JsonUtil.readJson;
+import static io.kontur.eventapi.util.JsonUtil.writeJson;
+
+public class MapListTypeHandler extends BaseTypeHandler<List<Map<String, Object>>> {
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, List<Map<String, Object>> parameter, JdbcType jdbcType) throws SQLException {
+        ps.setObject(i, writeJson(parameter));
+    }
+
+    @Override
+    public List<Map<String, Object>> getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        String value = rs.getString(columnName);
+        if (StringUtils.isEmpty(value)) {
+            return Collections.emptyList();
+        }
+        return readJson(value, new TypeReference<>() {});
+    }
+
+    @Override
+    public List<Map<String, Object>> getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        String value = rs.getString(columnIndex);
+        if (StringUtils.isEmpty(value)) {
+            return Collections.emptyList();
+        }
+        return readJson(value, new TypeReference<>() {});
+    }
+
+    @Override
+    public List<Map<String, Object>> getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        String value = cs.getString(columnIndex);
+        if (StringUtils.isEmpty(value)) {
+            return Collections.emptyList();
+        }
+        return readJson(value, new TypeReference<>() {});
+    }
+}

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -70,3 +70,6 @@ databaseChangeLog:
 - include:
     relativeToChangelogFile: true
     file: v1.21.0/v1.21.0.yaml
+- include:
+    relativeToChangelogFile: true
+    file: v1.22.0/v1.22.0.yaml

--- a/src/main/resources/db/changelog/v1.22.0/alter-cost-column-type.sql
+++ b/src/main/resources/db/changelog/v1.22.0/alter-cost-column-type.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset event-api-migrations:v1.22.0/alter-cost-column-type.sql runOnChange:false
+
+alter table normalized_observations
+    alter column cost type jsonb using case when cost is null then null else to_jsonb(cost) end;

--- a/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
+++ b/src/main/resources/db/changelog/v1.22.0/v1.22.0.yaml
@@ -1,0 +1,4 @@
+databaseChangeLog:
+  - include:
+      relativeToChangelogFile: true
+      file: alter-cost-column-type.sql

--- a/src/main/resources/db/mappers/NormalizedObservationsMapper.xml
+++ b/src/main/resources/db/mappers/NormalizedObservationsMapper.xml
@@ -17,7 +17,7 @@
             #{observationId}, #{externalEventId}, #{externalEpisodeId}, #{provider}, #{origin}, #{name}, #{properName},
             #{description}, #{episodeDescription}, #{type}, #{eventSeverity}, #{active}, #{loadedAt}, #{startedAt},
             #{endedAt}, #{sourceUpdatedAt}, #{region}, #{urls, typeHandler=io.kontur.eventapi.typehandler.StringArrayTypeHandler},
-            #{cost},
+            #{cost,typeHandler=io.kontur.eventapi.typehandler.MapListTypeHandler}::jsonb,
             <if test='loss != null'>#{loss,typeHandler=io.kontur.eventapi.typehandler.MapTypeHandler}::jsonb,</if>
             <if test='severityData != null'>#{severityData,typeHandler=io.kontur.eventapi.typehandler.MapTypeHandler}::jsonb,</if>
             <if test='point != null'>'SRID=4326;${point}'::geometry,</if>
@@ -30,7 +30,7 @@
             episode_description = #{episodeDescription}, type = #{type}, event_severity = #{eventSeverity},
             active = #{active}, loaded_at = #{loadedAt}, started_at = #{startedAt}, ended_at = #{endedAt},
             source_updated_at = #{sourceUpdatedAt}, region = #{region},
-            urls = #{urls, typeHandler=io.kontur.eventapi.typehandler.StringArrayTypeHandler}, cost = #{cost},
+            urls = #{urls, typeHandler=io.kontur.eventapi.typehandler.StringArrayTypeHandler}, cost = #{cost,typeHandler=io.kontur.eventapi.typehandler.MapListTypeHandler}::jsonb,
             <if test='loss != null'>loss = #{loss,typeHandler=io.kontur.eventapi.typehandler.MapTypeHandler}::jsonb,</if>
             <if test='severityData != null'>severity_data = #{severityData,typeHandler=io.kontur.eventapi.typehandler.MapTypeHandler}::jsonb,</if>
             <if test='point != null'>point = 'SRID=4326;${point}'::geometry,</if>
@@ -133,7 +133,7 @@
         <result property="sourceUpdatedAt" column="source_updated_at"/>
         <result property="region" column="region"/>
         <result property="urls" column="urls" typeHandler="io.kontur.eventapi.typehandler.StringArrayTypeHandler"/>
-        <result property="cost" column="cost"/>
+        <result property="cost" column="cost" typeHandler="io.kontur.eventapi.typehandler.MapListTypeHandler"/>
         <result property="loss" column="loss" typeHandler="io.kontur.eventapi.typehandler.MapTypeHandler"/>
         <result property="severityData" column="severity_data" typeHandler="io.kontur.eventapi.typehandler.MapTypeHandler"/>
         <result property="point" column="point"/>

--- a/src/test/java/io/kontur/eventapi/nifc/normalization/LocationsNifcNormalizerTest.java
+++ b/src/test/java/io/kontur/eventapi/nifc/normalization/LocationsNifcNormalizerTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static io.kontur.eventapi.TestUtil.readFile;
@@ -43,7 +45,7 @@ class LocationsNifcNormalizerTest {
         assertEquals(getDateTimeFromMilli(1626488389000L), observation.getStartedAt());
         assertNull(observation.getEpisodeDescription());
         assertNull(observation.getActive());
-        assertNull(observation.getCost());
+        assertEquals(List.of(Map.of("suppression_cost", 23000000.0)), observation.getCost());
         assertNull(observation.getRegion());
         assertTrue(observation.getUrls().isEmpty());
         assertNull(observation.getExternalEpisodeId());

--- a/src/test/java/io/kontur/eventapi/nifc/normalization/PerimetersNifcNormalizerTest.java
+++ b/src/test/java/io/kontur/eventapi/nifc/normalization/PerimetersNifcNormalizerTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static io.kontur.eventapi.TestUtil.readFile;
@@ -43,7 +45,7 @@ class PerimetersNifcNormalizerTest {
         assertEquals(getDateTimeFromMilli(1637450954000L), observation.getStartedAt());
         assertNull(observation.getEpisodeDescription());
         assertNull(observation.getActive());
-        assertNull(observation.getCost());
+        assertEquals(List.of(Map.of("suppression_cost", 35000.0)), observation.getCost());
         assertNull(observation.getRegion());
         assertTrue(observation.getUrls().isEmpty());
         assertNull(observation.getExternalEpisodeId());

--- a/src/test/java/io/kontur/eventapi/staticdata/normalization/CommonStaticNormalizerIT.java
+++ b/src/test/java/io/kontur/eventapi/staticdata/normalization/CommonStaticNormalizerIT.java
@@ -13,6 +13,8 @@ import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static io.kontur.eventapi.staticdata.normalization.StaticNormalizer.TORNADO_PROPERTIES;
@@ -48,7 +50,7 @@ class CommonStaticNormalizerIT extends AbstractCleanableIntegrationTest {
         assertEquals(dataLake.getProvider(), normalizedObservation.getProvider());
         assertFalse(normalizedObservation.getActive());
         assertEquals("Tornado - Stratford, Canada", normalizedObservation.getName());
-        assertEquals(BigDecimal.valueOf(100), normalizedObservation.getCost());
+        assertEquals(List.of(Map.of("damage_property_cost", BigDecimal.valueOf(100))), normalizedObservation.getCost());
         assertEquals(Severity.MINOR, normalizedObservation.getEventSeverity());
         assertEquals("tornado", normalizedObservation.getDescription());
         assertEquals(EventType.TORNADO, normalizedObservation.getType());


### PR DESCRIPTION
## Summary
- support cost as JSON list
- add `MapListTypeHandler`
- alter `cost` column type via migration
- normalize costs from multiple providers
- document DB column type change

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68544f5de1b883248903fca2f1c052b9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced cost information is now available for observations, supporting multiple provider-specific cost components.
- **Bug Fixes**
  - Improved handling and display of complex cost data from various sources.
- **Documentation**
  - Updated schema documentation to reflect the new cost data structure.
- **Tests**
  - Updated tests to verify the new structured cost representation in observations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->