### PR TITLE
fix(nifc): avoid duplicate episodes

### DIFF
--- a/src/main/java/io/kontur/eventapi/nifc/episodecomposition/NifcEpisodeCombinator.java
+++ b/src/main/java/io/kontur/eventapi/nifc/episodecomposition/NifcEpisodeCombinator.java
@@ -11,9 +11,12 @@ import org.wololo.geojson.FeatureCollection;
 
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
+import java.util.Objects;
 
 import static io.kontur.eventapi.nifc.converter.NifcDataLakeConverter.NIFC_LOCATIONS_PROVIDER;
 import static io.kontur.eventapi.nifc.converter.NifcDataLakeConverter.NIFC_PERIMETERS_PROVIDER;
+import static io.kontur.eventapi.util.GeometryUtil.isEqualGeometries;
 import static java.util.Collections.emptyList;
 
 @Component
@@ -30,13 +33,26 @@ public class NifcEpisodeCombinator extends WildfireEpisodeCombinator {
             return emptyList();
         }
         Set<NormalizedObservation> episodeObservations = findObservationsForEpisode(
-                eventObservations, observation.getSourceUpdatedAt(),0L, 0L);
+                eventObservations, observation.getSourceUpdatedAt(), 0L, 0L);
+
         NormalizedObservation latestObservation = findLatestEpisodeObservation(episodeObservations);
         FeedEpisode episode = createDefaultEpisode(latestObservation);
         episode.setStartedAt(findEpisodeStartedAt(episodeObservations));
         episode.setObservations(mapObservationsToIDs(episodeObservations));
         episode.setGeometries(computeEpisodeGeometries(episodeObservations));
         episode.setDescription(latestObservation.getDescription());
+
+        List<FeedEpisode> episodes = feedData.getEpisodes();
+        FeedEpisode lastEpisode = episodes.isEmpty() ? null : episodes.get(episodes.size() - 1);
+        if (lastEpisode != null && sameEpisodes(lastEpisode, episode)) {
+            lastEpisode.setEndedAt(episode.getEndedAt());
+            lastEpisode.setSourceUpdatedAt(episode.getSourceUpdatedAt());
+            lastEpisode.setUpdatedAt(episode.getUpdatedAt());
+            lastEpisode.addObservations(episode.getObservations());
+            lastEpisode.addUrlIfNotExists(episode.getUrls());
+            return emptyList();
+        }
+
         return List.of(episode);
     }
 
@@ -47,6 +63,14 @@ public class NifcEpisodeCombinator extends WildfireEpisodeCombinator {
                 .distinct()
                 .toArray(Feature[]::new);
         return new FeatureCollection(features);
+    }
+
+    private boolean sameEpisodes(FeedEpisode episode1, FeedEpisode episode2) {
+        return StringUtils.equalsIgnoreCase(episode1.getName(), episode2.getName())
+                && episode1.getLoss().equals(episode2.getLoss())
+                && episode1.getSeverity() == episode2.getSeverity()
+                && StringUtils.equalsIgnoreCase(episode1.getLocation(), episode2.getLocation())
+                && isEqualGeometries(episode1.getGeometries(), episode2.getGeometries());
     }
 
 }

--- a/src/test/java/io/kontur/eventapi/nifc/episodecomposition/NifcEpisodeCombinatorTest.java
+++ b/src/test/java/io/kontur/eventapi/nifc/episodecomposition/NifcEpisodeCombinatorTest.java
@@ -1,0 +1,59 @@
+package io.kontur.eventapi.nifc.episodecomposition;
+
+import io.kontur.eventapi.entity.FeedData;
+import io.kontur.eventapi.entity.FeedEpisode;
+import io.kontur.eventapi.entity.NormalizedObservation;
+import org.junit.jupiter.api.Test;
+import org.wololo.geojson.FeatureCollection;
+import org.wololo.geojson.GeoJSONFactory;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static io.kontur.eventapi.nifc.converter.NifcDataLakeConverter.NIFC_LOCATIONS_PROVIDER;
+import static org.junit.jupiter.api.Assertions.*;
+
+class NifcEpisodeCombinatorTest {
+
+    private final NifcEpisodeCombinator combinator = new NifcEpisodeCombinator();
+
+    @Test
+    void isApplicable() {
+        NormalizedObservation observation = new NormalizedObservation();
+        observation.setProvider(NIFC_LOCATIONS_PROVIDER);
+        assertTrue(combinator.isApplicable(observation));
+    }
+
+    @Test
+    void noDuplicateEpisodeWhenNothingChanged() {
+        NormalizedObservation obs1 = createObservation(OffsetDateTime.parse("2024-06-20T00:00:00Z"));
+        NormalizedObservation obs2 = createObservation(OffsetDateTime.parse("2024-06-21T00:00:00Z"));
+
+        FeedData feedData = new FeedData(UUID.randomUUID(), UUID.randomUUID(), 1L);
+        Set<NormalizedObservation> all = Set.of(obs1, obs2);
+
+        List<FeedEpisode> ep1 = combinator.processObservation(obs1, feedData, all);
+        feedData.getEpisodes().addAll(ep1);
+
+        List<FeedEpisode> ep2 = combinator.processObservation(obs2, feedData, all);
+        assertTrue(ep2.isEmpty());
+    }
+
+    private NormalizedObservation createObservation(OffsetDateTime updatedAt) {
+        NormalizedObservation obs = new NormalizedObservation();
+        obs.setObservationId(UUID.randomUUID());
+        obs.setProvider(NIFC_LOCATIONS_PROVIDER);
+        obs.setSourceUpdatedAt(updatedAt);
+        obs.setLoadedAt(updatedAt);
+        obs.setEndedAt(updatedAt);
+        obs.setStartedAt(updatedAt.minusHours(1));
+        obs.setName("Wildfire Test");
+        obs.setProperName("Test");
+        obs.setDescription("desc");
+        String geometry = "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[10,10]},\"properties\":{}}]}";
+        obs.setGeometries((FeatureCollection) GeoJSONFactory.create(geometry));
+        return obs;
+    }
+}


### PR DESCRIPTION
## Summary
- prevent duplicate NIFC episodes by comparing with the previous episode
- test NIFC episode combinator behaviour

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6861a40749bc8324bf36a0c0f288bc20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent duplicate episodes by merging equivalent incoming episodes into the previous entry — extends end/update times and combines observations and links instead of creating a new entry. Episodes are considered equivalent when names and locations match case-insensitively, loss and severity match, and geometries are equal.

* **Tests**
  * Added tests verifying combinator applicability and that no duplicate episodes are created when inputs differ only by timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->