### PR TITLE
feat(swagger): enable Keycloak login

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -2,6 +2,12 @@
 
 This document describes all available REST endpoints exposed by the application. All paths are prefixed with `/v1`.
 
+## Authentication
+
+Swagger UI now integrates with Keycloak. Click **Authorize** and log in with your
+Kontur account. Once authorized, Swagger will automatically attach the acquired
+access token to your requests.
+
 ## `GET /v1/`
 Search for events within a feed.
 

--- a/src/main/java/io/kontur/eventapi/config/OpenApiConfiguration.java
+++ b/src/main/java/io/kontur/eventapi/config/OpenApiConfiguration.java
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.OAuthFlow;
+import io.swagger.v3.oas.models.security.OAuthFlows;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -35,16 +37,24 @@ public class OpenApiConfiguration {
         boolean isJwtAuthDisabledProfileActive = Arrays.asList(environment.getActiveProfiles()).contains("jwtAuthDisabled");
 
         if (!isJwtAuthDisabledProfileActive) {
-            String securitySchemeName = "bearerAuth";
+            String securitySchemeName = "oauth2";
+
+            String issuer = environment.getProperty(
+                    "spring.security.oauth2.resourceserver.jwt.issuer-uri", "");
+            issuer = issuer.endsWith("/") ? issuer.substring(0, issuer.length() - 1) : issuer;
+            String authUrl = issuer + "/protocol/openid-connect/auth";
+            String tokenUrl = issuer + "/protocol/openid-connect/token";
 
             openAPI.addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
                     .components(new Components()
                             .addSecuritySchemes(securitySchemeName,
                                     new SecurityScheme()
                                             .name(securitySchemeName)
-                                            .type(SecurityScheme.Type.HTTP)
-                                            .scheme("bearer")
-                                            .bearerFormat("JWT")));
+                                            .type(SecurityScheme.Type.OAUTH2)
+                                            .flows(new OAuthFlows()
+                                                    .authorizationCode(new OAuthFlow()
+                                                            .authorizationUrl(authUrl)
+                                                            .tokenUrl(tokenUrl))));
         }
 
         return openAPI;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -230,6 +230,10 @@ springdoc:
   swagger-ui:
     path: 'doc'
     disable-swagger-default-url: true
+    oauth2-redirect-url: '/events/doc/oauth2-redirect.html'
+    oauth:
+      client-id: event-api
+      use-pkce-with-authorization-code-grant: true
 
 aws:
   sqs:


### PR DESCRIPTION
## Summary
- configure Swagger UI oauth settings
- hook Swagger security scheme to Keycloak
- document authentication with Keycloak in endpoints docs

## Testing
- `mvn -q test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685456f92f2c8324be74cbb563fb5843

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added instructions for authenticating with Swagger UI using Keycloak and Kontur accounts.
- **New Features**
  - Integrated OAuth2 authorization code flow into Swagger UI for secure API access.
- **Chores**
  - Updated configuration to support OAuth2 authentication and PKCE in Swagger UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->