### PR TITLE
feat(merge): add cross-provider merge groundwork

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -58,3 +58,9 @@ Find events similar to the specified event. Similarity is determined by event ty
 
 ## `GET /v1/user_feeds`
 Returns the list of feeds available for the authenticated user. The list is built from the roles present in the JWT token and is cached for one hour to improve response time.
+
+## `GET /v1/merge_pair`
+Retrieve merge candidate pair for manual review. When `pairID` is omitted the next available pair is returned.
+
+**Parameters**
+- `pairID` – array with two external event IDs.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -89,6 +89,9 @@ Stores event versions for each feed. Table was redesigned in version 1.15.
 | `urls` | `text[]` |
 | `proper_name` | `text` |
 | `location` | `text` |
+| `external_event_ids` | `text[]` |
+| `providers` | `text[]` |
+| `merge_done` | `boolean` default `true` |
 | `collected_geometry` | `geometry` generated from episodes |
 
 Unique key: (`event_id`, `version`, `feed_id`). Several GIST and BTREE indexes exist for geometry and timestamps. An additional
@@ -122,3 +125,17 @@ Tracks current events per feed.
 | `actual` | `boolean` |
 
 Unique on (`feed_id`, `event_id`).
+
+## `merge_operations`
+Pairs of events suggested for manual merge.
+
+| Column | Type | Notes |
+| ------ | ---- | ----- |
+| `merge_operation_id` | `serial` | primary key |
+| `event_ids` | `text[]` | pair of external event IDs |
+| `confidence` | `double` | similarity score |
+| `approved` | `boolean` | decision flag |
+| `decision_made_by` | `text` | username of approver |
+| `executed` | `boolean` | whether merge was executed |
+| `decision_made_at` | `timestamptz` | when decision was saved |
+| `taken_to_merge_at` | `timestamptz` | when the pair was taken for merge |

--- a/src/main/java/io/kontur/eventapi/config/WorkerScheduler.java
+++ b/src/main/java/io/kontur/eventapi/config/WorkerScheduler.java
@@ -58,6 +58,7 @@ public class WorkerScheduler {
     private final HumanitarianCrisisImportJob humanitarianCrisisImportJob;
     private final MetricsJob metricsJob;
     private final ReEnrichmentJob reEnrichmentJob;
+    private final CrossProviderMergeJob crossProviderMergeJob;
     private final NhcAtImportJob nhcAtImportJob;
     private final NhcCpImportJob nhcCpImportJob;
     private final NhcEpImportJob nhcEpImportJob;
@@ -115,6 +116,8 @@ public class WorkerScheduler {
     private String reEnrichmentEnabled;
     @Value("${scheduler.eventExpiration.enable}")
     private String eventExpirationEnabled;
+    @Value("${scheduler.crossProviderMerge.enable}")
+    private String crossProviderMergeEnabled;
 
 
     public WorkerScheduler(HpSrvSearchJob hpSrvSearchJob, HpSrvMagsJob hpSrvMagsJob,
@@ -129,7 +132,8 @@ public class WorkerScheduler {
                            EnrichmentJob enrichmentJob, CalFireSearchJob calFireSearchJob, NifcImportJob nifcImportJob,
                            InciWebImportJob inciWebImportJob, HumanitarianCrisisImportJob humanitarianCrisisImportJob,
                            NhcAtImportJob nhcAtImportJob, NhcCpImportJob nhcCpImportJob, NhcEpImportJob nhcEpImportJob,
-                           MetricsJob metricsJob, ReEnrichmentJob reEnrichmentJob, EventExpirationJob eventExpirationJob) {
+                           MetricsJob metricsJob, ReEnrichmentJob reEnrichmentJob, EventExpirationJob eventExpirationJob,
+                           CrossProviderMergeJob crossProviderMergeJob) {
         this.hpSrvSearchJob = hpSrvSearchJob;
         this.hpSrvMagsJob = hpSrvMagsJob;
         this.gdacsSearchJob = gdacsSearchJob;
@@ -157,6 +161,7 @@ public class WorkerScheduler {
         this.reEnrichmentJob = reEnrichmentJob;
         this.humanitarianCrisisImportJob = humanitarianCrisisImportJob;
         this.eventExpirationJob = eventExpirationJob;
+        this.crossProviderMergeJob = crossProviderMergeJob;
     }
 
     @Scheduled(initialDelayString = "${scheduler.hpSrvImport.initialDelay}", fixedDelay = Integer.MAX_VALUE)
@@ -352,6 +357,13 @@ public class WorkerScheduler {
     public void startExpirationJob() {
         if (Boolean.parseBoolean(eventExpirationEnabled)) {
             eventExpirationJob.run();
+        }
+    }
+
+    @Scheduled(initialDelayString = "${scheduler.crossProviderMerge.initialDelay}", fixedDelayString = "${scheduler.crossProviderMerge.fixedDelay}")
+    public void startCrossProviderMergeJob() {
+        if (Boolean.parseBoolean(crossProviderMergeEnabled)) {
+            crossProviderMergeJob.run();
         }
     }
 }

--- a/src/main/java/io/kontur/eventapi/dao/MergeOperationsDao.java
+++ b/src/main/java/io/kontur/eventapi/dao/MergeOperationsDao.java
@@ -1,0 +1,31 @@
+package io.kontur.eventapi.dao;
+
+import io.kontur.eventapi.dao.mapper.MergeOperationsMapper;
+import io.kontur.eventapi.entity.MergeOperation;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+public class MergeOperationsDao {
+    private final MergeOperationsMapper mapper;
+
+    public MergeOperationsDao(MergeOperationsMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    public Optional<MergeOperation> getByEventIds(List<String> eventIds) {
+        return Optional.ofNullable(mapper.getByEventIds(eventIds));
+    }
+
+    @Transactional
+    public Optional<MergeOperation> takeNext() {
+        MergeOperation op = mapper.selectNext();
+        if (op != null) {
+            mapper.markTaken(op.getMergeOperationId());
+        }
+        return Optional.ofNullable(op);
+    }
+}

--- a/src/main/java/io/kontur/eventapi/dao/mapper/MergeOperationsMapper.java
+++ b/src/main/java/io/kontur/eventapi/dao/mapper/MergeOperationsMapper.java
@@ -1,0 +1,14 @@
+package io.kontur.eventapi.dao.mapper;
+
+import io.kontur.eventapi.entity.MergeOperation;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface MergeOperationsMapper {
+    MergeOperation getByEventIds(@Param("eventIds") List<String> eventIds);
+    MergeOperation selectNext();
+    void markTaken(@Param("id") Integer id);
+}

--- a/src/main/java/io/kontur/eventapi/entity/MergeOperation.java
+++ b/src/main/java/io/kontur/eventapi/entity/MergeOperation.java
@@ -1,0 +1,17 @@
+package io.kontur.eventapi.entity;
+
+import lombok.Data;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Data
+public class MergeOperation {
+    private Integer mergeOperationId;
+    private List<String> eventIds;
+    private Double confidence;
+    private Boolean approved;
+    private String decisionMadeBy;
+    private Boolean executed;
+    private OffsetDateTime decisionMadeAt;
+    private OffsetDateTime takenToMergeAt;
+}

--- a/src/main/java/io/kontur/eventapi/job/CrossProviderMergeJob.java
+++ b/src/main/java/io/kontur/eventapi/job/CrossProviderMergeJob.java
@@ -1,0 +1,26 @@
+package io.kontur.eventapi.job;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CrossProviderMergeJob extends AbstractJob {
+    private static final Logger LOG = LoggerFactory.getLogger(CrossProviderMergeJob.class);
+
+    public CrossProviderMergeJob(MeterRegistry meterRegistry) {
+        super(meterRegistry);
+    }
+
+    @Override
+    public void execute() {
+        LOG.debug("Cross provider merge job executed");
+        // TODO implement candidate search logic
+    }
+
+    @Override
+    public String getName() {
+        return "crossProviderMerge";
+    }
+}

--- a/src/main/java/io/kontur/eventapi/resource/MergePairResource.java
+++ b/src/main/java/io/kontur/eventapi/resource/MergePairResource.java
@@ -1,0 +1,31 @@
+package io.kontur.eventapi.resource;
+
+import io.kontur.eventapi.resource.dto.MergeCandidatePairDTO;
+import io.kontur.eventapi.service.MergePairService;
+import io.swagger.v3.oas.annotations.Hidden;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collections;
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1")
+@Hidden
+public class MergePairResource {
+    private final MergePairService service;
+
+    public MergePairResource(MergePairService service) {
+        this.service = service;
+    }
+
+    @GetMapping(path = "/merge_pair", produces = MediaType.APPLICATION_JSON_VALUE)
+    public List<MergeCandidatePairDTO> getMergePair(@RequestParam(value = "pairID", required = false) List<String> pairID) {
+        return pairID != null && pairID.size() == 2 ?
+                service.getPair(pairID).map(List::of).orElse(Collections.emptyList()) :
+                service.takeNextPair().map(List::of).orElse(Collections.emptyList());
+    }
+}

--- a/src/main/java/io/kontur/eventapi/resource/dto/EpisodeDto.java
+++ b/src/main/java/io/kontur/eventapi/resource/dto/EpisodeDto.java
@@ -1,0 +1,28 @@
+package io.kontur.eventapi.resource.dto;
+
+import io.kontur.eventapi.entity.EventType;
+import io.kontur.eventapi.entity.Severity;
+import lombok.Data;
+import java.time.OffsetDateTime;
+import java.util.*;
+import org.wololo.geojson.FeatureCollection;
+
+@Data
+public class EpisodeDto {
+    private String name;
+    private String properName;
+    private String description;
+    private EventType type;
+    private Severity severity;
+    private OffsetDateTime startedAt;
+    private OffsetDateTime endedAt;
+    private OffsetDateTime updatedAt;
+    private OffsetDateTime sourceUpdatedAt;
+    private String location;
+    private List<String> urls = new ArrayList<>();
+    private Map<String, Object> loss = new HashMap<>();
+    private Map<String, Object> severityData = new HashMap<>();
+    private Map<String, Object> episodeDetails;
+    private Set<UUID> observations = new HashSet<>();
+    private FeatureCollection geometries;
+}

--- a/src/main/java/io/kontur/eventapi/resource/dto/EventDto.java
+++ b/src/main/java/io/kontur/eventapi/resource/dto/EventDto.java
@@ -1,0 +1,35 @@
+package io.kontur.eventapi.resource.dto;
+
+import io.kontur.eventapi.entity.EventType;
+import io.kontur.eventapi.entity.Severity;
+import lombok.Data;
+import org.wololo.geojson.FeatureCollection;
+
+import java.time.OffsetDateTime;
+import java.util.*;
+
+@Data
+public class EventDto {
+    private UUID eventId;
+    private Long version;
+    private String name;
+    private String properName;
+    private String description;
+    private EventType type;
+    private Severity severity;
+    private Boolean active;
+    private OffsetDateTime startedAt;
+    private OffsetDateTime endedAt;
+    private OffsetDateTime updatedAt;
+    private String location;
+    private List<String> urls = new ArrayList<>();
+    private Map<String, Object> loss = new HashMap<>();
+    private Map<String, Object> severityData = new HashMap<>();
+    private Map<String, Object> eventDetails;
+    private Set<UUID> observations = new HashSet<>();
+    private FeatureCollection geometries;
+    private List<EpisodeDto> episodes = new ArrayList<>();
+    private List<Double> bbox = new ArrayList<>();
+    private List<Double> centroid = new ArrayList<>();
+    private int episodeCount;
+}

--- a/src/main/java/io/kontur/eventapi/resource/dto/MergeCandidatePairDTO.java
+++ b/src/main/java/io/kontur/eventapi/resource/dto/MergeCandidatePairDTO.java
@@ -1,0 +1,17 @@
+package io.kontur.eventapi.resource.dto;
+
+import lombok.Data;
+
+import java.time.OffsetDateTime;
+
+@Data
+public class MergeCandidatePairDTO {
+    private String eventId1;
+    private String eventId2;
+    private Double confidence;
+    private Boolean approved;
+    private String decisionMadeBy;
+    private OffsetDateTime decisionMadeAt;
+    private EventDto event1;
+    private EventDto event2;
+}

--- a/src/main/java/io/kontur/eventapi/service/MergePairService.java
+++ b/src/main/java/io/kontur/eventapi/service/MergePairService.java
@@ -1,0 +1,64 @@
+package io.kontur.eventapi.service;
+
+import io.kontur.eventapi.dao.ApiDao;
+import io.kontur.eventapi.dao.KonturEventsDao;
+import io.kontur.eventapi.dao.MergeOperationsDao;
+import io.kontur.eventapi.entity.MergeOperation;
+import io.kontur.eventapi.resource.dto.*;
+import io.kontur.eventapi.resource.dto.EpisodeDto;
+import io.kontur.eventapi.util.JsonUtil;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+public class MergePairService {
+    private final MergeOperationsDao operationsDao;
+    private final KonturEventsDao eventsDao;
+    private final ApiDao apiDao;
+
+    private static final String FEED_ALIAS = "test-cross-provider-merge";
+
+    public MergePairService(MergeOperationsDao operationsDao, KonturEventsDao eventsDao, ApiDao apiDao) {
+        this.operationsDao = operationsDao;
+        this.eventsDao = eventsDao;
+        this.apiDao = apiDao;
+    }
+
+    public Optional<MergeCandidatePairDTO> takeNextPair() {
+        return operationsDao.takeNext().flatMap(this::toDto);
+    }
+
+    public Optional<MergeCandidatePairDTO> getPair(List<String> pair) {
+        return operationsDao.getByEventIds(pair).flatMap(this::toDto);
+    }
+
+    private Optional<MergeCandidatePairDTO> toDto(MergeOperation op) {
+        if (op == null || op.getEventIds().size() != 2) {
+            return Optional.empty();
+        }
+        EventDto e1 = fetchEvent(op.getEventIds().get(0));
+        EventDto e2 = fetchEvent(op.getEventIds().get(1));
+        if (e1 == null || e2 == null) {
+            return Optional.empty();
+        }
+        MergeCandidatePairDTO dto = new MergeCandidatePairDTO();
+        dto.setEventId1(op.getEventIds().get(0));
+        dto.setEventId2(op.getEventIds().get(1));
+        dto.setConfidence(op.getConfidence());
+        dto.setApproved(op.getApproved());
+        dto.setDecisionMadeBy(op.getDecisionMadeBy());
+        dto.setDecisionMadeAt(op.getDecisionMadeAt());
+        dto.setEvent1(e1);
+        dto.setEvent2(e2);
+        return Optional.of(dto);
+    }
+
+    private EventDto fetchEvent(String externalId) {
+        return eventsDao.getEventByExternalId(externalId)
+                .flatMap(ev -> apiDao.getEventByEventIdAndByVersionOrLast(ev.getEventId(), FEED_ALIAS, null,
+                        EpisodeFilterType.ANY, GeometryFilterType.ANY))
+                .map(json -> JsonUtil.readJson(json, EventDto.class))
+                .orElse(null);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -210,6 +210,10 @@ scheduler:
     initialDelay: 1000
     fixedDelay: PT3H
 
+  crossProviderMerge:
+    enable: false
+    initialDelay: 1000
+    fixedDelay: 1000
 
 feign:
   client:

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -73,3 +73,6 @@ databaseChangeLog:
 - include:
     relativeToChangelogFile: true
     file: v1.22.0/v1.22.0.yaml
+- include:
+    relativeToChangelogFile: true
+    file: v1.23.0/v1.23.0.yaml

--- a/src/main/resources/db/changelog/v1.23.0/add-external-event-id-to-kontur-events.sql
+++ b/src/main/resources/db/changelog/v1.23.0/add-external-event-id-to-kontur-events.sql
@@ -1,0 +1,13 @@
+--liquibase formatted sql
+
+--changeset event-api-migrations:v1.23.0/add-external-event-id-to-kontur-events.sql runOnChange:false
+alter table kontur_events add column if not exists external_event_id text;
+create unique index if not exists kontur_events_event_external_id_idx
+    on kontur_events (event_id, external_event_id)
+    where external_event_id is not null;
+update kontur_events ke
+set external_event_id = no.external_event_id
+from normalized_observations no
+where ke.observation_id = no.observation_id
+  and no.provider in ('wildfire.calfire','wildfire.inciweb','wildfire.perimeters.nifc','wildfire.locations.nifc')
+  and ke.external_event_id is null;

--- a/src/main/resources/db/changelog/v1.23.0/add-external-ids-providers-to-feed-data.sql
+++ b/src/main/resources/db/changelog/v1.23.0/add-external-ids-providers-to-feed-data.sql
@@ -1,0 +1,18 @@
+--liquibase formatted sql
+
+--changeset event-api-migrations:v1.23.0/add-external-ids-providers-to-feed-data.sql runOnChange:false
+alter table feed_data
+    add column if not exists external_event_ids text[] default '{}',
+    add column if not exists providers text[] default '{}';
+update feed_data fd
+set external_event_ids = (select array_agg(distinct no.external_event_id)
+                          from normalized_observations no
+                          where no.observation_id = any(fd.observations))
+where fd.feed_id in (select feed_id from feeds where alias in ('wildfire.calfire','wildfire.inciweb','wildfire.perimeters.nifc','wildfire.locations.nifc'))
+  and (fd.external_event_ids = '{}' or fd.external_event_ids is null);
+update feed_data fd
+set providers = (select array_agg(distinct no.provider)
+                 from normalized_observations no
+                 where no.observation_id = any(fd.observations))
+where fd.feed_id in (select feed_id from feeds where alias in ('wildfire.calfire','wildfire.inciweb','wildfire.perimeters.nifc','wildfire.locations.nifc'))
+  and (fd.providers = '{}' or fd.providers is null);

--- a/src/main/resources/db/changelog/v1.23.0/add-merge-done-column.sql
+++ b/src/main/resources/db/changelog/v1.23.0/add-merge-done-column.sql
@@ -1,0 +1,4 @@
+--liquibase formatted sql
+
+--changeset event-api-migrations:v1.23.0/add-merge-done-column.sql runOnChange:false
+alter table feed_data add column if not exists merge_done boolean default true;

--- a/src/main/resources/db/changelog/v1.23.0/create-cross-merge-feed.sql
+++ b/src/main/resources/db/changelog/v1.23.0/create-cross-merge-feed.sql
@@ -1,0 +1,21 @@
+--liquibase formatted sql
+
+--changeset event-api-migrations:v1.23.0/create-cross-merge-feed.sql runOnChange:true
+insert into feeds (feed_id, alias, name, description, providers, enrichment, enrichment_postprocessors, enrichment_request)
+values (
+    uuid_generate_v4(),
+    'test-cross-provider-merge',
+    'Test Cross Provider Merge',
+    'The feed contains global data from multiple providers.',
+    '{"wildfire.inciweb","wildfire.perimeters.nifc","wildfire.locations.nifc","wildfire.calfire"}',
+    '{}',
+    '{}',
+    null
+);
+
+insert into feed_event_status (feed_id, event_id, actual)
+select distinct on (event_id) f.feed_id, ke.event_id, false
+from kontur_events ke
+join feeds f on f.alias = 'test-cross-provider-merge'
+where ke.provider in ('wildfire.inciweb','wildfire.perimeters.nifc','wildfire.locations.nifc','wildfire.calfire')
+on conflict do nothing;

--- a/src/main/resources/db/changelog/v1.23.0/create-merge-operations.sql
+++ b/src/main/resources/db/changelog/v1.23.0/create-merge-operations.sql
@@ -1,0 +1,16 @@
+--liquibase formatted sql
+
+--changeset event-api-migrations:v1.23.0/create-merge-operations.sql runOnChange:false
+create table if not exists merge_operations (
+    merge_operation_id serial primary key,
+    event_ids text[] not null,
+    confidence double precision not null,
+    approved boolean default false,
+    decision_made_by text,
+    executed boolean default false,
+    decision_made_at timestamp with time zone,
+    taken_to_merge_at timestamp with time zone
+);
+create unique index if not exists merge_operations_event_ids_idx on merge_operations (event_ids);
+create index if not exists merge_operations_taken_idx on merge_operations (taken_to_merge_at asc nulls first);
+create index if not exists merge_operations_approved_idx on merge_operations (approved, executed, decision_made_at asc);

--- a/src/main/resources/db/changelog/v1.23.0/v1.23.0.yaml
+++ b/src/main/resources/db/changelog/v1.23.0/v1.23.0.yaml
@@ -1,0 +1,16 @@
+databaseChangeLog:
+  - include:
+      relativeToChangelogFile: true
+      file: create-cross-merge-feed.sql
+  - include:
+      relativeToChangelogFile: true
+      file: add-merge-done-column.sql
+  - include:
+      relativeToChangelogFile: true
+      file: create-merge-operations.sql
+  - include:
+      relativeToChangelogFile: true
+      file: add-external-event-id-to-kontur-events.sql
+  - include:
+      relativeToChangelogFile: true
+      file: add-external-ids-providers-to-feed-data.sql

--- a/src/main/resources/db/mappers/MergeOperationsMapper.xml
+++ b/src/main/resources/db/mappers/MergeOperationsMapper.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.kontur.eventapi.dao.mapper.MergeOperationsMapper">
+
+    <select id="getByEventIds" resultMap="mergeOperationMap">
+        select * from merge_operations where event_ids = #{eventIds, typeHandler=io.kontur.eventapi.typehandler.StringArrayTypeHandler}
+    </select>
+
+    <select id="selectNext" resultMap="mergeOperationMap">
+        select * from merge_operations order by taken_to_merge_at asc nulls first limit 1
+    </select>
+
+    <update id="markTaken">
+        update merge_operations set taken_to_merge_at = now() where merge_operation_id = #{id}
+    </update>
+
+    <resultMap id="mergeOperationMap" type="io.kontur.eventapi.entity.MergeOperation">
+        <id property="mergeOperationId" column="merge_operation_id"/>
+        <result property="eventIds" column="event_ids" typeHandler="io.kontur.eventapi.typehandler.StringArrayTypeHandler"/>
+        <result property="confidence" column="confidence"/>
+        <result property="approved" column="approved"/>
+        <result property="decisionMadeBy" column="decision_made_by"/>
+        <result property="executed" column="executed"/>
+        <result property="decisionMadeAt" column="decision_made_at"/>
+        <result property="takenToMergeAt" column="taken_to_merge_at"/>
+    </resultMap>
+</mapper>


### PR DESCRIPTION
## Summary
- create base DB schema for cross-provider merge
- expose internal merge pair endpoint
- add skeleton job for future merge logic
- document new endpoint, table and columns

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685acf6a36ac83249b203eafb9c9bab2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new API endpoint to retrieve merge candidate pairs for manual review.
  - Added support for managing and tracking merge operations, including a new scheduled job for cross-provider merge tasks.
  - New data transfer objects (DTOs) for event and episode details, as well as merge candidate pairs.

- **Database**
  - Added new tables and columns to support merge operations and tracking.
  - Enhanced feed and event data with external IDs, providers, and merge status.
  - Introduced a new feed aggregating wildfire data from multiple providers.

- **Documentation**
  - Updated API and schema documentation to reflect new endpoints and database changes.

- **Configuration**
  - Added new scheduler settings for cross-provider merge operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->