### PR TITLE
fix(usgs): handle non-numeric maxpga

### DIFF
--- a/docs/feed_sources.md
+++ b/docs/feed_sources.md
@@ -48,10 +48,10 @@ its first element is used. ShakeMap polygons do not include the original
 `Class`, `eventid`, `eventtype` and `polygonlabel` derived from the intensity
 value. `Class` becomes `Poly_SMPInt_&lt;intensity&gt;`, `eventid` matches the
 earthquake external ID, `eventtype` is `EQ` and `polygonlabel` is
-`Intensity &lt;intensity&gt;`. If `maxpga` in ShakeMap properties reaches at
-least `0.4` and the data provides `coverage_pga_high_res`, a union of
-pixels with PGA above `0.4 g` is computed and stored as a GeoJSON object in
-`severity_data` under the key `pga40Mask`.
+`Intensity &lt;intensity&gt;`. If the numeric `maxpga` value in ShakeMap
+properties reaches at least `0.4` and the data provides `coverage_pga_high_res`,
+a union of pixels with PGA above `0.4 g` is computed and stored as a GeoJSON
+object in `severity_data` under the key `pga40Mask`.
 If ShakeMap provides `coverage_pga_high_res`, it is copied to `severity_data` under `coverage_pga_highres`.
 Polygons created from ShakeMap contours and the `pga40Mask` are shifted with `ST_ShiftLongitude` if they cross the antimeridian so that longitudes stay within `[-180, 180]`.
 For every USGS earthquake a circular polygon with 100&nbsp;km radius is built around the epicenter. If this buffer crosses the antimeridian it is also shifted.

--- a/src/main/java/io/kontur/eventapi/usgs/earthquake/normalization/UsgsEarthquakeNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/usgs/earthquake/normalization/UsgsEarthquakeNormalizer.java
@@ -293,7 +293,15 @@ public class UsgsEarthquakeNormalizer extends Normalizer {
     private Double enrichPgaMask(Map<String, Object> shakemap, Map<String, Object> shaProps) {
         try {
             Object maxPgaObj = shaProps.get("maxpga");
-            Double maxPga = maxPgaObj == null ? null : Double.valueOf(maxPgaObj.toString());
+            Double maxPga = null;
+            if (maxPgaObj != null) {
+                String pgaStr = maxPgaObj.toString();
+                try {
+                    maxPga = Double.valueOf(pgaStr);
+                } catch (NumberFormatException ignored) {
+                    LOG.debug("Cannot parse maxpga value '{}'", pgaStr);
+                }
+            }
 
             Object coverage = shakemap.get("coverage_pga_high_res");
             if (coverage instanceof Map) {

--- a/src/test/java/io/kontur/eventapi/usgs/earthquake/normalization/UsgsEarthquakeNormalizerTest.java
+++ b/src/test/java/io/kontur/eventapi/usgs/earthquake/normalization/UsgsEarthquakeNormalizerTest.java
@@ -101,6 +101,21 @@ class UsgsEarthquakeNormalizerTest {
     }
 
     @Test
+    void testNormalizeWithNaNMaxPga() throws Exception {
+        when(shakemapDao.buildCentroidBuffer(anyDouble(), anyDouble())).thenReturn("{\"type\":\"Polygon\"}");
+
+        DataLake dl = createDataLake("/usgs/sample_nan.json");
+        NormalizedObservation obs = normalizer.normalize(dl);
+
+        verify(shakemapDao, never()).buildPgaMask(any());
+        assertFalse(obs.getSeverityData().containsKey("pga40Mask"));
+
+        Object cov = obs.getSeverityData().get("coverage_pga_highres");
+        assertTrue(cov instanceof Map);
+        assertEquals("Coverage", ((Map<?, ?>) cov).get("type"));
+    }
+
+    @Test
     void testMagnitudeUpgrade() throws Exception {
         when(shakemapDao.buildCentroidBuffer(anyDouble(), anyDouble())).thenReturn("{\"type\":\"Polygon\"}");
 

--- a/src/test/resources/usgs/sample_nan.json
+++ b/src/test/resources/usgs/sample_nan.json
@@ -1,0 +1,35 @@
+{
+  "type": "Feature",
+  "properties": {
+    "mag": 7.6,
+    "place": "2 km E of Aromas, CA",
+    "time": 1751906597590,
+    "updated": 1751906694946,
+    "url": "https://earthquake.usgs.gov/earthquakes/eventpage/nc75206757",
+    "detail": "https://earthquake.usgs.gov/earthquakes/feed/v1.0/detail/nc75206757.geojson",
+    "alert": "green",
+    "status": "automatic",
+    "tsunami": 0,
+    "sig": 317,
+    "net": "nc",
+    "code": "75206757",
+    "types": ",origin,phase-data,",
+    "type": "earthquake",
+    "title": "M 7.6 - 2 km E of Aromas, CA"
+  },
+  "shakemap": [
+    {
+      "properties": {
+        "maxpga": "nan"
+      },
+      "coverage_pga_high_res": {"type": "Coverage"},
+      "cont_pga_highres": {"type": "FeatureCollection"},
+      "cont_mmi": {"type": "FeatureCollection"}
+    }
+  ],
+  "geometry": {
+    "type": "Point",
+    "coordinates": [-121.6175, 36.895168, 0.45]
+  },
+  "id": "nc75206757"
+}


### PR DESCRIPTION
## Summary
- ignore invalid `maxpga` values when building PGA mask
- document numeric `maxpga` requirement
- test NaN `maxpga` handling

## Testing
- `mvn -q -Dtest=UsgsEarthquakeNormalizerTest test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6883c5affe888323b391b1009b9ad21b