### PR TITLE
feat(event-resource): 14730 add episode filter to similar events

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -55,6 +55,7 @@ Find events similar to the specified event. Similarity is determined by event ty
 - `eventId` – reference event UUID (required).
 - `limit` – number of records to return. Default is `10`.
 - `distance` – search radius in meters. Default is `50000`.
+- `episodeFilterType` – `ANY`, `LATEST` or `NONE`.
 - `geometryFilterType` – `ANY` or `NONE`.
 
 ## `GET /v1/user_feeds`

--- a/src/main/java/io/kontur/eventapi/dao/ApiDao.java
+++ b/src/main/java/io/kontur/eventapi/dao/ApiDao.java
@@ -70,7 +70,8 @@ public class ApiDao {
     }
 
     public String findSimilarEvents(UUID eventId, String feedAlias, int limit, double distance,
+                                   EpisodeFilterType episodeFilterType,
                                    GeometryFilterType geometryFilterType) {
-        return mapper.findSimilarEvents(eventId, feedAlias, limit, distance, geometryFilterType);
+        return mapper.findSimilarEvents(eventId, feedAlias, limit, distance, episodeFilterType, geometryFilterType);
     }
 }

--- a/src/main/java/io/kontur/eventapi/dao/mapper/ApiMapper.java
+++ b/src/main/java/io/kontur/eventapi/dao/mapper/ApiMapper.java
@@ -59,5 +59,6 @@ public interface ApiMapper {
                              @Param("feedAlias") String feedAlias,
                              @Param("limit") int limit,
                              @Param("distance") double distance,
+                             @Param("episodeFilterType") EpisodeFilterType episodeFilterType,
                              @Param("geometryFilterType") GeometryFilterType geometryFilterType);
 }

--- a/src/main/java/io/kontur/eventapi/resource/EventResource.java
+++ b/src/main/java/io/kontur/eventapi/resource/EventResource.java
@@ -291,12 +291,18 @@ public class EventResource {
             @Parameter(description = "Search radius in meters", example = "50000")
             @RequestParam(value = "distance", defaultValue = "50000")
             double distance,
+            @Parameter(description = "How many episodes to select: " +
+                    "<ul><li>ANY - all episodes</li>" +
+                    "<li>LATEST - the latest episode</li>" +
+                    "<li>NONE - no episodes</li></ul>")
+            @RequestParam(value = "episodeFilterType", defaultValue = "ANY")
+            EpisodeFilterType episodeFilterType,
             @Parameter(description = "How geometries should be returned: " +
                     "<ul><li>ANY - include geometries</li>" +
                     "<li>NONE - omit geometries</li></ul>")
             @RequestParam(value = "geometryFilterType", defaultValue = "ANY")
             GeometryFilterType geometryFilterType) {
-        return eventResourceService.findSimilarEvents(eventId, feed, limit, distance, geometryFilterType)
+        return eventResourceService.findSimilarEvents(eventId, feed, limit, distance, episodeFilterType, geometryFilterType)
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.noContent().build());
     }

--- a/src/main/java/io/kontur/eventapi/service/EventResourceService.java
+++ b/src/main/java/io/kontur/eventapi/service/EventResourceService.java
@@ -81,8 +81,9 @@ public class EventResourceService {
     }
 
     public Optional<String> findSimilarEvents(UUID eventId, String feedAlias, int limit, double distance,
+                                              EpisodeFilterType episodeFilterType,
                                               GeometryFilterType geometryFilterType) {
-        String data = apiDao.findSimilarEvents(eventId, feedAlias, limit, distance, geometryFilterType);
+        String data = apiDao.findSimilarEvents(eventId, feedAlias, limit, distance, episodeFilterType, geometryFilterType);
         return data == null ? Optional.empty() : Optional.of(data);
     }
 }

--- a/src/main/resources/db/mappers/ApiMapper.xml
+++ b/src/main/resources/db/mappers/ApiMapper.xml
@@ -25,7 +25,17 @@
                     <otherwise>fd.geometries,</otherwise>
                 </choose>
                 jsonb_array_length(fd.episodes) as episode_count,
-                fd.episodes,
+                <choose>
+                    <when test='"LATEST".equalsIgnoreCase(episodeFilterType)'>
+                        jsonb_build_array((select episode from jsonb_array_elements(fd.episodes) episode
+                                           order by (episode ->> 'updatedAt')::timestamptz desc
+                                           limit 1)) as episodes,
+                    </when>
+                    <when test='"NONE".equalsIgnoreCase(episodeFilterType)'>
+                        '[]'::jsonb as episodes,
+                    </when>
+                    <otherwise>fd.episodes,</otherwise>
+                </choose>
                 box2d(fd.collected_geometry) as bbox,
                 st_pointonsurface(fd.collected_geometry) as centroid,
                 st_distance(fd.collected_geometry::geography, t.collected_geometry::geography) as dist

--- a/src/test/java/io/kontur/eventapi/service/EventResourceServiceTest.java
+++ b/src/test/java/io/kontur/eventapi/service/EventResourceServiceTest.java
@@ -2,6 +2,7 @@ package io.kontur.eventapi.service;
 
 import io.kontur.eventapi.dao.ApiDao;
 import io.kontur.eventapi.resource.dto.GeometryFilterType;
+import io.kontur.eventapi.resource.dto.EpisodeFilterType;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.env.Environment;
 
@@ -20,12 +21,15 @@ public class EventResourceServiceTest {
 
         UUID eventId = UUID.randomUUID();
         String feed = "test";
-        when(apiDao.findSimilarEvents(eventId, feed, 5, 10.0, GeometryFilterType.NONE))
+        when(apiDao.findSimilarEvents(eventId, feed, 5, 10.0,
+                EpisodeFilterType.ANY, GeometryFilterType.NONE))
                 .thenReturn("{}");
 
-        Optional<String> result = service.findSimilarEvents(eventId, feed, 5, 10.0, GeometryFilterType.NONE);
+        Optional<String> result = service.findSimilarEvents(eventId, feed, 5, 10.0,
+                EpisodeFilterType.ANY, GeometryFilterType.NONE);
 
-        verify(apiDao, times(1)).findSimilarEvents(eventId, feed, 5, 10.0, GeometryFilterType.NONE);
+        verify(apiDao, times(1)).findSimilarEvents(eventId, feed, 5, 10.0,
+                EpisodeFilterType.ANY, GeometryFilterType.NONE);
         assertTrue(result.isPresent());
     }
 }


### PR DESCRIPTION
## Summary
- add `episodeFilterType` parameter to `GET /v1/event/similar`
- propagate parameter through service, DAO and mapper
- support filtering episodes in SQL
- document the new parameter
- update unit tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68653b1a3f288324969c480c885d8ded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an optional parameter, `episodeFilterType`, to the similar events endpoint. Users can now filter episodes returned as `ANY`, `LATEST`, or `NONE`.

* **Documentation**
  * Updated API documentation to describe the new `episodeFilterType` parameter for the similar events endpoint.

* **Tests**
  * Enhanced tests to cover the new episode filtering functionality in the similar events endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->