### PR TITLE
fix(gdacs): use alert urls for episodes

### DIFF
--- a/src/main/java/io/kontur/eventapi/gdacs/episodecomposition/GdacsAlertEpisodeCombinator.java
+++ b/src/main/java/io/kontur/eventapi/gdacs/episodecomposition/GdacsAlertEpisodeCombinator.java
@@ -43,9 +43,6 @@ public class GdacsAlertEpisodeCombinator extends EpisodeCombinator {
         FeedEpisode episode = createDefaultEpisode(alertObservation);
         episode.setObservations(findObservationsForEpisode(eventObservations));
         episode.setGeometries(geometryObservation.getGeometries());
-        if (CollectionUtils.isEmpty(episode.getUrls()) && !CollectionUtils.isEmpty(geometryObservation.getUrls())) {
-            episode.addUrlIfNotExists(geometryObservation.getUrls());
-        }
         if (isBlank(episode.getProperName())) {
             episode.setProperName(geometryObservation.getProperName());
         }


### PR DESCRIPTION
## Summary
- use URL from alert observation in GDACS combinator

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_6870eac98b5c832f9e8cce76be552bb6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated logic to no longer add URLs from geometry observations to episodes when episode URLs are empty. No changes to other episode data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->