### PR TITLE
Fix enrichment latest version

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -103,6 +103,10 @@ Stores event versions for each feed. Table was redesigned in version 1.15.
 | `location` | `text` |
 | `collected_geometry` | `geometry` generated from episodes |
 
+`is_latest_version` becomes `true` only after the corresponding event version is
+successfully enriched. Until then the previous enriched version remains the
+latest for API queries.
+
 Unique key: (`event_id`, `version`, `feed_id`). Several GIST and BTREE indexes exist for geometry and timestamps. An additional
 index `feed_data_event_feed_latest_idx` on `(event_id, feed_id)` with condition `is_latest_version` speeds up retrieval of the
 latest event by its ID.

--- a/src/main/java/io/kontur/eventapi/dao/FeedDao.java
+++ b/src/main/java/io/kontur/eventapi/dao/FeedDao.java
@@ -46,9 +46,9 @@ public class FeedDao {
                 feedData.getAutoExpire(), feedData.getGeomFuncType());
 
         if (count > 0) {
-            mapper.markOutdatedEventsVersions(feedData.getEventId(), feedData.getFeedId(), feedData.getVersion());
             feedEventStatusDao.markAsActual(feedData.getFeedId(), feedData.getEventId(), true);
             if (feedData.getEnriched()) {
+                mapper.markEventVersionAsLatest(feedData.getEventId(), feedData.getFeedId(), feedData.getVersion());
                 cacheUtil.evictEventListCache(feed);
                 cacheUtil.evictEventCache(feedData.getEventId(), feed);
             }
@@ -73,6 +73,7 @@ public class FeedDao {
                 event.getName(), event.getEventDetails(), writeJson(event.getEpisodes()),
                 event.getEnriched(), event.getEnrichmentAttempts(), event.getEnrichmentSkipped());
         if (event.getEnriched()) {
+            mapper.markEventVersionAsLatest(event.getEventId(), event.getFeedId(), event.getVersion());
             cacheUtil.evictEventListCache(feed);
             cacheUtil.evictEventCache(event.getEventId(), feed);
         }

--- a/src/main/java/io/kontur/eventapi/dao/mapper/FeedMapper.java
+++ b/src/main/java/io/kontur/eventapi/dao/mapper/FeedMapper.java
@@ -44,6 +44,10 @@ public interface FeedMapper {
                                     @Param("feedId") UUID feedId,
                                     @Param("version") Long version);
 
+    void markEventVersionAsLatest(@Param("eventId") UUID eventId,
+                                  @Param("feedId") UUID feedId,
+                                  @Param("version") Long version);
+
     Optional<Long> getLastFeedDataVersion(@Param("eventId") UUID eventId,
                                           @Param("feedId") UUID feedId);
 

--- a/src/main/resources/db/mappers/FeedMapper.xml
+++ b/src/main/resources/db/mappers/FeedMapper.xml
@@ -20,7 +20,7 @@
                                active, started_at, ended_at, updated_at, location, urls,
                                <if test='loss != null'>loss,</if>
                                <if test='severityData != null'>severity_data,</if>
-                               observations, geometries, episodes, enriched, auto_expire)
+                               observations, geometries, episodes, enriched, auto_expire, is_latest_version)
         values (#{eventId}, #{feedId}, #{version}, #{name}, #{properName}, #{description}, #{type},
                 (select severity_id from severities where severity = #{severity}),
                 #{active}, #{startedAt}, #{endedAt}, #{updatedAt}, #{location},
@@ -36,7 +36,7 @@
                         collectEventGeometries(#{episodes}::jsonb),
                     </otherwise>
                 </choose>
-                #{episodes}::jsonb, #{enriched}, #{autoExpire})
+                #{episodes}::jsonb, #{enriched}, #{autoExpire}, #{enriched})
     </insert>
 
     <update id="markOutdatedEventsVersions">
@@ -47,6 +47,12 @@
                 and version < #{version}
                 and is_latest_version is true
         ]]>
+    </update>
+
+    <update id="markEventVersionAsLatest">
+        update feed_data
+        set is_latest_version = case when version = #{version} then true else false end
+        where event_id = #{eventId} and feed_id = #{feedId};
     </update>
 
     <select id="getLastFeedDataVersion" resultType="java.lang.Long">


### PR DESCRIPTION
## Summary
- mark events as latest only after enrichment finishes
- clarify is_latest_version in schema docs

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6861a42ba0a08324ba0aa64a01f072cf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that is_latest_version is set only after a version is successfully enriched; described uniqueness and indexing of feed data and behavior when out-of-order enrichments occur.

* **Bug Fixes**
  * Ensure enriched event versions are marked as the latest during data insertion and analytics processing so API queries return the correct latest enriched version.

* **Performance**
  * Added an index to speed retrieval of the latest event by ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->