### PR TITLE
feat(jtwc): add JTWC cyclone rss import

### DIFF
--- a/docs/feed_sources.md
+++ b/docs/feed_sources.md
@@ -35,3 +35,4 @@ The system ingests data from multiple providers. Each provider name reflects its
 | `cyclones.nhc-at.noaa` | Atlantic cyclone advisories from NHC |
 | `cyclones.nhc-cp.noaa` | Central Pacific cyclone advisories from NHC |
 | `cyclones.nhc-ep.noaa` | Eastern Pacific cyclone advisories from NHC |
+| `cyclones.jtwc` | Joint Typhoon Warning Center RSS feed |

--- a/src/main/java/io/kontur/eventapi/config/WorkerScheduler.java
+++ b/src/main/java/io/kontur/eventapi/config/WorkerScheduler.java
@@ -15,6 +15,7 @@ import io.kontur.eventapi.job.*;
 import io.kontur.eventapi.nhc.job.NhcAtImportJob;
 import io.kontur.eventapi.nhc.job.NhcCpImportJob;
 import io.kontur.eventapi.nhc.job.NhcEpImportJob;
+import io.kontur.eventapi.jtwc.job.JtwcImportJob;
 import io.kontur.eventapi.nifc.job.NifcImportJob;
 import io.kontur.eventapi.pdc.job.PdcMapSrvSearchJob;
 import io.kontur.eventapi.stormsnoaa.job.StormsNoaaImportJob;
@@ -61,6 +62,7 @@ public class WorkerScheduler {
     private final NhcAtImportJob nhcAtImportJob;
     private final NhcCpImportJob nhcCpImportJob;
     private final NhcEpImportJob nhcEpImportJob;
+    private final JtwcImportJob jtwcImportJob;
     private final EventExpirationJob eventExpirationJob;
 
     @Value("${scheduler.hpSrvImport.enable}")
@@ -109,6 +111,8 @@ public class WorkerScheduler {
     private String nhcCpEnabled;
     @Value("${scheduler.nhcEpImport.enable}")
     private String nhcEpEnabled;
+    @Value("${scheduler.jtwcImport.enable}")
+    private String jtwcImportEnabled;
     @Value("${scheduler.metrics.enable}")
     private String metricsEnabled;
     @Value("${scheduler.reEnrichment.enable}")
@@ -129,6 +133,7 @@ public class WorkerScheduler {
                            EnrichmentJob enrichmentJob, CalFireSearchJob calFireSearchJob, NifcImportJob nifcImportJob,
                            InciWebImportJob inciWebImportJob, HumanitarianCrisisImportJob humanitarianCrisisImportJob,
                            NhcAtImportJob nhcAtImportJob, NhcCpImportJob nhcCpImportJob, NhcEpImportJob nhcEpImportJob,
+                           JtwcImportJob jtwcImportJob,
                            MetricsJob metricsJob, ReEnrichmentJob reEnrichmentJob, EventExpirationJob eventExpirationJob) {
         this.hpSrvSearchJob = hpSrvSearchJob;
         this.hpSrvMagsJob = hpSrvMagsJob;
@@ -153,6 +158,7 @@ public class WorkerScheduler {
         this.nhcAtImportJob = nhcAtImportJob;
         this.nhcCpImportJob = nhcCpImportJob;
         this.nhcEpImportJob = nhcEpImportJob;
+        this.jtwcImportJob = jtwcImportJob;
         this.metricsJob = metricsJob;
         this.reEnrichmentJob = reEnrichmentJob;
         this.humanitarianCrisisImportJob = humanitarianCrisisImportJob;
@@ -296,6 +302,13 @@ public class WorkerScheduler {
     public void startNhcEpImport() {
         if (Boolean.parseBoolean(nhcEpEnabled)) {
             nhcEpImportJob.run();
+        }
+    }
+
+    @Scheduled(initialDelayString = "${scheduler.jtwcImport.initialDelay}", fixedDelayString = "${scheduler.jtwcImport.fixedDelay}")
+    public void startJtwcImport() {
+        if (Boolean.parseBoolean(jtwcImportEnabled)) {
+            jtwcImportJob.run();
         }
     }
 

--- a/src/main/java/io/kontur/eventapi/jtwc/JtwcUtil.java
+++ b/src/main/java/io/kontur/eventapi/jtwc/JtwcUtil.java
@@ -1,0 +1,8 @@
+package io.kontur.eventapi.jtwc;
+
+public final class JtwcUtil {
+
+    private JtwcUtil() {}
+
+    public static final String JTWC_PROVIDER = "cyclones.jtwc";
+}

--- a/src/main/java/io/kontur/eventapi/jtwc/job/JtwcImportJob.java
+++ b/src/main/java/io/kontur/eventapi/jtwc/job/JtwcImportJob.java
@@ -1,0 +1,33 @@
+package io.kontur.eventapi.jtwc.job;
+
+import io.kontur.eventapi.jtwc.parser.JtwcRssParser;
+import io.kontur.eventapi.jtwc.service.JtwcImportService;
+import io.kontur.eventapi.job.AbstractJob;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JtwcImportJob extends AbstractJob {
+
+    private final JtwcRssParser parser;
+    private final JtwcImportService service;
+
+    public JtwcImportJob(MeterRegistry meterRegistry, JtwcRssParser parser, JtwcImportService service) {
+        super(meterRegistry);
+        this.parser = parser;
+        this.service = service;
+    }
+
+    @Override
+    public String getName() {
+        return "jtwcImport";
+    }
+
+    @Override
+    public void execute() throws Exception {
+        for (JtwcRssParser.RssItem item : parser.parse()) {
+            String text = parser.loadText(item.link());
+            service.storeText(text, item.pubDate());
+        }
+    }
+}

--- a/src/main/java/io/kontur/eventapi/jtwc/parser/JtwcRssParser.java
+++ b/src/main/java/io/kontur/eventapi/jtwc/parser/JtwcRssParser.java
@@ -1,0 +1,70 @@
+package io.kontur.eventapi.jtwc.parser;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+@Component
+public class JtwcRssParser {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JtwcRssParser.class);
+
+    @Value("${jtwc.rss}")
+    private String rssUrl;
+
+    private static final DateTimeFormatter PUBDATE_FORMATTER =
+            DateTimeFormatter.ofPattern("EEE, dd MMM yy HH:mm:ss xx", Locale.ENGLISH);
+
+    private static final List<String> VALID_TITLES = List.of(
+            "Current Northwest Pacific/North Indian Ocean* Tropical Systems",
+            "Current Central/Eastern Pacific Tropical Systems",
+            "Current Southern Hemisphere Tropical Systems"
+    );
+
+    public List<RssItem> parse() {
+        List<RssItem> result = new ArrayList<>();
+        try {
+            Document doc = Jsoup.connect(rssUrl).get();
+            Elements items = doc.select("item");
+            for (Element item : items) {
+                String title = item.selectFirst("title").text();
+                if (!VALID_TITLES.contains(title)) {
+                    continue;
+                }
+                String description = item.selectFirst("description").text();
+                if (description.contains("No Current Tropical Cyclone Warnings.")) {
+                    continue;
+                }
+                String pubDateString = item.selectFirst("pubDate").text();
+                OffsetDateTime pubDate = OffsetDateTime.parse(pubDateString, PUBDATE_FORMATTER);
+                Document descDoc = Jsoup.parse(description);
+                Element link = descDoc.selectFirst("li > a:contains(TC Warning Text)");
+                if (link != null) {
+                    String href = link.attr("href");
+                    result.add(new RssItem(href, pubDate));
+                }
+            }
+        } catch (IOException e) {
+            LOG.warn("Failed to fetch JTWC RSS feed: {}", e.getMessage());
+        }
+        return result;
+    }
+
+    public String loadText(String url) throws IOException {
+        return Jsoup.connect(url).ignoreContentType(true).execute().body();
+    }
+
+    public record RssItem(String link, OffsetDateTime pubDate) {}
+}

--- a/src/main/java/io/kontur/eventapi/jtwc/service/JtwcImportService.java
+++ b/src/main/java/io/kontur/eventapi/jtwc/service/JtwcImportService.java
@@ -1,0 +1,42 @@
+package io.kontur.eventapi.jtwc.service;
+
+import io.kontur.eventapi.dao.DataLakeDao;
+import io.kontur.eventapi.entity.DataLake;
+import io.kontur.eventapi.jtwc.JtwcUtil;
+import io.kontur.eventapi.util.DateTimeUtil;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+@Service
+public class JtwcImportService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JtwcImportService.class);
+
+    private final DataLakeDao dataLakeDao;
+
+    public JtwcImportService(DataLakeDao dataLakeDao) {
+        this.dataLakeDao = dataLakeDao;
+    }
+
+    public void storeText(String text, OffsetDateTime updatedAt) {
+        String externalId = DigestUtils.md5Hex(text);
+        try {
+            if (dataLakeDao.isNewEvent(externalId, JtwcUtil.JTWC_PROVIDER,
+                    updatedAt.format(DateTimeFormatter.ISO_INSTANT))) {
+                DataLake dataLake = new DataLake(UUID.randomUUID(), externalId, updatedAt,
+                        DateTimeUtil.uniqueOffsetDateTime());
+                dataLake.setProvider(JtwcUtil.JTWC_PROVIDER);
+                dataLake.setData(text);
+                dataLakeDao.storeEventData(dataLake);
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to store JTWC record: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,6 +67,8 @@ emdat:
 
 stormsNoaa:
   host: 'https://www1.ncdc.noaa.gov/pub/data/swdi/stormevents/csvfiles/'
+jtwc:
+  rss: 'https://www.metoc.navy.mil/jtwc/rss/jtwc.rss'
 
 staticdata:
   s3Bucket: 'event-api-locker01'
@@ -167,6 +169,10 @@ scheduler:
     initialDelay: 1000
     fixedDelay: 1800000
   nhcEpImport:
+    enable: true
+    initialDelay: 1000
+    fixedDelay: 1800000
+  jtwcImport:
     enable: true
     initialDelay: 1000
     fixedDelay: 1800000

--- a/src/test/java/io/kontur/eventapi/jtwc/job/JtwcImportJobIT.java
+++ b/src/test/java/io/kontur/eventapi/jtwc/job/JtwcImportJobIT.java
@@ -1,0 +1,52 @@
+package io.kontur.eventapi.jtwc.job;
+
+import io.kontur.eventapi.dao.DataLakeDao;
+import io.kontur.eventapi.dao.FeedDao;
+import io.kontur.eventapi.entity.DataLake;
+import io.kontur.eventapi.jtwc.JtwcUtil;
+import io.kontur.eventapi.jtwc.parser.JtwcRssParser;
+import io.kontur.eventapi.test.AbstractCleanableIntegrationTest;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.isA;
+
+class JtwcImportJobIT extends AbstractCleanableIntegrationTest {
+
+    private final DataLakeDao dataLakeDao;
+    private final JtwcImportJob job;
+
+    @MockBean
+    private JtwcRssParser parser;
+
+    @Autowired
+    public JtwcImportJobIT(JdbcTemplate jdbcTemplate, DataLakeDao dataLakeDao,
+                           JtwcImportJob job, FeedDao feedDao) {
+        super(jdbcTemplate, feedDao);
+        this.dataLakeDao = dataLakeDao;
+        this.job = job;
+    }
+
+    @Test
+    public void testJtwcImportJobRun() throws Exception {
+        OffsetDateTime time = OffsetDateTime.now();
+        Mockito.when(parser.parse()).thenReturn(List.of(new JtwcRssParser.RssItem("https://example.com/test.txt", time)));
+        Mockito.when(parser.loadText(isA(String.class))).thenReturn("TEST DATA");
+        job.run();
+        List<DataLake> data = dataLakeDao.getDenormalizedEvents(List.of(JtwcUtil.JTWC_PROVIDER));
+        assertEquals(1, data.size());
+        DataLake dl = data.get(0);
+        assertEquals(time, dl.getUpdatedAt());
+        assertEquals(JtwcUtil.JTWC_PROVIDER, dl.getProvider());
+        assertEquals(DigestUtils.md5Hex("TEST DATA"), dl.getExternalId());
+        assertEquals("TEST DATA", dl.getData());
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -20,6 +20,8 @@ konturApps:
 
 stormsNoaa:
   host: 'https://www1.ncdc.noaa.gov/pub/data/swdi/stormevents/csvfiles/'
+jtwc:
+  rss: 'https://www.metoc.navy.mil/jtwc/rss/jtwc.rss'
 
 staticdata:
   s3Bucket: 'event-api-locker01'
@@ -120,6 +122,10 @@ scheduler:
     initialDelay: 999999
     fixedDelay: 999999
   nhcEpImport:
+    enable: false
+    initialDelay: 999999
+    fixedDelay: 999999
+  jtwcImport:
     enable: false
     initialDelay: 999999
     fixedDelay: 999999


### PR DESCRIPTION
## Summary
- add JTWC cyclone RSS importer
- schedule the JTWC import job
- document the new `cyclones.jtwc` provider

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6861a3e60ae48324aaf65b044022aae6