### PR TITLE
feat(usgs): format earthquake observation name

### DIFF
--- a/docs/event_combination.md
+++ b/docs/event_combination.md
@@ -31,4 +31,5 @@ trailing part is stored as the observation `region`. A human‑readable episode
 description is composed using the event start time, magnitude and depth from the
 source data, for example: `On 7/5/2025 7:42:20 PM, an earthquake occurred 55 km
 SSW of Lithakiá, Greece. The earthquake had Magnitude 4.7M, Depth:10km.` The
-observation `name` is always `Earthquake` and `proper_name` remains `null`.
+observation `name` becomes `M <magnitude> - <place>` and `proper_name` remains
+`null`.

--- a/src/main/java/io/kontur/eventapi/usgs/earthquake/normalization/UsgsEarthquakeNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/usgs/earthquake/normalization/UsgsEarthquakeNormalizer.java
@@ -110,7 +110,14 @@ public class UsgsEarthquakeNormalizer extends Normalizer {
             String place = readString(props, "place");
             obs.setDescription(place);
             magnitude = readDouble(props, "mag");
-            obs.setName("Earthquake");
+            if (magnitude != null && place != null) {
+                obs.setName(String.format(Locale.US, "M %.1f - %s", magnitude, place));
+            } else if (magnitude != null) {
+                obs.setName(String.format(Locale.US, "M %.1f", magnitude));
+            } else if (place != null) {
+                obs.setName(place);
+            }
+            obs.setProperName(null);
             obs.setStartedAt(readDateTime(props, "time"));
 
             if (place != null) {

--- a/src/test/java/io/kontur/eventapi/usgs/earthquake/normalization/UsgsEarthquakeNormalizerTest.java
+++ b/src/test/java/io/kontur/eventapi/usgs/earthquake/normalization/UsgsEarthquakeNormalizerTest.java
@@ -35,7 +35,7 @@ class UsgsEarthquakeNormalizerTest {
         assertEquals("nc75206757", obs.getExternalEventId());
         assertEquals(Severity.MINOR, obs.getEventSeverity());
         assertEquals(EventType.EARTHQUAKE, obs.getType());
-        assertEquals("Earthquake", obs.getName());
+        assertEquals("M 1.6 - 2 km E of Aromas, CA", obs.getName());
         assertNull(obs.getProperName());
         assertEquals("2 km E of Aromas, CA", obs.getDescription());
         assertEquals("CA", obs.getRegion());


### PR DESCRIPTION
## Summary
- update normalizer to use `M <magnitude> - <place>` as observation name
- ensure `proper_name` is always null for USGS earthquakes
- document new naming rule
- adjust tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687b909c0d3c8323b7609aca8c593c37