### PR TITLE
feat(api): add actual filter and forecasted flag

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -24,6 +24,7 @@ Search for events within a feed.
 - `sortOrder` – `ASC` or `DESC` by `updatedAt`.
 - `episodeFilterType` – `ANY`, `LATEST` or `NONE`.
 - `geometryFilterType` – `ANY` or `NONE`.
+- `actual` – if `true`, return only events marked as actual.
 
 Returns events sorted by update date using cursor based pagination. Response body is JSON containing `pageMetadata.nextAfterValue` and event data.
 
@@ -31,6 +32,7 @@ Returns events sorted by update date using cursor based pagination. Response bod
 Same as the root `/v1/` endpoint but returns results as GeoJSON `FeatureCollection`.
 
 Additional optional parameter `access_token` can be passed for geojson visualisation services.
+All other parameters are the same as for `/v1/`. The `actual` flag can be used here as well.
 
 ## `GET /v1/observations/{observationId}`
 Return raw observation data by its UUID. Content type can be JSON, XML, CSV, or another one depending on the source.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -91,6 +91,8 @@ Stores event versions for each feed. Table was redesigned in version 1.15.
 | `location` | `text` |
 | `collected_geometry` | `geometry` generated from episodes |
 
+Each element in the `episodes` array includes a boolean `forecasted` flag.
+
 Unique key: (`event_id`, `version`, `feed_id`). Several GIST and BTREE indexes exist for geometry and timestamps. An additional
 index `feed_data_event_feed_latest_idx` on `(event_id, feed_id)` with condition `is_latest_version` speeds up retrieval of the
 latest event by its ID.

--- a/src/main/java/io/kontur/eventapi/dao/ApiDao.java
+++ b/src/main/java/io/kontur/eventapi/dao/ApiDao.java
@@ -34,33 +34,34 @@ public class ApiDao {
                                               OffsetDateTime to, OffsetDateTime updatedAfter, int limit,
                                               List<Severity> severities, SortOrder sortOrder, List<BigDecimal> bBox,
                                               EpisodeFilterType episodeFilterType,
-                                              GeometryFilterType geometryFilterType) {
+                                              GeometryFilterType geometryFilterType,
+                                              boolean actual) {
                 if (bBox != null) {
                         var xMin = bBox.get(0);
                         var yMin = bBox.get(1);
                         var xMax = bBox.get(2);
                         var yMax = bBox.get(3);
                         return mapper.searchForEvents(feedAlias, eventTypes, from, to, updatedAfter, limit, severities, sortOrder,
-                                        xMin, xMax, yMin, yMax, episodeFilterType, geometryFilterType);
+                                        xMin, xMax, yMin, yMax, episodeFilterType, geometryFilterType, actual);
                 }
                 return mapper.searchForEvents(feedAlias, eventTypes, from, to, updatedAfter, limit, severities, sortOrder,
-                                null, null, null, null, episodeFilterType, geometryFilterType);
+                                null, null, null, null, episodeFilterType, geometryFilterType, actual);
         }
 
-	public String searchForEventsGeoJson(String feedAlias, List<EventType> eventTypes, OffsetDateTime from,
-	                                            OffsetDateTime to, OffsetDateTime updatedAfter, int limit,
-	                                            List<Severity> severities, SortOrder sortOrder, List<BigDecimal> bBox,
-	                                            EpisodeFilterType episodeFilterType) {
+        public String searchForEventsGeoJson(String feedAlias, List<EventType> eventTypes, OffsetDateTime from,
+                                                    OffsetDateTime to, OffsetDateTime updatedAfter, int limit,
+                                                    List<Severity> severities, SortOrder sortOrder, List<BigDecimal> bBox,
+                                                    EpisodeFilterType episodeFilterType, boolean actual) {
 		if (bBox != null) {
 			var xMin = bBox.get(0);
 			var yMin = bBox.get(1);
 			var xMax = bBox.get(2);
 			var yMax = bBox.get(3);
-			return mapper.searchForEventsGeoJson(feedAlias, eventTypes, from, to, updatedAfter, limit, severities, sortOrder,
-					xMin, xMax, yMin, yMax, episodeFilterType);
+                        return mapper.searchForEventsGeoJson(feedAlias, eventTypes, from, to, updatedAfter, limit, severities, sortOrder,
+                                        xMin, xMax, yMin, yMax, episodeFilterType, actual);
 		}
-		return mapper.searchForEventsGeoJson(feedAlias, eventTypes, from, to, updatedAfter, limit, severities, sortOrder,
-				null, null, null, null, episodeFilterType);
+                return mapper.searchForEventsGeoJson(feedAlias, eventTypes, from, to, updatedAfter, limit, severities, sortOrder,
+                                null, null, null, null, episodeFilterType, actual);
 	}
 
     public Optional<String> getEventByEventIdAndByVersionOrLast(UUID eventId, String feed, Long version,

--- a/src/main/java/io/kontur/eventapi/dao/mapper/ApiMapper.java
+++ b/src/main/java/io/kontur/eventapi/dao/mapper/ApiMapper.java
@@ -33,7 +33,8 @@ public interface ApiMapper {
                                @Param("yMin") BigDecimal yMin,
                                @Param("yMax") BigDecimal yMax,
                                @Param("episodeFilterType") EpisodeFilterType episodeFilterType,
-                               @Param("geometryFilterType") GeometryFilterType geometryFilterType);
+                               @Param("geometryFilterType") GeometryFilterType geometryFilterType,
+                               @Param("actual") boolean actual);
 
 	String searchForEventsGeoJson(@Param("feedAlias") String feedAlias,
 	                              @Param("eventTypes") List<EventType> eventTypes,
@@ -46,8 +47,9 @@ public interface ApiMapper {
 	                              @Param("xMin") BigDecimal xMin,
 	                              @Param("xMax") BigDecimal xMax,
 	                              @Param("yMin") BigDecimal yMin,
-	                              @Param("yMax") BigDecimal yMax,
-	                              @Param("episodeFilterType") EpisodeFilterType episodeFilterType);
+                                      @Param("yMax") BigDecimal yMax,
+                                      @Param("episodeFilterType") EpisodeFilterType episodeFilterType,
+                                      @Param("actual") boolean actual);
 
     Optional<String> getEventByEventIdAndByVersionOrLast(@Param("eventId") UUID eventId,
                                                          @Param("feedAlias") String feedAlias,

--- a/src/main/java/io/kontur/eventapi/entity/FeedData.java
+++ b/src/main/java/io/kontur/eventapi/entity/FeedData.java
@@ -17,6 +17,10 @@ public class FeedData {
     private String description;
     private EventType type;
     private Severity severity;
+    /**
+     * True if the event is derived from forecast data only.
+     */
+    private Boolean forecasted;
     private Boolean active;
     private OffsetDateTime startedAt;
     private OffsetDateTime endedAt;

--- a/src/main/java/io/kontur/eventapi/entity/FeedEpisode.java
+++ b/src/main/java/io/kontur/eventapi/entity/FeedEpisode.java
@@ -17,6 +17,10 @@ public class FeedEpisode {
     private String description;
     private EventType type;
     private Severity severity;
+    /**
+     * Indicates that the episode was produced from forecast data rather than actual observations.
+     */
+    private Boolean forecasted;
     private OffsetDateTime startedAt;
     private OffsetDateTime endedAt;
     private OffsetDateTime updatedAt;

--- a/src/main/java/io/kontur/eventapi/resource/EventResource.java
+++ b/src/main/java/io/kontur/eventapi/resource/EventResource.java
@@ -116,11 +116,15 @@ public class EventResource {
                     "<ul><li>ANY - include geometries</li>" +
                     "<li>NONE - omit geometries</li></ul>")
             @RequestParam(value = "geometryFilterType", defaultValue = "ANY")
-            GeometryFilterType geometryFilterType) {
+            GeometryFilterType geometryFilterType,
+            @Parameter(description = "Return only events marked as actual")
+            @RequestParam(value = "actual", defaultValue = "false")
+            boolean actual) {
         Optional<String> dataOpt = eventResourceService.searchEvents(feed, eventTypes,
                 datetime != null && datetime.getFrom() != null ? datetime.getFrom() : null,
                 datetime != null && datetime.getTo() != null ? datetime.getTo() : null,
-                updatedAfter, limit, severities, sortOrder, bbox, episodeFilterType, geometryFilterType);
+                updatedAfter, limit, severities, sortOrder, bbox, episodeFilterType,
+                geometryFilterType, actual);
         if (dataOpt.isEmpty()) {
             return ResponseEntity.noContent().build();
         }
@@ -205,11 +209,14 @@ public class EventResource {
                     "<li>LATEST - the latest episode</li>" +
                     "<li>NONE - no episodes</li></ul>")
             @RequestParam(value = "episodeFilterType", defaultValue = "ANY")
-            EpisodeFilterType episodeFilterType) {
+            EpisodeFilterType episodeFilterType,
+            @Parameter(description = "Return only events marked as actual")
+            @RequestParam(value = "actual", defaultValue = "false")
+            boolean actual) {
         Optional<String> geoJsonOpt = eventResourceService.searchEventsGeoJson(feed, eventTypes,
                 datetime != null && datetime.getFrom() != null ? datetime.getFrom() : null,
                 datetime != null && datetime.getTo() != null ? datetime.getTo() : null,
-                updatedAfter, limit, severities, sortOrder, bbox, episodeFilterType);
+                updatedAfter, limit, severities, sortOrder, bbox, episodeFilterType, actual);
         if (geoJsonOpt.isEmpty()) {
             return ResponseEntity.noContent().build();
         }

--- a/src/main/java/io/kontur/eventapi/service/EventResourceService.java
+++ b/src/main/java/io/kontur/eventapi/service/EventResourceService.java
@@ -51,10 +51,11 @@ public class EventResourceService {
     public Optional<String> searchEvents(String feedAlias, List<EventType> eventTypes, OffsetDateTime from,
                                        OffsetDateTime to, OffsetDateTime updatedAfter, int limit,
                                        List<Severity> severities, SortOrder sortOrder, List<BigDecimal> bbox,
-                                       EpisodeFilterType episodeFilterType, GeometryFilterType geometryFilterType) {
+                                       EpisodeFilterType episodeFilterType, GeometryFilterType geometryFilterType,
+                                       boolean actual) {
         long start = System.currentTimeMillis();
         String data = apiDao.searchForEvents(feedAlias, eventTypes, from, to, updatedAfter,
-                limit, severities, sortOrder, bbox, episodeFilterType, geometryFilterType);
+                limit, severities, sortOrder, bbox, episodeFilterType, geometryFilterType, actual);
         long duration = System.currentTimeMillis() - start;
         logger.debug("searchEvents feed={} eventTypes={} bboxPresent={} duration={}ms",
                 feedAlias, eventTypes, bbox != null, duration);
@@ -70,10 +71,10 @@ public class EventResourceService {
     public Optional<String> searchEventsGeoJson(String feedAlias, List<EventType> eventTypes, OffsetDateTime from,
                                                 OffsetDateTime to, OffsetDateTime updatedAfter, int limit,
                                                 List<Severity> severities, SortOrder sortOrder, List<BigDecimal> bbox,
-                                                EpisodeFilterType episodeFilterType) {
+                                                EpisodeFilterType episodeFilterType, boolean actual) {
         long start = System.currentTimeMillis();
         String geoJson = apiDao.searchForEventsGeoJson(feedAlias, eventTypes, from, to,
-                updatedAfter, limit, severities, sortOrder, bbox, episodeFilterType);
+                updatedAfter, limit, severities, sortOrder, bbox, episodeFilterType, actual);
         long duration = System.currentTimeMillis() - start;
         logger.debug("searchEventsGeoJson feed={} eventTypes={} bboxPresent={} duration={}ms",
                 feedAlias, eventTypes, bbox != null, duration);

--- a/src/main/resources/db/mappers/ApiMapper.xml
+++ b/src/main/resources/db/mappers/ApiMapper.xml
@@ -94,6 +94,9 @@
                 </choose>
                 box2d(fd.collected_geometry) as bbox, st_pointonsurface(fd.collected_geometry) as centroid
             from feed_data fd
+            <if test='actual'>
+                inner join feed_event_status fes on fd.event_id = fes.event_id and fd.feed_id = fes.feed_id and fes.actual
+            </if>
             left join severities sv on fd.severity_id = sv.severity_id
             where fd.feed_id = ( select feed_id from feeds where alias = #{feedAlias} )
                 and fd.is_latest_version and fd.enriched
@@ -183,6 +186,9 @@
                 </choose>
                 box2d(fd.collected_geometry) as bbox, st_pointonsurface(fd.collected_geometry) as centroid
             from feed_data fd
+            <if test='actual'>
+                inner join feed_event_status fes on fd.event_id = fes.event_id and fd.feed_id = fes.feed_id and fes.actual
+            </if>
             left join severities sv on fd.severity_id = sv.severity_id
             where fd.event_id = #{eventId}
                 and fd.feed_id = ( select feed_id from feeds where alias = #{feedAlias} )


### PR DESCRIPTION
## Summary
- expose `forecasted` field for episodes and events
- allow filtering of only actual events via new request parameter
- document new API flag and JSON field

## Testing
- `mvn test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_6861a43a789c83249fa21036e609d5fc