### PR TITLE
fix(gdacs): prefer geometry url for episodes

### DIFF
--- a/src/main/java/io/kontur/eventapi/gdacs/episodecomposition/GdacsAlertEpisodeCombinator.java
+++ b/src/main/java/io/kontur/eventapi/gdacs/episodecomposition/GdacsAlertEpisodeCombinator.java
@@ -6,7 +6,6 @@ import io.kontur.eventapi.entity.NormalizedObservation;
 import io.kontur.eventapi.episodecomposition.EpisodeCombinator;
 import io.kontur.eventapi.job.exception.FeedCompositionSkipException;
 import org.springframework.stereotype.Component;
-import org.springframework.util.CollectionUtils;
 
 import java.util.*;
 
@@ -43,9 +42,7 @@ public class GdacsAlertEpisodeCombinator extends EpisodeCombinator {
         FeedEpisode episode = createDefaultEpisode(alertObservation);
         episode.setObservations(findObservationsForEpisode(eventObservations));
         episode.setGeometries(geometryObservation.getGeometries());
-        if (CollectionUtils.isEmpty(episode.getUrls()) && !CollectionUtils.isEmpty(geometryObservation.getUrls())) {
-            episode.addUrlIfNotExists(geometryObservation.getUrls());
-        }
+        episode.setUrls(geometryObservation.getUrls());
         if (isBlank(episode.getProperName())) {
             episode.setProperName(geometryObservation.getProperName());
         }

--- a/src/test/java/io/kontur/eventapi/gdacs/episodecomposition/GdacsAlertEpisodeCombinatorTest.java
+++ b/src/test/java/io/kontur/eventapi/gdacs/episodecomposition/GdacsAlertEpisodeCombinatorTest.java
@@ -33,8 +33,10 @@ class GdacsAlertEpisodeCombinatorTest {
     @Test
     public void testProcessObservation() throws IOException {
         NormalizedObservation alertObservation = createObservation(GDACS_ALERT_PROVIDER, null);
+        alertObservation.setUrls(List.of("alert-url"));
         FeatureCollection geometries = (FeatureCollection) GeoJSONFactory.create(readFile("geometry.json"));
         NormalizedObservation geometryObservation = createObservation(GDACS_ALERT_GEOMETRY_PROVIDER, geometries);
+        geometryObservation.setUrls(List.of("geometry-url"));
         FeedData feedData = new FeedData(UUID.randomUUID(), UUID.randomUUID(), 1L);
 
         List<FeedEpisode> feedEpisodes = episodeCombinator.processObservation(alertObservation,
@@ -46,6 +48,7 @@ class GdacsAlertEpisodeCombinatorTest {
         assertTrue(feedEpisode.getObservations().contains(alertObservation.getObservationId()));
         assertTrue(feedEpisode.getObservations().contains(geometryObservation.getObservationId()));
         assertNotNull(feedEpisode.getGeometries());
+        assertEquals(List.of("geometry-url"), feedEpisode.getUrls());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- use geometry observation URLs in GDACS episode combination
- test that geometry URL is preferred

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870ecebb808832f85cb129aa57e01ad

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of URLs in episode processing to ensure that URLs from geometry observations are always used.

* **Tests**
  * Enhanced test coverage to verify that URLs from geometry observations are correctly assigned to episodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->