### PR TITLE
Add USGS ShakeMap provider

### DIFF
--- a/docs/feed_sources.md
+++ b/docs/feed_sources.md
@@ -35,3 +35,4 @@ The system ingests data from multiple providers. Each provider name reflects its
 | `cyclones.nhc-at.noaa` | Atlantic cyclone advisories from NHC |
 | `cyclones.nhc-cp.noaa` | Central Pacific cyclone advisories from NHC |
 | `cyclones.nhc-ep.noaa` | Eastern Pacific cyclone advisories from NHC |
+| `earthquake.shakemap.usgs` | Earthquake ShakeMap data from USGS |

--- a/src/main/java/io/kontur/eventapi/usgs/client/UsgsClient.java
+++ b/src/main/java/io/kontur/eventapi/usgs/client/UsgsClient.java
@@ -1,0 +1,21 @@
+package io.kontur.eventapi.usgs.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(value = "usgsClient", url = "${usgs.host}")
+public interface UsgsClient {
+
+    @GetMapping("/fdsnws/event/1/query")
+    String getShakeMapEvents(@RequestParam("format") String format,
+                             @RequestParam("orderby") String orderby,
+                             @RequestParam("producttype") String productType,
+                             @RequestParam("limit") int limit,
+                             @RequestParam("minmagnitude") Double minMagnitude);
+
+    @GetMapping("/fdsnws/event/1/query")
+    String getEvent(@RequestParam("eventid") String eventId,
+                    @RequestParam("format") String format,
+                    @RequestParam("producttype") String productType);
+}

--- a/src/main/java/io/kontur/eventapi/usgs/converter/UsgsShakeMapDataLakeConverter.java
+++ b/src/main/java/io/kontur/eventapi/usgs/converter/UsgsShakeMapDataLakeConverter.java
@@ -1,0 +1,21 @@
+package io.kontur.eventapi.usgs.converter;
+
+import io.kontur.eventapi.entity.DataLake;
+import io.kontur.eventapi.util.DateTimeUtil;
+import org.springframework.stereotype.Component;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Component
+public class UsgsShakeMapDataLakeConverter {
+
+    public static final String USGS_SHAKEMAP_PROVIDER = "earthquake.shakemap.usgs";
+
+    public DataLake convertDataLake(String externalId, OffsetDateTime updatedAt, String data) {
+        DataLake dataLake = new DataLake(UUID.randomUUID(), externalId, updatedAt, DateTimeUtil.uniqueOffsetDateTime());
+        dataLake.setProvider(USGS_SHAKEMAP_PROVIDER);
+        dataLake.setData(data);
+        return dataLake;
+    }
+}

--- a/src/main/java/io/kontur/eventapi/usgs/job/UsgsShakeMapImportJob.java
+++ b/src/main/java/io/kontur/eventapi/usgs/job/UsgsShakeMapImportJob.java
@@ -1,0 +1,27 @@
+package io.kontur.eventapi.usgs.job;
+
+import io.kontur.eventapi.job.AbstractJob;
+import io.kontur.eventapi.usgs.service.UsgsShakeMapService;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UsgsShakeMapImportJob extends AbstractJob {
+
+    private final UsgsShakeMapService service;
+
+    public UsgsShakeMapImportJob(MeterRegistry meterRegistry, UsgsShakeMapService service) {
+        super(meterRegistry);
+        this.service = service;
+    }
+
+    @Override
+    public void execute() {
+        service.importLatestShakeMaps();
+    }
+
+    @Override
+    public String getName() {
+        return "usgsShakeMapImport";
+    }
+}

--- a/src/main/java/io/kontur/eventapi/usgs/normalization/UsgsShakeMapNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/usgs/normalization/UsgsShakeMapNormalizer.java
@@ -1,0 +1,81 @@
+package io.kontur.eventapi.usgs.normalization;
+
+import io.kontur.eventapi.entity.DataLake;
+import io.kontur.eventapi.entity.EventType;
+import io.kontur.eventapi.entity.NormalizedObservation;
+import io.kontur.eventapi.entity.Severity;
+import io.kontur.eventapi.normalization.Normalizer;
+import org.springframework.stereotype.Component;
+import org.wololo.geojson.Feature;
+import org.wololo.geojson.GeoJSONFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.kontur.eventapi.usgs.converter.UsgsShakeMapDataLakeConverter.USGS_SHAKEMAP_PROVIDER;
+import static io.kontur.eventapi.util.DateTimeUtil.getDateTimeFromMilli;
+import static io.kontur.eventapi.util.GeometryUtil.*;
+import static io.kontur.eventapi.util.SeverityUtil.*;
+
+@Component
+public class UsgsShakeMapNormalizer extends Normalizer {
+
+    private static final Map<String, Object> GEOMETRY_PROPERTIES = Map.of(
+            AREA_TYPE_PROPERTY, ALERT_AREA,
+            IS_OBSERVED_PROPERTY, true
+    );
+
+    @Override
+    public boolean isApplicable(DataLake dataLakeDto) {
+        return USGS_SHAKEMAP_PROVIDER.equals(dataLakeDto.getProvider());
+    }
+
+    @Override
+    public NormalizedObservation normalize(DataLake dataLakeDto) {
+        Feature feature = (Feature) GeoJSONFactory.create(dataLakeDto.getData());
+        Map<String, Object> props = feature.getProperties();
+
+        NormalizedObservation o = new NormalizedObservation();
+        o.setObservationId(dataLakeDto.getObservationId());
+        o.setProvider(dataLakeDto.getProvider());
+        o.setLoadedAt(dataLakeDto.getLoadedAt());
+        o.setSourceUpdatedAt(dataLakeDto.getUpdatedAt());
+        o.setExternalEventId(feature.getId());
+        o.setType(EventType.EARTHQUAKE);
+        o.setName(readString(props, "title"));
+        o.setDescription(readString(props, "place"));
+        o.setStartedAt(getDateTimeFromMilli(readLong(props, "time")));
+        o.setEndedAt(getDateTimeFromMilli(readLong(props, "updated")));
+        o.setGeometries(convertGeometryToFeatureCollection(feature.getGeometry(), GEOMETRY_PROPERTIES));
+
+        Double mag = readDouble(props, "mag");
+        Double depth = null;
+        if (feature.getGeometry() instanceof org.wololo.geojson.Point p && p.getCoordinates().length > 2) {
+            depth = p.getCoordinates()[2];
+        }
+        Map<String, Object> severityData = new HashMap<>();
+        if (mag != null) {
+            severityData.put(MAGNITUDE, mag);
+        }
+        if (depth != null) {
+            severityData.put(DEPTH_KM, depth);
+        }
+        o.setSeverityData(severityData);
+        o.setEventSeverity(calcSeverity(mag));
+        return o;
+    }
+
+    private Severity calcSeverity(Double mag) {
+        if (mag == null) {
+            return Severity.UNKNOWN;
+        } else if (mag < 5.0) {
+            return Severity.MINOR;
+        } else if (mag < 6.5) {
+            return Severity.MODERATE;
+        } else if (mag < 7.5) {
+            return Severity.SEVERE;
+        } else {
+            return Severity.EXTREME;
+        }
+    }
+}

--- a/src/main/java/io/kontur/eventapi/usgs/service/UsgsShakeMapService.java
+++ b/src/main/java/io/kontur/eventapi/usgs/service/UsgsShakeMapService.java
@@ -1,0 +1,52 @@
+package io.kontur.eventapi.usgs.service;
+
+import io.kontur.eventapi.dao.DataLakeDao;
+import io.kontur.eventapi.entity.DataLake;
+import io.kontur.eventapi.usgs.client.UsgsClient;
+import io.kontur.eventapi.usgs.converter.UsgsShakeMapDataLakeConverter;
+import org.springframework.stereotype.Service;
+import org.wololo.geojson.Feature;
+import org.wololo.geojson.FeatureCollection;
+import org.wololo.geojson.GeoJSONFactory;
+
+import java.time.OffsetDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static io.kontur.eventapi.usgs.converter.UsgsShakeMapDataLakeConverter.USGS_SHAKEMAP_PROVIDER;
+import static io.kontur.eventapi.util.DateTimeUtil.getDateTimeFromMilli;
+
+@Service
+public class UsgsShakeMapService {
+
+    private final UsgsClient client;
+    private final DataLakeDao dataLakeDao;
+    private final UsgsShakeMapDataLakeConverter converter;
+
+    public UsgsShakeMapService(UsgsClient client, DataLakeDao dataLakeDao, UsgsShakeMapDataLakeConverter converter) {
+        this.client = client;
+        this.dataLakeDao = dataLakeDao;
+        this.converter = converter;
+    }
+
+    public void importLatestShakeMaps() {
+        String feed = client.getShakeMapEvents("geojson", "time", "shakemap", 20, 4.5);
+        FeatureCollection fc = (FeatureCollection) GeoJSONFactory.create(feed);
+        Set<String> ids = Arrays.stream(fc.getFeatures()).map(Feature::getId).collect(Collectors.toSet());
+        Map<String, DataLake> exists = new HashMap<>();
+        dataLakeDao.getDataLakesByExternalIdsAndProvider(ids, USGS_SHAKEMAP_PROVIDER)
+                .forEach(dl -> exists.put(dl.getExternalId(), dl));
+        List<DataLake> toStore = new ArrayList<>();
+        for (Feature feature : fc.getFeatures()) {
+            String id = feature.getId();
+            if (exists.containsKey(id)) continue;
+            String detail = client.getEvent(id, "geojson", "shakemap");
+            OffsetDateTime updated = getDateTimeFromMilli(((Number) feature.getProperties().get("updated")).longValue());
+            DataLake dl = converter.convertDataLake(id, updated, detail);
+            toStore.add(dl);
+        }
+        if (!toStore.isEmpty()) {
+            dataLakeDao.storeDataLakes(toStore);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -91,6 +91,9 @@ inciweb:
 nhc:
   host: 'https://www.nhc.noaa.gov'
 
+usgs:
+  host: 'https://earthquake.usgs.gov'
+
 firms:
   host: 'https://firms.modaps.eosdis.nasa.gov/data/active_fire'
   modis: '/modis-c6.1/csv/MODIS_C6_1_Global_24h.csv'

--- a/src/test/java/io/kontur/eventapi/usgs/job/UsgsShakeMapImportJobTest.java
+++ b/src/test/java/io/kontur/eventapi/usgs/job/UsgsShakeMapImportJobTest.java
@@ -1,0 +1,54 @@
+package io.kontur.eventapi.usgs.job;
+
+import io.kontur.eventapi.dao.DataLakeDao;
+import io.kontur.eventapi.entity.DataLake;
+import io.kontur.eventapi.usgs.client.UsgsClient;
+import io.kontur.eventapi.usgs.converter.UsgsShakeMapDataLakeConverter;
+import io.kontur.eventapi.usgs.service.UsgsShakeMapService;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class UsgsShakeMapImportJobTest {
+
+    private final UsgsClient client = mock(UsgsClient.class);
+    private final DataLakeDao dataLakeDao = mock(DataLakeDao.class);
+    private final UsgsShakeMapDataLakeConverter converter = mock(UsgsShakeMapDataLakeConverter.class);
+    private final UsgsShakeMapService service = new UsgsShakeMapService(client, dataLakeDao, converter);
+    private final UsgsShakeMapImportJob job = new UsgsShakeMapImportJob(new SimpleMeterRegistry(), service);
+
+    @AfterEach
+    void resetMocks() {
+        reset(client, dataLakeDao, converter);
+    }
+
+    @Test
+    void testExecute() throws IOException {
+        String feed = readFile("UsgsShakeMapImportJob_Feed.json");
+        String detail = readFile("UsgsShakeMapImportJob_Detail.json");
+        when(client.getShakeMapEvents(anyString(), anyString(), anyString(), anyInt(), any())).thenReturn(feed);
+        when(client.getEvent(anyString(), anyString(), anyString())).thenReturn(detail);
+        when(dataLakeDao.getDataLakesByExternalIdsAndProvider(anySet(), anyString())).thenReturn(Collections.emptyList());
+        when(converter.convertDataLake(any(), any(), any())).thenReturn(new DataLake());
+
+        job.execute();
+
+        verify(client, times(1)).getShakeMapEvents("geojson", "time", "shakemap", 20, 4.5);
+        verify(client, times(1)).getEvent("test1", "geojson", "shakemap");
+        verify(dataLakeDao, times(1)).storeDataLakes(any());
+    }
+
+    private String readFile(String name) throws IOException {
+        return IOUtils.toString(this.getClass().getResourceAsStream(name), StandardCharsets.UTF_8);
+    }
+}

--- a/src/test/java/io/kontur/eventapi/usgs/normalization/UsgsShakeMapNormalizerTest.java
+++ b/src/test/java/io/kontur/eventapi/usgs/normalization/UsgsShakeMapNormalizerTest.java
@@ -1,0 +1,44 @@
+package io.kontur.eventapi.usgs.normalization;
+
+import io.kontur.eventapi.entity.DataLake;
+import io.kontur.eventapi.entity.EventType;
+import io.kontur.eventapi.entity.NormalizedObservation;
+import io.kontur.eventapi.entity.Severity;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import static io.kontur.eventapi.usgs.converter.UsgsShakeMapDataLakeConverter.USGS_SHAKEMAP_PROVIDER;
+import static org.junit.jupiter.api.Assertions.*;
+
+class UsgsShakeMapNormalizerTest {
+
+    private final UsgsShakeMapNormalizer normalizer = new UsgsShakeMapNormalizer();
+
+    @Test
+    void testNormalize() throws IOException {
+        DataLake dl = createDataLake();
+        NormalizedObservation o = normalizer.normalize(dl);
+
+        assertEquals(dl.getObservationId(), o.getObservationId());
+        assertEquals(EventType.EARTHQUAKE, o.getType());
+        assertEquals("test1", o.getExternalEventId());
+        assertEquals("M 5.5 - Test Place", o.getName());
+        assertEquals(Severity.MODERATE, o.getEventSeverity());
+        assertEquals(5.5, o.getSeverityData().get("magnitude"));
+        assertEquals(5.0, o.getSeverityData().get("depthKm"));
+        assertNotNull(o.getGeometries());
+    }
+
+    private DataLake createDataLake() throws IOException {
+        String data = IOUtils.toString(this.getClass().getResourceAsStream("UsgsShakeMapNormalizerTest.json"), StandardCharsets.UTF_8);
+        DataLake dl = new DataLake(UUID.randomUUID(), "test1", OffsetDateTime.now(), OffsetDateTime.now());
+        dl.setProvider(USGS_SHAKEMAP_PROVIDER);
+        dl.setData(data);
+        return dl;
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -44,6 +44,9 @@ inciweb:
 nhc:
   host: 'https://www.nhc.noaa.gov'
 
+usgs:
+  host: 'https://earthquake.usgs.gov'
+
 firms:
   host: 'https://firms.modaps.eosdis.nasa.gov/data/active_fire'
   modis: '/modis-c6.1/csv/MODIS_C6_1_Global_24h.csv'

--- a/src/test/resources/io/kontur/eventapi/usgs/job/UsgsShakeMapImportJob_Detail.json
+++ b/src/test/resources/io/kontur/eventapi/usgs/job/UsgsShakeMapImportJob_Detail.json
@@ -1,0 +1,18 @@
+{
+  "type": "Feature",
+  "properties": {
+    "mag": 5.5,
+    "place": "Test Place",
+    "time": 1620000000000,
+    "updated": 1620003600000,
+    "url": "http://example.com/event",
+    "code": "test1",
+    "title": "M 5.5 - Test Place",
+    "types": "origin,shakemap"
+  },
+  "geometry": {
+    "type": "Point",
+    "coordinates": [10.0, 20.0, 5.0]
+  },
+  "id": "test1"
+}

--- a/src/test/resources/io/kontur/eventapi/usgs/job/UsgsShakeMapImportJob_Feed.json
+++ b/src/test/resources/io/kontur/eventapi/usgs/job/UsgsShakeMapImportJob_Feed.json
@@ -1,0 +1,25 @@
+{
+  "type": "FeatureCollection",
+  "metadata": {
+    "generated": 1620000000000,
+    "title": "Test Feed"
+  },
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "mag": 5.5,
+        "place": "Test Place",
+        "time": 1620000000000,
+        "updated": 1620003600000,
+        "url": "http://example.com/event",
+        "code": "test1"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [10.0, 20.0, 5.0]
+      },
+      "id": "test1"
+    }
+  ]
+}

--- a/src/test/resources/io/kontur/eventapi/usgs/normalization/UsgsShakeMapNormalizerTest.json
+++ b/src/test/resources/io/kontur/eventapi/usgs/normalization/UsgsShakeMapNormalizerTest.json
@@ -1,0 +1,18 @@
+{
+  "type": "Feature",
+  "properties": {
+    "mag": 5.5,
+    "place": "Test Place",
+    "time": 1620000000000,
+    "updated": 1620003600000,
+    "url": "http://example.com/event",
+    "code": "test1",
+    "title": "M 5.5 - Test Place",
+    "types": "origin,shakemap"
+  },
+  "geometry": {
+    "type": "Point",
+    "coordinates": [10.0, 20.0, 5.0]
+  },
+  "id": "test1"
+}


### PR DESCRIPTION
## Summary
- ingest USGS ShakeMap events through new job and service
- normalize earthquake ShakeMap observations
- document new feed source
- add unit tests for job and normalizer
- configure USGS host

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM because of network issues)*

------
https://chatgpt.com/codex/tasks/task_e_685ad48fcf888324b5b70d4cf38dc2b3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Integrated support for importing and normalizing USGS ShakeMap earthquake data, enabling automatic retrieval and processing of recent earthquake events.
  - Added USGS ShakeMap as a documented event feed source.

- **Configuration**
  - Introduced new configuration options for specifying the USGS host URL.

- **Tests**
  - Added comprehensive tests for USGS ShakeMap import and normalization processes, including new test data files and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->