### PR TITLE
fix(usgs): handle missing shakemap features

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -54,7 +54,8 @@ For USGS earthquakes `geometries` may contain ShakeMap polygons. They are derive
 from contour lines published by USGS. If `shakemap` is an array, only
 its first element is used. ShakeMap polygons do not include the original
 `Class`, `country` or `areaType` attributes. Polygons whose `value` ends up
-`null` are discarded during normalization. Each polygon is enriched with
+`null` are discarded during normalization. If `cont_mmi` contains no
+`features` array, the polygons are skipped. Each polygon is enriched with
 `Class`, `eventid`, `eventtype` and `polygonlabel` derived from the intensity
 value. `Class` becomes `Poly_SMPInt_&lt;intensity&gt;`, `eventid` matches the
 earthquake external ID, `eventtype` is `EQ` and `polygonlabel` is

--- a/src/main/java/io/kontur/eventapi/usgs/earthquake/normalization/UsgsEarthquakeNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/usgs/earthquake/normalization/UsgsEarthquakeNormalizer.java
@@ -178,10 +178,12 @@ public class UsgsEarthquakeNormalizer extends Normalizer {
 
                 FeatureCollection smPolygons = buildShakemapPolygons(shakemap);
                 if (smPolygons != null) {
-                    for (Feature smFeature : smPolygons.getFeatures()) {
-                        Map<String, Object> polygonProps = smFeature.getProperties() == null
-                                ? new HashMap<>()
-                                : new HashMap<>(smFeature.getProperties());
+                    Feature[] smFeatures = smPolygons.getFeatures();
+                    if (smFeatures != null) {
+                        for (Feature smFeature : smFeatures) {
+                            Map<String, Object> polygonProps = smFeature.getProperties() == null
+                                    ? new HashMap<>()
+                                    : new HashMap<>(smFeature.getProperties());
 
                         Object valObj = polygonProps.get("value");
                         String intensity = null;
@@ -203,9 +205,12 @@ public class UsgsEarthquakeNormalizer extends Normalizer {
                             polygonProps.put("polygonlabel", "Intensity " + intensity);
                         }
 
-                        geometryFeatures.add(new Feature(smFeature.getGeometry(), polygonProps));
+                            geometryFeatures.add(new Feature(smFeature.getGeometry(), polygonProps));
+                        }
+                        LOG.debug("Appended {} ShakeMap polygon(s)", smFeatures.length);
+                    } else {
+                        LOG.debug("ShakeMap polygons feature array is null");
                     }
-                    LOG.debug("Appended {} ShakeMap polygon(s)", smPolygons.getFeatures().length);
                 } else {
                     LOG.debug("No ShakeMap polygons were built");
                 }

--- a/src/test/java/io/kontur/eventapi/usgs/earthquake/normalization/UsgsEarthquakeNormalizerTest.java
+++ b/src/test/java/io/kontur/eventapi/usgs/earthquake/normalization/UsgsEarthquakeNormalizerTest.java
@@ -71,6 +71,18 @@ class UsgsEarthquakeNormalizerTest {
     }
 
     @Test
+    void testNormalizeWithNullShakeMapFeatures() throws Exception {
+        when(shakemapDao.buildShakemapPolygons(any())).thenReturn("{\"type\":\"FeatureCollection\"}");
+        when(shakemapDao.buildCentroidBuffer(anyDouble(), anyDouble())).thenReturn("{\"type\":\"Polygon\"}");
+
+        DataLake dl = createDataLake("/usgs/sample.json");
+        NormalizedObservation obs = normalizer.normalize(dl);
+
+        verify(shakemapDao).buildShakemapPolygons(any());
+        assertEquals(2, obs.getGeometries().getFeatures().length);
+    }
+
+    @Test
     void testNormalizeWithPgaMask() throws Exception {
         when(shakemapDao.buildPgaMask(any())).thenReturn("{\"type\":\"Polygon\"}");
         when(shakemapDao.buildCentroidBuffer(anyDouble(), anyDouble())).thenReturn("{\"type\":\"Polygon\"}");


### PR DESCRIPTION
## Summary
- skip ShakeMap polygons when `features` array is missing
- document this edge case
- cover empty features with a unit test

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6880f060665c832388d6648fcc0815cf