### PR TITLE
feat(normalization): split providers into groups

### DIFF
--- a/src/main/java/io/kontur/eventapi/config/WorkerScheduler.java
+++ b/src/main/java/io/kontur/eventapi/config/WorkerScheduler.java
@@ -2,6 +2,7 @@ package io.kontur.eventapi.config;
 
 import static io.kontur.eventapi.entity.PdcMapSrvSearchJobs.PDC_MAP_SRV_IDS;
 
+import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 
 import io.kontur.eventapi.calfire.job.CalFireSearchJob;
@@ -81,6 +82,10 @@ public class WorkerScheduler {
     private String firmsSuomiImportEnabled;
     @Value("${scheduler.normalization.enable}")
     private String normalizationEnabled;
+    @Value("${scheduler.normalization.providersGroup1}")
+    private String[] normalizationProvidersGroup1;
+    @Value("${scheduler.normalization.providersGroup2}")
+    private String[] normalizationProvidersGroup2;
     @Value("${scheduler.eventCombination.enable}")
     private String eventCombinationEnabled;
     @Value("${scheduler.feedComposition.enable}")
@@ -319,7 +324,12 @@ public class WorkerScheduler {
     @Scheduled(initialDelayString = "${scheduler.normalization.initialDelay}", fixedDelayString = "${scheduler.normalization.fixedDelay}")
     public void startNormalization() {
         if (Boolean.parseBoolean(normalizationEnabled)) {
-            normalizationJob.run();
+            if (normalizationProvidersGroup1.length > 0) {
+                normalizationJob.run(Arrays.asList(normalizationProvidersGroup1));
+            }
+            if (normalizationProvidersGroup2.length > 0) {
+                normalizationJob.run(Arrays.asList(normalizationProvidersGroup2));
+            }
         }
     }
 

--- a/src/main/java/io/kontur/eventapi/job/NormalizationJob.java
+++ b/src/main/java/io/kontur/eventapi/job/NormalizationJob.java
@@ -10,11 +10,9 @@ import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 
-import java.util.Arrays;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -28,8 +26,7 @@ public class NormalizationJob extends AbstractJob {
     private final DataLakeDao dataLakeDao;
     private final NormalizedObservationsDao normalizedObservationsDao;
 
-    @Value("${scheduler.normalization.providers}")
-    private String[] providers;
+    private List<String> providers = List.of();
 
     public NormalizationJob(List<Normalizer> normalizers, DataLakeDao dataLakeDao,
                             NormalizedObservationsDao normalizedObservationsDao, MeterRegistry meterRegistry) {
@@ -39,9 +36,14 @@ public class NormalizationJob extends AbstractJob {
         this.normalizedObservationsDao = normalizedObservationsDao;
     }
 
+    public void run(List<String> providers) {
+        this.providers = providers;
+        super.run();
+    }
+
     @Override
     public void execute() {
-        List<DataLake> dataLakes = dataLakeDao.getDenormalizedEvents(Arrays.asList(providers));
+        List<DataLake> dataLakes = dataLakeDao.getDenormalizedEvents(providers);
         if (!CollectionUtils.isEmpty(dataLakes)) {
             LOG.info("Normalization processing: {} data lakes", dataLakes.size());
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -181,11 +181,12 @@ scheduler:
     enable: true
     initialDelay: 1000
     fixedDelay: 1000
-    providers: gdacsAlert, gdacsAlertGeometry, kontur.events, em-dat, tornado.canada-gov,
+    providersGroup1: gdacsAlert, gdacsAlertGeometry, kontur.events, em-dat, tornado.canada-gov,
       tornado.australian-bm, tornado.osm-wiki, tornado.des-inventar-sendai, storms.noaa, wildfire.frap.cal,
       wildfire.sa-gov, wildfire.qld-des-gov, wildfire.victoria-gov, wildfire.nsw-gov, wildfire.calfire,
       wildfire.perimeters.nifc, wildfire.locations.nifc, cyclones.nhc-at.noaa, cyclones.nhc-ep.noaa, cyclones.nhc-cp.noaa,
       pdcSqs, pdcMapSrv, pdcSqsNasa, pdcMapSrvNasa, usgs.earthquake
+    providersGroup2: firms.modis-c6, firms.suomi-npp-viirs-c2, firms.noaa-20-viirs-c2
   eventCombination:
     enable: true
     initialDelay: 1000

--- a/src/test/java/io/kontur/eventapi/config/WorkerSchedulerTest.java
+++ b/src/test/java/io/kontur/eventapi/config/WorkerSchedulerTest.java
@@ -269,17 +269,21 @@ class WorkerSchedulerTest {
     @Test
     public void startNormalizationJob() {
         ReflectionTestUtils.setField(scheduler, "normalizationEnabled", "true");
+        ReflectionTestUtils.setField(scheduler, "normalizationProvidersGroup1", new String[]{"p1"});
+        ReflectionTestUtils.setField(scheduler, "normalizationProvidersGroup2", new String[]{"p2"});
         scheduler.startNormalization();
 
-        verify(normalizationJob, times(1)).run();
+        verify(normalizationJob, times(2)).run(anyList());
     }
 
     @Test
     public void skipNormalizationJob() {
         ReflectionTestUtils.setField(scheduler, "normalizationEnabled", "false");
+        ReflectionTestUtils.setField(scheduler, "normalizationProvidersGroup1", new String[]{"p1"});
+        ReflectionTestUtils.setField(scheduler, "normalizationProvidersGroup2", new String[]{"p2"});
         scheduler.startNormalization();
 
-        verify(normalizationJob, never()).run();
+        verify(normalizationJob, never()).run(anyList());
     }
 
     @Test

--- a/src/test/java/io/kontur/eventapi/firms/event/FirmsEventAndEpisodeCombinationsJobIT.java
+++ b/src/test/java/io/kontur/eventapi/firms/event/FirmsEventAndEpisodeCombinationsJobIT.java
@@ -16,6 +16,7 @@ import io.kontur.eventapi.firms.jobs.FirmsImportModisJob;
 import io.kontur.eventapi.firms.jobs.FirmsImportNoaaJob;
 import io.kontur.eventapi.firms.jobs.FirmsImportSuomiJob;
 import io.kontur.eventapi.job.NormalizationJob;
+import io.kontur.eventapi.firms.FirmsUtil;
 import io.kontur.eventapi.resource.dto.TestEpisodeDto;
 import io.kontur.eventapi.resource.dto.TestEventDto;
 import io.kontur.eventapi.test.AbstractCleanableIntegrationTest;
@@ -100,7 +101,7 @@ public class FirmsEventAndEpisodeCombinationsJobIT extends AbstractCleanableInte
         firmsImportModisJob.run();
         firmsImportNoaaJob.run();
         firmsImportSuomiJob.run();
-        normalizationJob.run();
+        normalizationJob.run(FirmsUtil.FIRMS_PROVIDERS);
         eventCombinationJob.run();
 
         //THEN
@@ -137,7 +138,7 @@ public class FirmsEventAndEpisodeCombinationsJobIT extends AbstractCleanableInte
         firmsImportModisJob.run();
         firmsImportNoaaJob.run();
         firmsImportSuomiJob.run();
-        normalizationJob.run();
+        normalizationJob.run(FirmsUtil.FIRMS_PROVIDERS);
         eventCombinationJob.run();
 
         //THEN
@@ -208,7 +209,7 @@ public class FirmsEventAndEpisodeCombinationsJobIT extends AbstractCleanableInte
         firmsImportModisJob.run();
         firmsImportNoaaJob.run();
         firmsImportSuomiJob.run();
-        normalizationJob.run();
+        normalizationJob.run(FirmsUtil.FIRMS_PROVIDERS);
         eventCombinationJob.run();
         feedCompositionJob.run();
 

--- a/src/test/java/io/kontur/eventapi/job/EventCombinationJobIT.java
+++ b/src/test/java/io/kontur/eventapi/job/EventCombinationJobIT.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.List;
 import java.util.UUID;
 
 import static io.kontur.eventapi.pdc.converter.PdcDataLakeConverter.HP_SRV_MAG_PROVIDER;
@@ -93,7 +94,7 @@ public class EventCombinationJobIT extends AbstractCleanableIntegrationTest {
         dataLake.setData(data);
 
         dataLakeDao.storeEventData(dataLake);
-        normalizationJob.run();
+        normalizationJob.run(List.of(provider));
     }
 
     private String readMessageFromFile(String fileName) throws IOException {

--- a/src/test/java/io/kontur/eventapi/job/EventExpirationJobIT.java
+++ b/src/test/java/io/kontur/eventapi/job/EventExpirationJobIT.java
@@ -89,7 +89,7 @@ public class EventExpirationJobIT extends AbstractCleanableIntegrationTest {
 		DataLake dataLake = createDataLake(fileName);
 		dataLakeDao.storeEventData(dataLake);
 
-		normalizationJob.run();
+                normalizationJob.run(List.of(PDC_SQS_PROVIDER));
 		List<NormalizedObservation> observations = normalizedObservationsDao.getObservationsNotLinkedToEvent(List.of(PDC_SQS_PROVIDER));
 		assertEquals(1, observations.size());
 		NormalizedObservation observation = observations.get(0);

--- a/src/test/java/io/kontur/eventapi/job/FeedCompositionJobIT.java
+++ b/src/test/java/io/kontur/eventapi/job/FeedCompositionJobIT.java
@@ -137,7 +137,7 @@ public class FeedCompositionJobIT extends AbstractCleanableIntegrationTest {
         dataLake.setData(data);
 
         dataLakeDao.storeEventData(dataLake);
-        normalizationJob.run();
+        normalizationJob.run(List.of(provider));
     }
 
     @Test
@@ -171,7 +171,7 @@ public class FeedCompositionJobIT extends AbstractCleanableIntegrationTest {
         hpSrvHazardDataLake.setData(readMessageFromFile("HpSrvSearchTestOrder.json"));
         dataLakeDao.storeEventData(hpSrvHazardDataLake);
 
-        normalizationJob.run();
+        normalizationJob.run(List.of(HP_SRV_SEARCH_PROVIDER));
         eventCombinationJob.run();
 
         feedCompositionJob.run();

--- a/src/test/java/io/kontur/eventapi/pdc/composition/PdcEpisodeCompositionTest.java
+++ b/src/test/java/io/kontur/eventapi/pdc/composition/PdcEpisodeCompositionTest.java
@@ -213,7 +213,7 @@ public class PdcEpisodeCompositionTest extends AbstractCleanableIntegrationTest 
         dataLake.setData(data);
 
         dataLakeDao.storeEventData(dataLake);
-        normalizationJob.run();
+        normalizationJob.run(List.of(provider));
     }
 
     private String readMessageFromFile(String fileName) throws IOException {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -134,11 +134,12 @@ scheduler:
     enable: false
     initialDelay: 999999
     fixedDelay: 999999
-    providers: em-dat, gdacsAlert, gdacsAlertGeometry, hpSrvMag, hpSrvSearch, pdcMapSrv, pdcSqs, tornado.canada-gov, 
+    providersGroup1: em-dat, gdacsAlert, gdacsAlertGeometry, hpSrvMag, hpSrvSearch, pdcMapSrv, pdcSqs, tornado.canada-gov,
       tornado.australian-bm, tornado.osm-wiki, tornado.des-inventar-sendai, storms.noaa, wildfire.frap.cal,
       wildfire.sa-gov, wildfire.qld-des-gov, wildfire.victoria-gov, wildfire.nsw-gov, wildfire.calfire,
       wildfire.perimeters.nifc, wildfire.locations.nifc, wildfire.inciweb, kontur.events, cyclones.nhc-at.noaa,
-      cyclones.nhc-ep.noaa, cyclones.nhc-cp.noaa, firms.modis-c6, firms.suomi-npp-viirs-c2, firms.noaa-20-viirs-c2
+      cyclones.nhc-ep.noaa, cyclones.nhc-cp.noaa
+    providersGroup2: firms.modis-c6, firms.suomi-npp-viirs-c2, firms.noaa-20-viirs-c2
   eventCombination:
     enable: false
     initialDelay: 999999


### PR DESCRIPTION
## Summary
- split provider list in scheduler config for normalization
- pass provider groups to NormalizationJob sequentially
- adjust tests for updated NormalizationJob API
- update default configs

## Testing
- `mvn -q -DskipTests install` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6861a4839f248324929bf51145a779c1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Normalization jobs can now be run for specific provider groups, allowing more granular control over processing.

* **Configuration**
  * Application and test configuration files now support two separate provider groups for normalization jobs.

* **Bug Fixes**
  * Improved handling of provider selection during normalization to ensure correct grouping.

* **Tests**
  * Updated tests to verify normalization jobs run with specified provider groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->