### PR TITLE
fix-null-pointer-exception-in-wildfire-perimeters-nifc-processing

### DIFF
--- a/src/test/java/io/kontur/eventapi/nifc/job/NifcImportJobTest.java
+++ b/src/test/java/io/kontur/eventapi/nifc/job/NifcImportJobTest.java
@@ -60,6 +60,18 @@ class NifcImportJobTest {
         verify(dataLakeDao, never()).storeDataLakes(any());
     }
 
+    @Test
+    void skipMalformedJson() throws Exception {
+        when(nifcClient.getNifcLocations()).thenReturn("{not json}");
+        when(nifcClient.getNifcPerimeters()).thenReturn("{\"error\":true}");
+
+        nifcImportJob.execute();
+
+        verify(dataLakeDao, never()).getDataLakesByExternalIdsAndProvider(any(), any());
+        verify(nifcDataLakeConverter, never()).convertDataLake(any(), any(), any(), any());
+        verify(dataLakeDao, never()).storeDataLakes(any());
+    }
+
     private String readFile(String fileName) throws IOException {
         return IOUtils.toString(Objects.requireNonNull(this.getClass().getResourceAsStream(fileName)), "UTF-8");
     }


### PR DESCRIPTION
## Summary
- skip malformed NIFC API responses
- add regression test for invalid JSON

## Testing
- `mvn -q -DskipTests=false test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68765257bf488323973b8cfdc6452253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed or invalid GeoJSON data to prevent processing errors.
* **Tests**
  * Added tests to ensure that malformed or invalid JSON is properly detected and skipped during data import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->