### PR TITLE
feat(event-resource): 14730 add geometry filter to similar events endpoint

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -55,6 +55,7 @@ Find events similar to the specified event. Similarity is determined by event ty
 - `eventId` – reference event UUID (required).
 - `limit` – number of records to return. Default is `10`.
 - `distance` – search radius in meters. Default is `50000`.
+- `geometryFilterType` – `ANY` or `NONE`.
 
 ## `GET /v1/user_feeds`
 Returns the list of feeds available for the authenticated user. The list is built from the roles present in the JWT token and is cached for one hour to improve response time.

--- a/src/main/java/io/kontur/eventapi/dao/ApiDao.java
+++ b/src/main/java/io/kontur/eventapi/dao/ApiDao.java
@@ -69,7 +69,8 @@ public class ApiDao {
         return mapper.getEventByEventIdAndByVersionOrLast(eventId, feed, version, episodeFilterType, geometryFilterType);
     }
 
-    public String findSimilarEvents(UUID eventId, String feedAlias, int limit, double distance) {
-        return mapper.findSimilarEvents(eventId, feedAlias, limit, distance);
+    public String findSimilarEvents(UUID eventId, String feedAlias, int limit, double distance,
+                                   GeometryFilterType geometryFilterType) {
+        return mapper.findSimilarEvents(eventId, feedAlias, limit, distance, geometryFilterType);
     }
 }

--- a/src/main/java/io/kontur/eventapi/dao/mapper/ApiMapper.java
+++ b/src/main/java/io/kontur/eventapi/dao/mapper/ApiMapper.java
@@ -58,5 +58,6 @@ public interface ApiMapper {
     String findSimilarEvents(@Param("eventId") UUID eventId,
                              @Param("feedAlias") String feedAlias,
                              @Param("limit") int limit,
-                             @Param("distance") double distance);
+                             @Param("distance") double distance,
+                             @Param("geometryFilterType") GeometryFilterType geometryFilterType);
 }

--- a/src/main/java/io/kontur/eventapi/resource/EventResource.java
+++ b/src/main/java/io/kontur/eventapi/resource/EventResource.java
@@ -290,8 +290,13 @@ public class EventResource {
             int limit,
             @Parameter(description = "Search radius in meters", example = "50000")
             @RequestParam(value = "distance", defaultValue = "50000")
-            double distance) {
-        return eventResourceService.findSimilarEvents(eventId, feed, limit, distance)
+            double distance,
+            @Parameter(description = "How geometries should be returned: " +
+                    "<ul><li>ANY - include geometries</li>" +
+                    "<li>NONE - omit geometries</li></ul>")
+            @RequestParam(value = "geometryFilterType", defaultValue = "ANY")
+            GeometryFilterType geometryFilterType) {
+        return eventResourceService.findSimilarEvents(eventId, feed, limit, distance, geometryFilterType)
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.noContent().build());
     }

--- a/src/main/java/io/kontur/eventapi/service/EventResourceService.java
+++ b/src/main/java/io/kontur/eventapi/service/EventResourceService.java
@@ -80,8 +80,9 @@ public class EventResourceService {
         return geoJson == null ? Optional.empty() : Optional.of(geoJson);
     }
 
-    public Optional<String> findSimilarEvents(UUID eventId, String feedAlias, int limit, double distance) {
-        String data = apiDao.findSimilarEvents(eventId, feedAlias, limit, distance);
+    public Optional<String> findSimilarEvents(UUID eventId, String feedAlias, int limit, double distance,
+                                              GeometryFilterType geometryFilterType) {
+        String data = apiDao.findSimilarEvents(eventId, feedAlias, limit, distance, geometryFilterType);
         return data == null ? Optional.empty() : Optional.of(data);
     }
 }

--- a/src/main/resources/db/mappers/ApiMapper.xml
+++ b/src/main/resources/db/mappers/ApiMapper.xml
@@ -19,7 +19,11 @@
                 fd.event_id, fd.version, fd.name, fd.proper_name, fd.description, fd.type,
                 sv.severity, fd.active,
                 fd.started_at, fd.ended_at, fd.updated_at, fd.location, fd.urls,
-                fd.loss, fd.severity_data, fd.event_details, fd.observations, fd.geometries,
+                fd.loss, fd.severity_data, fd.event_details, fd.observations,
+                <choose>
+                    <when test='"NONE".equalsIgnoreCase(geometryFilterType)'>null as geometries,</when>
+                    <otherwise>fd.geometries,</otherwise>
+                </choose>
                 jsonb_array_length(fd.episodes) as episode_count,
                 fd.episodes,
                 box2d(fd.collected_geometry) as bbox,

--- a/src/test/java/io/kontur/eventapi/service/EventResourceServiceTest.java
+++ b/src/test/java/io/kontur/eventapi/service/EventResourceServiceTest.java
@@ -1,0 +1,31 @@
+package io.kontur.eventapi.service;
+
+import io.kontur.eventapi.dao.ApiDao;
+import io.kontur.eventapi.resource.dto.GeometryFilterType;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.Environment;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+public class EventResourceServiceTest {
+    @Test
+    public void findSimilarEventsDelegatesToDao() {
+        ApiDao apiDao = mock(ApiDao.class);
+        Environment env = mock(Environment.class);
+        EventResourceService service = new EventResourceService(apiDao, env);
+
+        UUID eventId = UUID.randomUUID();
+        String feed = "test";
+        when(apiDao.findSimilarEvents(eventId, feed, 5, 10.0, GeometryFilterType.NONE))
+                .thenReturn("{}");
+
+        Optional<String> result = service.findSimilarEvents(eventId, feed, 5, 10.0, GeometryFilterType.NONE);
+
+        verify(apiDao, times(1)).findSimilarEvents(eventId, feed, 5, 10.0, GeometryFilterType.NONE);
+        assertTrue(result.isPresent());
+    }
+}


### PR DESCRIPTION
## Summary
- add `geometryFilterType` option for the similar events endpoint
- propagate new flag through service and DAO
- document geometry filter in API docs
- test service to verify flag is passed

Refs: [Task](https://kontur.fibery.io/Tasks/Task/14730)


------
https://chatgpt.com/codex/tasks/task_e_6861a47043ec83249805985b365c131c