### PR TITLE
feat(feeddata): sort observations

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -82,8 +82,8 @@ Stores event versions for each feed. Table was redesigned in version 1.15.
 | `type` | `text` |
 | `name` | `text` |
 | `description` | `text` |
-| `episodes` | `jsonb` |
-| `observations` | `uuid[]` |
+| `episodes` | `jsonb` (observations inside each episode are ordered by observation date) |
+| `observations` | `uuid[]` sorted by observation date |
 | `event_details` | `jsonb` default `{}` |
 | `geometries` | `jsonb` |
 | `urls` | `text[]` |

--- a/src/main/java/io/kontur/eventapi/episodecomposition/EpisodeCombinator.java
+++ b/src/main/java/io/kontur/eventapi/episodecomposition/EpisodeCombinator.java
@@ -4,6 +4,7 @@ import static io.kontur.eventapi.entity.Severity.UNKNOWN;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
+import java.util.stream.Collectors;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import io.kontur.eventapi.entity.FeedData;
@@ -139,10 +140,12 @@ public abstract class EpisodeCombinator implements Applicable<NormalizedObservat
     }
 
     protected Set<UUID> mapObservationsToIDs(Set<NormalizedObservation> observations) {
+        // sort by observation date to ensure deterministic order for comparison
         return observations
                 .stream()
+                .sorted(comparing(NormalizedObservation::getSourceUpdatedAt))
                 .map(NormalizedObservation::getObservationId)
-                .collect(toSet());
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     protected Map<String, Object> findEpisodeLoss(Set<NormalizedObservation> episodeObservations) {

--- a/src/main/java/io/kontur/eventapi/job/FeedCompositionJob.java
+++ b/src/main/java/io/kontur/eventapi/job/FeedCompositionJob.java
@@ -28,6 +28,7 @@ import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.Comparator.*;
 import static java.util.stream.Collectors.toSet;
+import java.util.stream.Collectors;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 @Component
@@ -83,8 +84,12 @@ public class FeedCompositionJob extends AbstractJob {
             FeedData feedData = new FeedData(eventId, feed.getFeedId(),
                     lastFeedDataVersion.map(v -> v + 1).orElse(1L));
 
+            // sort observations by their timestamp for deterministic ordering in feed_data
             feedData.setObservations(
-                    eventObservations.stream().map(NormalizedObservation::getObservationId).collect(toSet()));
+                    eventObservations.stream()
+                            .sorted(comparing(NormalizedObservation::getSourceUpdatedAt))
+                            .map(NormalizedObservation::getObservationId)
+                            .collect(Collectors.toCollection(LinkedHashSet::new)));
             fillEpisodes(eventObservations, feedData);
             fillFeedData(feedData, eventObservations);
 


### PR DESCRIPTION
## Summary
- sort observations by observation date when creating `feed_data`
- keep order of observation IDs inside episodes
- document new deterministic order for observation UUID arrays

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6861a3f4e22c8324a2b595ce5a44c2a3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that observation IDs within episodes and feeds are consistently ordered by observation date for deterministic behavior.

* **Documentation**
  * Clarified in the documentation that episodes and observations are now explicitly ordered by observation date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->