### PR TITLE
21961-mg-ingest-usgs-to-data_lake

### DIFF
--- a/docs/event_combination.md
+++ b/docs/event_combination.md
@@ -1,0 +1,35 @@
+# Event Combination
+
+This process groups normalized observations into events. A scheduled job selects
+observations that are not yet linked to an event and tries to find a matching
+event for each of them. If none exists, a new event ID is generated.
+
+1. **Select observations** – rows from `normalized_observations` where
+   `recombined` is `false` are fetched for the configured providers.
+2. **Find or create event** – an `EventCombinator` searches for an event
+   corresponding to the observation. The default implementation looks up an
+   event by `external_event_id`.
+3. **Append observation** – the observation is inserted into `kontur_events`
+   with `(event_id, provider, observation_id)` and marked as recombined so it is
+   not processed again.
+4. **Feed update** – other jobs later build feed data from the accumulated
+   observations.
+
+Provider specific combinators may override this logic. For example FIRMS
+wildfire observations are clustered by geometry before new events are created.
+
+## USGS earthquakes
+
+Earthquake observations from USGS do not contain separate episodes. Each update
+represents the same event with more details, so the default combination job just
+groups observations by `external_event_id`. When several updates for the same
+earthquake are present, the observation with the most recent ShakeMap geometry
+provides the geometry for the resulting event.
+
+During normalization the `place` property is split by the last comma and the
+trailing part is stored as the observation `region`. A human‑readable episode
+description is composed using the event start time, magnitude and depth from the
+source data, for example: `On 7/5/2025 7:42:20 PM, an earthquake occurred 55 km
+SSW of Lithakiá, Greece. The earthquake had Magnitude 4.7M, Depth:10km.` The
+observation `name` becomes `M <magnitude> - <place>` and `proper_name` remains
+`null`.

--- a/docs/feed_sources.md
+++ b/docs/feed_sources.md
@@ -35,3 +35,25 @@ The system ingests data from multiple providers. Each provider name reflects its
 | `cyclones.nhc-at.noaa` | Atlantic cyclone advisories from NHC |
 | `cyclones.nhc-cp.noaa` | Central Pacific cyclone advisories from NHC |
 | `cyclones.nhc-ep.noaa` | Eastern Pacific cyclone advisories from NHC |
+| `usgs.earthquake` | Earthquake events from the USGS 4.5‑week feed |
+
+## usgs.earthquake ##
+
+For USGS earthquakes `geometries` may contain ShakeMap polygons. They are derived
+from contour lines published by USGS. If `shakemap` is an array, only
+its first element is used. ShakeMap polygons do not include the original
+`Class`, `country` or `areaType` attributes. Polygons whose `value` ends up
+`null` are discarded during normalization. If `cont_mmi` contains no
+`features` array, the polygons are skipped. Each polygon is enriched with
+`Class`, `eventid`, `eventtype` and `polygonlabel` derived from the intensity
+value. `Class` becomes `Poly_SMPInt_&lt;intensity&gt;`, `eventid` matches the
+earthquake external ID, `eventtype` is `EQ` and `polygonlabel` is
+`Intensity &lt;intensity&gt;`. If the numeric `maxpga` value in ShakeMap
+properties reaches at least `0.4` and the data provides `coverage_pga_high_res`,
+a union of pixels with PGA above `0.4 g` is computed and stored as a GeoJSON
+object in `severity_data` under the key `pga40Mask`.
+If ShakeMap provides `coverage_pga_high_res`, it is copied to `severity_data` under `coverage_pga_highres`.
+Polygons created from ShakeMap contours and the `pga40Mask` are shifted with `ST_ShiftLongitude` if they cross the antimeridian so that longitudes stay within `[-180, 180]`.
+For every USGS earthquake a circular polygon with 100&nbsp;km radius is built around the epicenter. If this buffer crosses the antimeridian it is also shifted.
+It is stored in `geometries` with properties `Class`=`Poly_Circle`, `eventid` equal
+to the external ID, `areaType`=`alertArea`, `eventtype`=`EQ` and `polygonlabel`=`100km`.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -50,6 +50,18 @@ Normalized information extracted from `data_lake`.
 
 Indexes exist for `external_event_id` and `collected_geography`.
 
+## `kontur_events`
+Links observations to events.
+
+| Column | Type | Notes |
+| ------ | ---- | ----- |
+| `event_id` | `uuid` | event identifier |
+| `observation_id` | `uuid` references `normalized_observations` |
+| `provider` | `text` | observation provider |
+| `recombined_at` | `timestamptz` | when observation was attached |
+
+Unique on (`event_id`, `observation_id`). Indexes exist for `observation_id` and `recombined_at`.
+
 ## `feeds`
 List of available feeds.
 

--- a/src/main/java/io/kontur/eventapi/config/WorkerScheduler.java
+++ b/src/main/java/io/kontur/eventapi/config/WorkerScheduler.java
@@ -18,6 +18,8 @@ import io.kontur.eventapi.nhc.job.NhcEpImportJob;
 import io.kontur.eventapi.nifc.job.NifcImportJob;
 import io.kontur.eventapi.pdc.job.PdcMapSrvSearchJob;
 import io.kontur.eventapi.stormsnoaa.job.StormsNoaaImportJob;
+import io.kontur.eventapi.usgs.earthquake.job.UsgsEarthquakeImportJob;
+import io.kontur.eventapi.usgs.earthquake.job.UsgsEarthquakeNormalizationJob;
 import io.kontur.eventapi.staticdata.job.StaticImportJob;
 import io.kontur.eventapi.emdat.jobs.EmDatImportJob;
 import io.kontur.eventapi.gdacs.job.GdacsSearchJob;
@@ -54,6 +56,8 @@ public class WorkerScheduler {
     private final EnrichmentJob enrichmentJob;
     private final CalFireSearchJob calFireSearchJob;
     private final NifcImportJob nifcImportJob;
+    private final UsgsEarthquakeImportJob usgsEarthquakeImportJob;
+    private final UsgsEarthquakeNormalizationJob usgsEarthquakeNormalizationJob;
     private final InciWebImportJob inciWebImportJob;
     private final HumanitarianCrisisImportJob humanitarianCrisisImportJob;
     private final MetricsJob metricsJob;
@@ -99,6 +103,8 @@ public class WorkerScheduler {
     private String calfireEnabled;
     @Value("${scheduler.nifcImport.enable}")
     private String nifcImportEnabled;
+    @Value("${scheduler.usgsEarthquakeImport.enable}")
+    private String usgsEarthquakeImportEnabled;
     @Value("${scheduler.inciwebImport.enable}")
     private String inciwebEnabled;
     @Value("${scheduler.humanitarianCrisisImport.enable}")
@@ -127,6 +133,8 @@ public class WorkerScheduler {
                            HistoricalTornadoJapanMaImportJob historicalTornadoJapanMaImportJob,
                            PdcMapSrvSearchJobs pdcMapSrvSearchJobs,
                            EnrichmentJob enrichmentJob, CalFireSearchJob calFireSearchJob, NifcImportJob nifcImportJob,
+                           UsgsEarthquakeImportJob usgsEarthquakeImportJob,
+                           UsgsEarthquakeNormalizationJob usgsEarthquakeNormalizationJob,
                            InciWebImportJob inciWebImportJob, HumanitarianCrisisImportJob humanitarianCrisisImportJob,
                            NhcAtImportJob nhcAtImportJob, NhcCpImportJob nhcCpImportJob, NhcEpImportJob nhcEpImportJob,
                            MetricsJob metricsJob, ReEnrichmentJob reEnrichmentJob, EventExpirationJob eventExpirationJob) {
@@ -149,6 +157,8 @@ public class WorkerScheduler {
         this.enrichmentJob = enrichmentJob;
         this.calFireSearchJob = calFireSearchJob;
         this.nifcImportJob = nifcImportJob;
+        this.usgsEarthquakeImportJob = usgsEarthquakeImportJob;
+        this.usgsEarthquakeNormalizationJob = usgsEarthquakeNormalizationJob;
         this.inciWebImportJob = inciWebImportJob;
         this.nhcAtImportJob = nhcAtImportJob;
         this.nhcCpImportJob = nhcCpImportJob;
@@ -263,6 +273,13 @@ public class WorkerScheduler {
         }
     }
 
+    @Scheduled(initialDelayString = "${scheduler.usgsEarthquakeImport.initialDelay}", fixedDelayString = "${scheduler.usgsEarthquakeImport.fixedDelay}")
+    public void startUsgsEarthquakeImport() {
+        if (Boolean.parseBoolean(usgsEarthquakeImportEnabled)) {
+            usgsEarthquakeImportJob.run();
+        }
+    }
+
     @Scheduled(initialDelayString = "${scheduler.inciwebImport.initialDelay}", fixedDelayString = "${scheduler.inciwebImport.fixedDelay}")
     public void startInciWebImport() {
         if (Boolean.parseBoolean(inciwebEnabled)) {
@@ -306,6 +323,13 @@ public class WorkerScheduler {
         }
     }
 
+    @Scheduled(initialDelayString = "${scheduler.normalization.initialDelay}", fixedDelayString = "${scheduler.normalization.fixedDelay}")
+    public void startUsgsEarthquakeNormalization() {
+        if (Boolean.parseBoolean(normalizationEnabled)) {
+            usgsEarthquakeNormalizationJob.run();
+        }
+    }
+
     @Scheduled(initialDelayString = "${scheduler.eventCombination.initialDelay}", fixedDelayString = "${scheduler.eventCombination.fixedDelay}")
     public void startCombinationJob() {
         if (Boolean.parseBoolean(eventCombinationEnabled)) {
@@ -319,6 +343,7 @@ public class WorkerScheduler {
             firmsEventCombinationJob.run();
         }
     }
+
 
     @Scheduled(initialDelayString = "${scheduler.feedComposition.initialDelay}", fixedDelayString = "${scheduler.feedComposition.fixedDelay}")
     public void startFeedCompositionJob() {

--- a/src/main/java/io/kontur/eventapi/dao/ShakemapDao.java
+++ b/src/main/java/io/kontur/eventapi/dao/ShakemapDao.java
@@ -1,0 +1,25 @@
+package io.kontur.eventapi.dao;
+
+import io.kontur.eventapi.dao.mapper.NormalizedObservationsMapper;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ShakemapDao {
+    private final NormalizedObservationsMapper mapper;
+
+    public ShakemapDao(NormalizedObservationsMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    public String buildShakemapPolygons(String json) {
+        return mapper.buildShakemapPolygons(json);
+    }
+
+    public String buildPgaMask(String json) {
+        return mapper.buildPgaMask(json);
+    }
+
+    public String buildCentroidBuffer(Double lon, Double lat) {
+        return mapper.buildCentroidBuffer(lon, lat);
+    }
+}

--- a/src/main/java/io/kontur/eventapi/dao/mapper/NormalizedObservationsMapper.java
+++ b/src/main/java/io/kontur/eventapi/dao/mapper/NormalizedObservationsMapper.java
@@ -60,4 +60,11 @@ public interface NormalizedObservationsMapper {
                                           @Param("timezone") String timezone);
 
     Integer getNotRecombinedObservationsCount();
+
+    String buildShakemapPolygons(@Param("json") String json);
+
+    String buildPgaMask(@Param("json") String json);
+
+    String buildCentroidBuffer(@Param("lon") Double lon,
+                               @Param("lat") Double lat);
 }

--- a/src/main/java/io/kontur/eventapi/usgs/earthquake/client/UsgsEarthquakeClient.java
+++ b/src/main/java/io/kontur/eventapi/usgs/earthquake/client/UsgsEarthquakeClient.java
@@ -1,0 +1,14 @@
+package io.kontur.eventapi.usgs.earthquake.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(value = "usgsEarthquakeClient", url = "${usgs.host}")
+public interface UsgsEarthquakeClient {
+
+    @GetMapping("/earthquakes/feed/v1.0/summary/4.5_week.geojson")
+    String getEarthquakes();
+
+    @GetMapping("/earthquakes/feed/v1.0/detail/{id}.geojson")
+    String getDetail(@org.springframework.web.bind.annotation.PathVariable("id") String id);
+}

--- a/src/main/java/io/kontur/eventapi/usgs/earthquake/converter/UsgsEarthquakeDataLakeConverter.java
+++ b/src/main/java/io/kontur/eventapi/usgs/earthquake/converter/UsgsEarthquakeDataLakeConverter.java
@@ -1,0 +1,21 @@
+package io.kontur.eventapi.usgs.earthquake.converter;
+
+import io.kontur.eventapi.entity.DataLake;
+import io.kontur.eventapi.util.DateTimeUtil;
+import org.springframework.stereotype.Component;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Component
+public class UsgsEarthquakeDataLakeConverter {
+
+    public static final String USGS_EARTHQUAKE_PROVIDER = "usgs.earthquake";
+
+    public DataLake convert(String externalId, OffsetDateTime updatedAt, String data) {
+        DataLake dataLake = new DataLake(UUID.randomUUID(), externalId, updatedAt, DateTimeUtil.uniqueOffsetDateTime());
+        dataLake.setProvider(USGS_EARTHQUAKE_PROVIDER);
+        dataLake.setData(data);
+        return dataLake;
+    }
+}

--- a/src/main/java/io/kontur/eventapi/usgs/earthquake/job/UsgsEarthquakeImportJob.java
+++ b/src/main/java/io/kontur/eventapi/usgs/earthquake/job/UsgsEarthquakeImportJob.java
@@ -1,0 +1,279 @@
+package io.kontur.eventapi.usgs.earthquake.job;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.kontur.eventapi.dao.DataLakeDao;
+import io.kontur.eventapi.entity.DataLake;
+import io.kontur.eventapi.job.AbstractJob;
+import io.kontur.eventapi.usgs.earthquake.client.UsgsEarthquakeClient;
+import io.kontur.eventapi.usgs.earthquake.converter.UsgsEarthquakeDataLakeConverter;
+import io.kontur.eventapi.util.DateTimeUtil;
+import io.kontur.eventapi.util.JsonUtil;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class UsgsEarthquakeImportJob extends AbstractJob {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UsgsEarthquakeImportJob.class);
+
+    private final UsgsEarthquakeClient client;
+    private final DataLakeDao dataLakeDao;
+    private final UsgsEarthquakeDataLakeConverter converter;
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+
+    public UsgsEarthquakeImportJob(MeterRegistry meterRegistry,
+                                   UsgsEarthquakeClient client,
+                                   DataLakeDao dataLakeDao,
+                                   UsgsEarthquakeDataLakeConverter converter) {
+        super(meterRegistry);
+        this.client = client;
+        this.dataLakeDao = dataLakeDao;
+        this.converter = converter;
+    }
+
+    @Override
+    public String getName() {
+        return "usgsEarthquakeImport";
+    }
+
+    @Override
+    public void execute() {
+        try {
+            String geoJson = client.getEarthquakes();
+            if (StringUtils.isBlank(geoJson)) {
+                LOG.warn("Skip processing usgs earthquake feed due to empty response");
+                return;
+            }
+            JsonNode root = JsonUtil.readTree(geoJson);
+            ArrayNode features = (ArrayNode) root.get("features");
+            List<DataLake> dataLakes = new ArrayList<>();
+            for (JsonNode node : features) {
+                try {
+                    ObjectNode feature = (ObjectNode) node;
+                    String externalId = feature.get("id").asText();
+                    JsonNode updatedNode = feature.path("properties").path("updated");
+                    if (!updatedNode.isMissingNode() && StringUtils.isNotBlank(externalId)) {
+                        OffsetDateTime updatedAt = DateTimeUtil.getDateTimeFromMilli(updatedNode.asLong());
+                        if (Boolean.TRUE.equals(dataLakeDao.isNewEvent(externalId,
+                                UsgsEarthquakeDataLakeConverter.USGS_EARTHQUAKE_PROVIDER,
+                                updatedAt.format(DateTimeFormatter.ISO_INSTANT)))) {
+                            enrichFeature(feature, externalId);
+                            dataLakes.add(converter.convert(externalId, updatedAt, feature.toString()));
+                        } else {
+                            LOG.debug("USGS earthquake {} with updated_at {} already present", externalId, updatedAt);
+                        }
+                    }
+                } catch (Exception e) {
+                    LOG.error("Failed to process feature from usgs earthquake feed", e);
+                }
+            }
+            if (!dataLakes.isEmpty()) {
+                dataLakeDao.storeDataLakes(dataLakes);
+            }
+        } catch (Exception e) {
+            LOG.warn("Error while obtaining usgs earthquake feed", e);
+        }
+    }
+
+    private void enrichFeature(ObjectNode feature, String externalId) {
+        try {
+            JsonNode typesNode = feature.get("properties").get("types");
+            String types = typesNode != null ? typesNode.asText() : null;
+            boolean needShakemap = types != null && types.contains("shakemap");
+            boolean needLoss = types != null && types.contains("losspager");
+            if (!needShakemap && !needLoss) {
+                return;
+            }
+            String detailJson = client.getDetail(externalId);
+            if (StringUtils.isBlank(detailJson)) {
+                if (needShakemap) {
+                    feature.put("shakemap_cont_retrieval", false);
+                    feature.put("shakemap_hishres_pga_retrieval", false);
+                }
+                if (needLoss) {
+                    feature.put("loss_estimation_retrieval", false);
+                }
+                return;
+            }
+            JsonNode detail = JsonUtil.readTree(detailJson);
+            if (needShakemap) {
+                enrichWithShakemap(feature, detail, externalId);
+            }
+            if (needLoss) {
+                enrichWithLossEstimation(feature, detail, externalId);
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to enrich feature {}", externalId, e);
+        }
+    }
+
+    private void enrichWithShakemap(ObjectNode feature, JsonNode detail, String externalId) {
+        try {
+            JsonNode shakemapArray = detail.at("/properties/products/shakemap");
+            if (!shakemapArray.isArray() || shakemapArray.size() == 0) {
+                feature.put("shakemap_cont_retrieval", false);
+                feature.put("shakemap_hishres_pga_retrieval", false);
+                return;
+            }
+            JsonNode first = shakemapArray.get(0);
+            ObjectNode result = (ObjectNode) JsonUtil.readTree("{}");
+            copyField(first, result, "indexid");
+            copyField(first, result, "indexTime");
+            copyField(first, result, "id");
+            copyField(first, result, "type");
+            copyField(first, result, "code");
+            copyField(first, result, "source");
+            copyField(first, result, "updateTime");
+            copyField(first, result, "status");
+            JsonNode props = first.get("properties");
+            if (props != null) {
+                result.set("properties", props);
+            }
+            JsonNode contents = first.get("contents");
+            JsonNode contNode = contents != null ? contents.get("download/cont_mmi.json") : null;
+            if (contNode != null) {
+                String url = contNode.get("url").asText();
+                feature.put("shm_url", url);
+                String contPga = fetchUrl(url);
+                if (contPga != null) {
+                    result.set("download/cont_mmi.json", contNode);
+                    try {
+                        JsonNode contPgaNode = JsonUtil.readTree(contPga);
+                        result.set("cont_mmi", contPgaNode);
+                    } catch (Exception e) {
+                        LOG.warn("Failed to parse cont_mmi.json for event {}", externalId, e);
+                        feature.put("shakemap_cont_retrieval", false);
+                        return;
+                    }
+                } else {
+                    feature.put("shakemap_cont_retrieval", false);
+                    return;
+                }
+            } else {
+                feature.put("shakemap_cont_retrieval", false);
+                return;
+            }
+
+            JsonNode contPgaHiNode = contents != null ? contents.get("download/cont_pga_highres.json") : null;
+            if (contPgaHiNode != null) {
+                String url = contPgaHiNode.get("url").asText();
+                String contHiContent = fetchUrl(url);
+                if (contHiContent != null) {
+                    result.set("download/cont_pga_highres.json", contPgaHiNode);
+                    try {
+                        JsonNode contHi = JsonUtil.readTree(contHiContent);
+                        result.set("cont_pga_highres", contHi);
+                    } catch (Exception e) {
+                        LOG.warn("Failed to parse cont_pga_highres.json for event {}", externalId, e);
+                    }
+                }
+            }
+
+            JsonNode hiResNode = contents != null ? contents.get("download/coverage_pga_high_res.covjson") : null;
+            if (hiResNode != null) {
+                String url = hiResNode.get("url").asText();
+                String hiResContent = fetchUrl(url);
+                if (hiResContent != null) {
+                    result.set("download/coverage_pga_high_res.covjson", hiResNode);
+                    try {
+                        JsonNode hiRes = JsonUtil.readTree(hiResContent);
+                        result.set("coverage_pga_high_res", hiRes);
+                    } catch (Exception e) {
+                        LOG.warn("Failed to parse coverage_pga_high_res.covjson for event {}", externalId, e);
+                        feature.put("shakemap_hishres_pga_retrieval", false);
+                    }
+                } else {
+                    feature.put("shakemap_hishres_pga_retrieval", false);
+                }
+            } else {
+                feature.put("shakemap_hishres_pga_retrieval", false);
+            }
+            ArrayNode arr = feature.putArray("shakemap");
+            arr.add(result);
+        } catch (Exception e) {
+            LOG.warn("Failed to enrich feature with shakemap", e);
+            feature.put("shakemap_cont_retrieval", false);
+            feature.put("shakemap_hishres_pga_retrieval", false);
+        }
+    }
+
+    private void enrichWithLossEstimation(ObjectNode feature, JsonNode detail, String externalId) {
+        try {
+            JsonNode pagerArray = detail.at("/properties/products/losspager");
+            if (!pagerArray.isArray() || pagerArray.size() == 0) {
+                feature.put("loss_estimation_retrieval", false);
+                return;
+            }
+            JsonNode first = pagerArray.get(0);
+            ObjectNode result = (ObjectNode) JsonUtil.readTree("{}");
+            copyField(first, result, "indexid");
+            copyField(first, result, "indexTime");
+            copyField(first, result, "id");
+            copyField(first, result, "type");
+            copyField(first, result, "code");
+            copyField(first, result, "source");
+            copyField(first, result, "updateTime");
+            copyField(first, result, "status");
+            JsonNode props = first.get("properties");
+            if (props != null) {
+                result.set("properties", props);
+            }
+            JsonNode contents = first.get("contents");
+            JsonNode lossNode = contents != null ? contents.get("json/losses.json") : null;
+            if (lossNode != null) {
+                String url = lossNode.get("url").asText();
+                feature.put("loss_url", url);
+                String body = fetchUrl(url);
+                if (body != null) {
+                    JsonNode loss = JsonUtil.readTree(body);
+                    result.set("loss_estimations", loss);
+                } else {
+                    feature.put("loss_estimation_retrieval", false);
+                    return;
+                }
+            } else {
+                feature.put("loss_estimation_retrieval", false);
+                return;
+            }
+            ArrayNode arr = feature.putArray("loss_estimation");
+            arr.add(result);
+        } catch (Exception e) {
+            LOG.warn("Failed to enrich feature with loss estimation", e);
+            feature.put("loss_estimation_retrieval", false);
+        }
+    }
+
+    private void copyField(JsonNode from, ObjectNode to, String field) {
+        JsonNode node = from.get(field);
+        if (node != null) {
+            to.set(field, node);
+        }
+    }
+
+    private String fetchUrl(String url) {
+        try {
+            HttpRequest request = HttpRequest.newBuilder(URI.create(url)).GET().build();
+            HttpResponse<String> resp = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (resp.statusCode() == 200) {
+                return resp.body();
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to download url {}", url, e);
+        }
+        return null;
+    }
+}

--- a/src/main/java/io/kontur/eventapi/usgs/earthquake/job/UsgsEarthquakeNormalizationJob.java
+++ b/src/main/java/io/kontur/eventapi/usgs/earthquake/job/UsgsEarthquakeNormalizationJob.java
@@ -1,0 +1,65 @@
+package io.kontur.eventapi.usgs.earthquake.job;
+
+import io.kontur.eventapi.dao.DataLakeDao;
+import io.kontur.eventapi.dao.NormalizedObservationsDao;
+import io.kontur.eventapi.entity.DataLake;
+import io.kontur.eventapi.job.AbstractJob;
+import io.kontur.eventapi.usgs.earthquake.converter.UsgsEarthquakeDataLakeConverter;
+import io.kontur.eventapi.usgs.earthquake.normalization.UsgsEarthquakeNormalizer;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+
+import java.util.List;
+
+@Component
+public class UsgsEarthquakeNormalizationJob extends AbstractJob {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UsgsEarthquakeNormalizationJob.class);
+    private final UsgsEarthquakeNormalizer normalizer;
+    private final DataLakeDao dataLakeDao;
+    private final NormalizedObservationsDao observationsDao;
+
+    public UsgsEarthquakeNormalizationJob(MeterRegistry meterRegistry,
+                                          UsgsEarthquakeNormalizer normalizer,
+                                          DataLakeDao dataLakeDao,
+                                          NormalizedObservationsDao observationsDao) {
+        super(meterRegistry);
+        this.normalizer = normalizer;
+        this.dataLakeDao = dataLakeDao;
+        this.observationsDao = observationsDao;
+    }
+
+    @Override
+    public String getName() {
+        return "usgsEarthquakeNormalization";
+    }
+
+    @Override
+    public void execute() {
+        List<DataLake> dataLakes = dataLakeDao.getDenormalizedEvents(
+                List.of(UsgsEarthquakeDataLakeConverter.USGS_EARTHQUAKE_PROVIDER));
+        if (CollectionUtils.isEmpty(dataLakes)) {
+            LOG.debug("No USGS earthquake data to normalize");
+            return;
+        }
+
+        LOG.info("USGS normalization: {} data lakes", dataLakes.size());
+        for (DataLake dl : dataLakes) {
+            try {
+                LOG.debug("Normalizing USGS earthquake {} at {}", dl.getExternalId(), dl.getUpdatedAt());
+                if (!normalizer.isSkipped()) {
+                    observationsDao.insert(normalizer.normalize(dl));
+                    LOG.info("USGS earthquake {} normalized", dl.getExternalId());
+                } else {
+                    dataLakeDao.markAsSkipped(dl.getObservationId());
+                    LOG.info("USGS earthquake {} skipped", dl.getExternalId());
+                }
+            } catch (Exception e) {
+                LOG.warn("Failed to normalize USGS earthquake {}", dl.getExternalId(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/io/kontur/eventapi/usgs/earthquake/normalization/UsgsEarthquakeNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/usgs/earthquake/normalization/UsgsEarthquakeNormalizer.java
@@ -1,0 +1,355 @@
+package io.kontur.eventapi.usgs.earthquake.normalization;
+
+import io.kontur.eventapi.entity.DataLake;
+import io.kontur.eventapi.entity.EventType;
+import io.kontur.eventapi.entity.NormalizedObservation;
+import io.kontur.eventapi.entity.Severity;
+import io.kontur.eventapi.normalization.Normalizer;
+import io.kontur.eventapi.usgs.earthquake.converter.UsgsEarthquakeDataLakeConverter;
+import io.kontur.eventapi.util.JsonUtil;
+import io.kontur.eventapi.util.GeometryUtil;
+import io.kontur.eventapi.dao.ShakemapDao;
+import static io.kontur.eventapi.util.SeverityUtil.PGA40_MASK;
+import static io.kontur.eventapi.util.SeverityUtil.COVERAGE_PGA_HIGHRES;
+import org.wololo.geojson.Feature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.wololo.geojson.FeatureCollection;
+import org.wololo.geojson.Point;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+import java.time.OffsetDateTime;
+import java.util.*;
+
+import static io.kontur.eventapi.util.GeometryUtil.*;
+
+@Component
+public class UsgsEarthquakeNormalizer extends Normalizer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UsgsEarthquakeNormalizer.class);
+
+    private static final DateTimeFormatter DESCRIPTION_DATE_FORMATTER =
+            DateTimeFormatter.ofPattern("M/d/yyyy h:mm:ss a", Locale.US);
+
+    private final ShakemapDao shakemapDao;
+
+    private static final Map<String, String> NETWORKS = Map.ofEntries(
+        Map.entry("admin", "USGS Administrative"),
+            Map.entry("ak", "Alaska Earthquake Center"),
+            Map.entry("at", "National Tsunami Warning Center"),
+            Map.entry("atlas", "ATLAS seismic network"),
+            Map.entry("av", "Alaska Volcano Observatory"),
+            Map.entry("cgs", "California Geological Survey"),
+            Map.entry("ci", "California Integrated Seismic Network (Caltech/USGS)"),
+            Map.entry("ew", "Early Warning (ShakeAlert earthquake early warning)"),
+            Map.entry("hv", "Hawaiian Volcano Observatory"),
+            Map.entry("ismp", "Idaho Strong Motion Program"),
+            Map.entry("ld", "Lamont-Doherty Cooperative Seismographic Network"),
+            Map.entry("mb", "Montana Bureau of Mines and Geology"),
+            Map.entry("nc", "Northern California Seismic System"),
+            Map.entry("nm", "New Madrid Seismic Network"),
+            Map.entry("nn", "Nevada Seismological Laboratory"),
+            Map.entry("np", "National Strong-Motion Project"),
+            Map.entry("official", "Official"),
+            Map.entry("ok", "Oklahoma Geological Survey"),
+            Map.entry("pr", "Puerto Rico Seismic Network"),
+            Map.entry("pt", "Pacific Tsunami Warning Center"),
+            Map.entry("se", "Center for Earthquake Research and Information"),
+            Map.entry("tx", "Texas Seismological Network"),
+            Map.entry("us", "USGS National Earthquake Information Center"),
+            Map.entry("uu", "University of Utah Seismograph Stations"),
+        Map.entry("uw", "Pacific Northwest Seismic Network")
+    );
+
+    public UsgsEarthquakeNormalizer(ShakemapDao shakemapDao) {
+        this.shakemapDao = shakemapDao;
+    }
+
+    private static Severity mapAlert(String alert) {
+        if (alert == null) return Severity.UNKNOWN;
+        return switch (alert) {
+            case "green" -> Severity.MINOR;
+            case "yellow" -> Severity.MODERATE;
+            case "orange" -> Severity.SEVERE;
+            case "red" -> Severity.EXTREME;
+            default -> Severity.UNKNOWN;
+        };
+    }
+
+    @Override
+    public boolean isApplicable(DataLake dataLake) {
+        return UsgsEarthquakeDataLakeConverter.USGS_EARTHQUAKE_PROVIDER.equals(dataLake.getProvider());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public NormalizedObservation normalize(DataLake dataLake) {
+        LOG.debug("Start normalization of USGS earthquake {}", dataLake.getExternalId());
+        Map<String, Object> feature = JsonUtil.readJson(dataLake.getData(), Map.class);
+        NormalizedObservation obs = new NormalizedObservation();
+        List<Feature> geometryFeatures = new ArrayList<>();
+        Double depthKm = null;
+        Double magnitude = null;
+        Double maxPga = null;
+        Severity eventSeverity = Severity.UNKNOWN;
+        obs.setObservationId(dataLake.getObservationId());
+        obs.setProvider(dataLake.getProvider());
+        obs.setLoadedAt(dataLake.getLoadedAt());
+        obs.setSourceUpdatedAt(dataLake.getUpdatedAt());
+        obs.setEndedAt(dataLake.getUpdatedAt());
+        obs.setActive(true);
+        obs.setType(EventType.EARTHQUAKE);
+        obs.setRecombined(false);
+        obs.setNormalizedAt(OffsetDateTime.now());
+
+        obs.setExternalEventId(readString(feature, "id"));
+
+        Map<String, Object> props = (Map<String, Object>) feature.get("properties");
+        if (props != null) {
+            String place = readString(props, "place");
+            obs.setDescription(place);
+            magnitude = readDouble(props, "mag");
+            if (magnitude != null && place != null) {
+                obs.setName(String.format(Locale.US, "M %.1f - %s", magnitude, place));
+            } else if (magnitude != null) {
+                obs.setName(String.format(Locale.US, "M %.1f", magnitude));
+            } else if (place != null) {
+                obs.setName(place);
+            }
+            obs.setProperName(null);
+            obs.setStartedAt(readDateTime(props, "time"));
+
+            if (place != null) {
+                int idx = place.lastIndexOf(',');
+                obs.setRegion(idx >= 0 ? place.substring(idx + 1).trim() : place);
+            }
+
+            Integer sig = readInt(props, "sig");
+            eventSeverity = defineSeverityFromSig(sig);
+            String net = readString(props, "net");
+            if (net == null) {
+                net = readString(props, "source");
+            }
+            if (net != null) {
+                Map<String, String> originMap = Map.of(
+                        "code", net,
+                        "origin_name", NETWORKS.getOrDefault(net, net)
+                );
+                obs.setOrigin(JsonUtil.writeJson(originMap));
+            }
+            List<String> urls = new ArrayList<>();
+            String url = readString(props, "url");
+            String detail = readString(props, "detail");
+            if (url != null) urls.add(url);
+            if (detail != null) urls.add(detail);
+            String shmUrl = readString(props, "shm_url");
+            if (shmUrl != null) urls.add(shmUrl);
+            String detailUrl = readString(feature, "detail_url");
+            if (detailUrl != null) urls.add(detailUrl);
+            String lossUrl = readString(feature, "loss_url");
+            if (lossUrl != null) urls.add(lossUrl);
+            obs.setUrls(urls);
+            Object smObj = feature.get("shakemap");
+            Map<String, Object> shakemap = null;
+            if (smObj instanceof List<?> list) {
+                LOG.debug("ShakeMap is array with {} item(s)", list.size());
+                if (!list.isEmpty() && list.get(0) instanceof Map<?, ?> first) {
+                    shakemap = (Map<String, Object>) first;
+                } else {
+                    LOG.debug("ShakeMap array is empty or first element is not a map");
+                }
+            } else if (smObj instanceof Map<?, ?>) {
+                LOG.debug("ShakeMap is an object");
+                shakemap = (Map<String, Object>) smObj;
+            } else if (smObj != null) {
+                LOG.debug("Unexpected ShakeMap type: {}", smObj.getClass());
+            } else {
+                LOG.debug("No ShakeMap found in root object");
+            }
+            if (shakemap != null) {
+                Map<String, Object> shaProps = (Map<String, Object>) shakemap.get("properties");
+                if (shaProps != null) {
+                    maxPga = enrichPgaMask(shakemap, shaProps);
+                    obs.setSeverityData(shaProps);
+                }
+
+                FeatureCollection smPolygons = buildShakemapPolygons(shakemap);
+                if (smPolygons != null) {
+                    Feature[] smFeatures = smPolygons.getFeatures();
+                    if (smFeatures != null) {
+                        for (Feature smFeature : smFeatures) {
+                            Map<String, Object> polygonProps = smFeature.getProperties() == null
+                                    ? new HashMap<>()
+                                    : new HashMap<>(smFeature.getProperties());
+
+                        Object valObj = polygonProps.get("value");
+                        String intensity = null;
+                        if (valObj != null) {
+                            try {
+                                double val = Double.parseDouble(valObj.toString());
+                                intensity = (val % 1 == 0)
+                                        ? String.valueOf((int) val)
+                                        : String.format(Locale.US, "%.1f", val);
+                            } catch (NumberFormatException ignored) {
+                                intensity = valObj.toString();
+                            }
+                        }
+
+                        if (intensity != null) {
+                            polygonProps.put("Class", "Poly_SMPInt_" + intensity);
+                            polygonProps.put("eventid", dataLake.getExternalId());
+                            polygonProps.put("eventtype", "EQ");
+                            polygonProps.put("polygonlabel", "Intensity " + intensity);
+                        }
+
+                            geometryFeatures.add(new Feature(smFeature.getGeometry(), polygonProps));
+                        }
+                        LOG.debug("Appended {} ShakeMap polygon(s)", smFeatures.length);
+                    } else {
+                        LOG.debug("ShakeMap polygons feature array is null");
+                    }
+                } else {
+                    LOG.debug("No ShakeMap polygons were built");
+                }
+            }
+        }
+
+        Map<String, Object> geometry = (Map<String, Object>) feature.get("geometry");
+        if (geometry != null) {
+            List<?> coords = (List<?>) geometry.get("coordinates");
+            if (coords != null && coords.size() >= 2) {
+                Double lon = Double.valueOf(coords.get(0).toString());
+                Double lat = Double.valueOf(coords.get(1).toString());
+                if (coords.size() >= 3) {
+                    depthKm = Double.valueOf(coords.get(2).toString());
+                }
+                Point point = new Point(new double[]{lon, lat});
+                FeatureCollection fc = convertGeometryToFeatureCollection(point, Map.of(AREA_TYPE_PROPERTY, CENTER_POINT));
+                geometryFeatures.addAll(Arrays.asList(fc.getFeatures()));
+
+                try {
+                    String circleJson = shakemapDao.buildCentroidBuffer(lon, lat);
+                    if (circleJson != null) {
+                        org.wololo.geojson.Geometry circle = JsonUtil.readJson(circleJson, org.wololo.geojson.Geometry.class);
+                        Map<String, Object> circleProps = new HashMap<>();
+                        circleProps.put("Class", "Poly_Circle");
+                        circleProps.put("eventid", dataLake.getExternalId());
+                        circleProps.put("areaType", ALERT_AREA);
+                        circleProps.put("eventtype", "EQ");
+                        circleProps.put("polygonlabel", "100km");
+                        geometryFeatures.add(new Feature(circle, circleProps));
+                        LOG.debug("Appended 100km buffer polygon");
+                    } else {
+                        LOG.debug("buildCentroidBuffer returned null JSON");
+                    }
+                } catch (Exception e) {
+                    LOG.warn("Failed to build 100km buffer polygon", e);
+                }
+            }
+        }
+
+        if (obs.getStartedAt() != null) {
+            String dateStr = obs.getStartedAt().format(DESCRIPTION_DATE_FORMATTER);
+            StringBuilder sb = new StringBuilder();
+            sb.append("On ").append(dateStr).append(", an earthquake occurred ");
+            if (obs.getDescription() != null) {
+                sb.append(obs.getDescription());
+            }
+            sb.append(". The earthquake had");
+            if (magnitude != null) {
+                sb.append(" Magnitude ").append(magnitude).append("M,");
+            }
+            if (depthKm != null) {
+                sb.append(" Depth:").append(depthKm).append("km.");
+            } else {
+                if (sb.charAt(sb.length() - 1) == ',') {
+                    sb.setCharAt(sb.length() - 1, '.');
+                } else {
+                    sb.append('.');
+                }
+            }
+            obs.setEpisodeDescription(sb.toString());
+        }
+
+        if (!geometryFeatures.isEmpty()) {
+            obs.setGeometries(new FeatureCollection(geometryFeatures.toArray(new Feature[0])));
+        }
+
+        if ((maxPga != null && maxPga >= 0.4) || (magnitude != null && magnitude >= 7.5)) {
+            if (eventSeverity.getValue() < Severity.SEVERE.getValue()) {
+                eventSeverity = Severity.SEVERE;
+            }
+        }
+        obs.setEventSeverity(eventSeverity);
+
+        LOG.debug("Finished normalization of USGS earthquake {}", dataLake.getExternalId());
+        return obs;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Double enrichPgaMask(Map<String, Object> shakemap, Map<String, Object> shaProps) {
+        try {
+            Object maxPgaObj = shaProps.get("maxpga");
+            Double maxPga = null;
+            if (maxPgaObj != null) {
+                String pgaStr = maxPgaObj.toString();
+                try {
+                    maxPga = Double.valueOf(pgaStr);
+                } catch (NumberFormatException ignored) {
+                    LOG.debug("Cannot parse maxpga value '{}'", pgaStr);
+                }
+            }
+
+            Object coverage = shakemap.get("coverage_pga_high_res");
+            if (coverage instanceof Map) {
+                //noinspection unchecked
+                shaProps.put(COVERAGE_PGA_HIGHRES, (Map<String, Object>) coverage);
+
+                if (maxPga != null && maxPga >= 0.4) {
+                    String mask = shakemapDao.buildPgaMask(JsonUtil.writeJson(coverage));
+                    if (mask != null) {
+                        shaProps.put(PGA40_MASK, JsonUtil.readJson(mask, Map.class));
+                    }
+                }
+            }
+            return maxPga;
+        } catch (Exception e) {
+            LOG.warn("Failed to build PGA mask", e);
+            return null;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private FeatureCollection buildShakemapPolygons(Map<String, Object> shakemap) {
+        Object contObj = shakemap.get("cont_mmi");
+        if (!(contObj instanceof Map)) {
+            LOG.debug("ShakeMap does not contain cont_mmi section");
+            return null;
+        }
+        try {
+            String fcJson = shakemapDao.buildShakemapPolygons(JsonUtil.writeJson(contObj));
+            if (fcJson == null) {
+                LOG.debug("buildShakemapPolygons returned null JSON");
+                return null;
+            }
+            LOG.debug("ShakeMap polygons JSON size: {} bytes", fcJson.length());
+            return JsonUtil.readJson(fcJson, FeatureCollection.class);
+        } catch (Exception e) {
+            LOG.warn("Failed to build ShakeMap polygons", e);
+            return null;
+        }
+    }
+
+    private Severity defineSeverityFromSig(Integer sig) {
+        if (sig == null) return Severity.UNKNOWN;
+        if (sig >= 900) return Severity.EXTREME;
+        if (sig >= 600) return Severity.SEVERE;
+        if (sig >= 450) return Severity.MODERATE;
+        if (sig >= 300) return Severity.MINOR;
+        return Severity.UNKNOWN;
+    }
+
+}

--- a/src/main/java/io/kontur/eventapi/util/SeverityUtil.java
+++ b/src/main/java/io/kontur/eventapi/util/SeverityUtil.java
@@ -19,6 +19,8 @@ public class SeverityUtil {
     public final static String FUJITA_SCALE = "fujitaScale";
     public final static String TORNADO_LENGTH_KM = "tornadoLengthKm";
     public final static String TORNADO_WIDTH_M = "tornadoWidthM";
+    public final static String PGA40_MASK = "pga40Mask";
+    public final static String COVERAGE_PGA_HIGHRES = "coverage_pga_highres";
 
     public final static String CATEGORY_TD = "TD";
     public final static String CATEGORY_TS = "TS";

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -22,6 +22,9 @@ humanitarianCrisis:
 staticdata:
   s3Folder: 'TEST DEV/'
 
+usgs:
+  host: 'https://earthquake.usgs.gov'
+
 aws:
   sqs:
     enabled: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -19,6 +19,9 @@ pdc:
 staticdata:
   s3Folder: 'PROD/'
 
+usgs:
+  host: 'https://earthquake.usgs.gov'
+
 humanitarianCrisis:
   s3Folder: 'kontur_events/PROD/'
 

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -16,6 +16,9 @@ pdc:
   host: 'https://testemops.pdc.org'
   mapSrvHost: 'https://testapps.pdc.org'
 
+usgs:
+  host: 'https://earthquake.usgs.gov'
+
 staticdata:
   s3Folder: 'TEST QA/'
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -88,6 +88,9 @@ nifc:
 inciweb:
   host: 'https://inciweb.nwcg.gov'
 
+usgs:
+  host: 'https://earthquake.usgs.gov'
+
 nhc:
   host: 'https://www.nhc.noaa.gov'
 
@@ -150,6 +153,10 @@ scheduler:
     enable: true
     initialDelay: 1000
     fixedDelay: 300000
+  usgsEarthquakeImport:
+    enable: true
+    initialDelay: 1000
+    fixedDelay: 300000
   inciwebImport:
     enable: false
     initialDelay: 1000
@@ -178,7 +185,7 @@ scheduler:
       tornado.australian-bm, tornado.osm-wiki, tornado.des-inventar-sendai, storms.noaa, wildfire.frap.cal,
       wildfire.sa-gov, wildfire.qld-des-gov, wildfire.victoria-gov, wildfire.nsw-gov, wildfire.calfire,
       wildfire.perimeters.nifc, wildfire.locations.nifc, cyclones.nhc-at.noaa, cyclones.nhc-ep.noaa, cyclones.nhc-cp.noaa,
-      pdcSqs, pdcMapSrv, pdcSqsNasa, pdcMapSrvNasa
+      pdcSqs, pdcMapSrv, pdcSqsNasa, pdcMapSrvNasa, usgs.earthquake
   eventCombination:
     enable: true
     initialDelay: 1000
@@ -187,7 +194,7 @@ scheduler:
       tornado.australian-bm, tornado.osm-wiki, tornado.des-inventar-sendai, storms.noaa, wildfire.frap.cal,
       wildfire.sa-gov, wildfire.qld-des-gov, wildfire.victoria-gov, wildfire.nsw-gov, wildfire.calfire,
       wildfire.perimeters.nifc, wildfire.locations.nifc, cyclones.nhc-at.noaa, cyclones.nhc-ep.noaa, cyclones.nhc-cp.noaa,
-      pdcSqs, pdcMapSrv, pdcSqsNasa, pdcMapSrvNasa
+      pdcSqs, pdcMapSrv, pdcSqsNasa, pdcMapSrvNasa, usgs.earthquake
   feedComposition:
     enable: true
     initialDelay: 1000

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -73,3 +73,6 @@ databaseChangeLog:
 - include:
     relativeToChangelogFile: true
     file: v1.22.0/v1.22.0.yaml
+- include:
+    relativeToChangelogFile: true
+    file: v1.23.0/v1.23.0.yaml

--- a/src/main/resources/db/changelog/v1.23.0/add-usgs-to-feeds.sql
+++ b/src/main/resources/db/changelog/v1.23.0/add-usgs-to-feeds.sql
@@ -1,0 +1,12 @@
+--liquibase formatted sql
+
+--changeset event-api-migrations:v1.24.0/add-usgs-to-feeds.sql runOnChange:true
+
+update feeds
+set providers = '{"em-dat","tornado.canada-gov","tornado.australian-bm","tornado.osm-wiki","tornado.des-inventar-sendai","storms.noaa","wildfire.frap.cal","wildfire.sa-gov","wildfire.qld-des-gov","wildfire.victoria-gov","wildfire.nsw-gov","wildfire.calfire","wildfire.perimeters.nifc","wildfire.locations.nifc","cyclones.nhc-at.noaa","cyclones.nhc-ep.noaa","cyclones.nhc-cp.noaa","usgs.earthquake"}'::text[]
+where alias = 'kontur-private';
+
+update feeds
+set providers = '{"wildfire.calfire","wildfire.perimeters.nifc","wildfire.locations.nifc","storms.noaa","gdacsAlert","gdacsAlertGeometry","cyclones.nhc-at.noaa","cyclones.nhc-ep.noaa","cyclones.nhc-cp.noaa","usgs.earthquake"}'::text[],
+    description = 'Feed from California Department of Forestry and Fire Protection (CAL FIRE), National Interagency Fire Center (NIFC), National Oceanic and Atmospheric Administration (NOAA, Storm Events Database), Global Disaster Alert and coordination system (GDACS), National Hurricane Center (NHC), US Geological Survey (USGS)'
+where alias = 'micglobal';

--- a/src/main/resources/db/changelog/v1.23.0/create-pga-mask-function.sql
+++ b/src/main/resources/db/changelog/v1.23.0/create-pga-mask-function.sql
@@ -1,0 +1,65 @@
+--liquibase formatted sql
+
+--changeset event-api-migrations:v1.25.0/create-pga-mask-function.sql runOnChange:true
+
+drop function if exists buildPgaMask;
+
+create function buildPgaMask(jsonb) returns geometry
+    language sql
+    volatile
+    strict
+    parallel safe
+as $_$
+    with meta as (
+        select
+            ($1 #>> '{domain,axes,x,start}')::float8  as x0,
+            ($1 #>> '{domain,axes,x,stop}')::float8   as xN,
+            ($1 #>> '{domain,axes,x,num}')::int       as nx,
+            ($1 #>> '{domain,axes,y,start}')::float8  as y0,
+            ($1 #>> '{domain,axes,y,stop}')::float8   as yN,
+            ($1 #>> '{domain,axes,y,num}')::int       as ny,
+            $1  #>  '{ranges,PGA,values}'            as vals
+    ),
+    vals as (
+        select (v.value)::float8 as ln_pga,
+               v.ordinality-1    as idx
+        from meta,
+             jsonb_array_elements(meta.vals) with ordinality as v(value, ordinality)
+    ),
+    filtered as (
+        select idx from vals where ln_pga > ln(0.40)
+    ),
+    grid as (
+        select
+            idx / m.nx as j,
+            idx % m.nx as i,
+            m.*,
+            (m.xN - m.x0)::float8 / (m.nx - 1) as dx,
+            (m.yN - m.y0)::float8 / (m.ny - 1) as dy
+        from filtered
+        cross join meta m
+    ),
+    cells as (
+        select
+            ST_SnapToGrid(
+                ST_MakeEnvelope(
+                    x0 + i*dx - 0.5*dx,
+                    y0 + j*dy - 0.5*dy,
+                    x0 + i*dx + 0.5*dx,
+                    y0 + j*dy + 0.5*dy,
+                    4326
+                ),
+                dx/100.0, dy/100.0
+            )::geometry(Polygon,4326) as geom
+        from grid
+    ),
+    unioned as (
+        select ST_Union(geom)::geometry(MultiPolygon,4326) as geom
+        from cells
+    )
+    select CASE
+               WHEN ST_XMax(geom) > 180 OR ST_XMin(geom) < -180 THEN ST_ShiftLongitude(geom)
+               ELSE geom
+           END
+    from unioned;
+$_$;

--- a/src/main/resources/db/changelog/v1.23.0/create-shakemap-polygons-function.sql
+++ b/src/main/resources/db/changelog/v1.23.0/create-shakemap-polygons-function.sql
@@ -1,0 +1,132 @@
+--liquibase formatted sql
+
+--changeset event-api-migrations:v1.23.0/create-shakemap-polygons-function.sql runOnChange:true
+
+drop function if exists buildShakemapPolygons;
+
+create function buildShakemapPolygons(jsonb) returns jsonb
+    language sql
+    volatile
+    strict
+    parallel safe
+as $_$
+    with params as (
+        select $1 -> 'bbox' as bbox,
+               $1 -> 'features' as features
+    ),
+    bbox as (
+        select ST_Boundary(
+                   ST_MakeEnvelope(
+                       (bbox ->> 0)::double precision,
+                       (bbox ->> 1)::double precision,
+                       (bbox ->> 2)::double precision,
+                       (bbox ->> 3)::double precision,
+                       4326
+                   )
+               ) as geom
+        from params
+    ),
+    lines as (
+        select jsonb_array_elements(features) -> 'properties' as properties,
+               ST_GeomFromGeoJSON(jsonb_array_elements(features) -> 'geometry') as geom
+        from params
+    ),
+    linework as (
+        select ST_UnaryUnion(
+                   ST_Collect( ARRAY[
+                       (select geom from bbox),
+                       (select ST_Collect(geom) from lines)
+                   ])
+               )::geometry(MultiLineString,4326) as geom
+    ),
+    noded as (
+        select ST_Node(geom) as geom
+        from linework
+    ),
+    polys as (
+        select (ST_Dump(ST_Polygonize(geom))).geom::geometry(Polygon,4326) as geom
+        from noded
+    ),
+    poly_attr as (
+        select row_number() over () as id,
+               p.geom as geom,
+               (l.props ->> 'value')::float as mmi,
+               l.props as props
+        from polys p
+        cross join lateral (
+            select properties as props
+            from lines
+            order by p.geom <-> geom
+            limit 1
+        ) l
+    ),
+    vals as (
+        select mmi,
+               lag(mmi) over(order by mmi) as lower_mmi
+        from (
+            select distinct mmi
+            from poly_attr
+            order by mmi
+        ) v
+    ),
+    ext as (
+        select min(mmi) as min_mmi,
+               max(mmi) as max_mmi
+        from poly_attr
+    ),
+    neighbors_equal as (
+        select a.id,
+               bool_and(coalesce(b.mmi, a.mmi) = a.mmi) as all_equal
+        from poly_attr a
+        left join poly_attr b on a.id <> b.id and ST_Touches(a.geom, b.geom)
+        group by a.id
+    ),
+    step1 as (
+        select a.id,
+               a.geom,
+               case
+                   when ne.all_equal and a.mmi = (select max_mmi from ext) then a.mmi
+                   when ne.all_equal and a.mmi = (select min_mmi from ext) then null
+                   when ne.all_equal then v.lower_mmi
+                   else a.mmi
+               end as mmi,
+               a.props
+        from poly_attr a
+        join neighbors_equal ne on ne.id = a.id
+        left join vals v on v.mmi = a.mmi
+    ),
+    neighbors_null as (
+        select s.id,
+               bool_and(n.mmi is null) as all_null
+        from step1 s
+        left join step1 n on s.id <> n.id and ST_Touches(s.geom, n.geom)
+        group by s.id
+    ),
+    final as (
+        select s.geom,
+               (s.props - 'Class' - 'country' - 'areaType') as props,
+               case
+                   when s.mmi is null and nn.all_null then (select min_mmi from ext)
+                   else s.mmi
+               end as value
+        from step1 s
+        left join neighbors_null nn on nn.id = s.id
+    )
+    select jsonb_build_object(
+        'type','FeatureCollection',
+        'features', jsonb_agg(
+            jsonb_build_object(
+                'type','Feature',
+                'geometry', ST_AsGeoJSON(
+                    CASE
+                        WHEN ST_XMax(f.geom) > 180 OR ST_XMin(f.geom) < -180 THEN ST_ShiftLongitude(f.geom)
+                        ELSE f.geom
+                    END
+                )::jsonb,
+                'properties', f.props || jsonb_build_object('value', f.value)
+            )
+        )
+    )
+    from final f
+    where f.value is not null;
+$_$;

--- a/src/main/resources/db/changelog/v1.23.0/v1.23.0.yaml
+++ b/src/main/resources/db/changelog/v1.23.0/v1.23.0.yaml
@@ -1,0 +1,26 @@
+databaseChangeLog:
+  - changeSet:
+      id: v1.23.0/create-shakemap-polygons-function
+      author: event-api-migrations
+      changes:
+        - sqlFile:
+            path: create-shakemap-polygons-function.sql
+            relativeToChangelogFile: true
+            splitStatements: false
+            endDelimiter: $_$;
+  - changeSet:
+      id: v1.23.0/add-usgs-to-feeds
+      author: event-api-migrations
+      changes:
+        - sqlFile:
+            path: add-usgs-to-feeds.sql
+            relativeToChangelogFile: true
+  - changeSet:
+      id: v1.23.0/create-pga-mask-function
+      author: event-api-migrations
+      changes:
+        - sqlFile:
+            path: create-pga-mask-function.sql
+            relativeToChangelogFile: true
+            splitStatements: false
+            endDelimiter: $_$;

--- a/src/main/resources/db/mappers/DataLakeMapper.xml
+++ b/src/main/resources/db/mappers/DataLakeMapper.xml
@@ -4,9 +4,13 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="io.kontur.eventapi.dao.mapper.DataLakeMapper">
 
-    <insert id="create" useGeneratedKeys="false">
-        insert into data_lake (observation_id, external_id, updated_at, loaded_at, provider, data, normalized, skipped)
-        values (#{observationId}, #{externalId}, #{updatedAt}, #{loadedAt}, #{provider}, #{data}, #{normalized}, #{skipped})
+    <insert id="create" parameterType="io.kontur.eventapi.entity.DataLake" useGeneratedKeys="false">
+        insert into data_lake (observation_id, external_id, updated_at, loaded_at,
+                               provider, data, normalized, skipped)
+        values (#{observationId}, #{externalId}, #{updatedAt}, #{loadedAt},
+                #{provider}, #{data}, #{normalized}, #{skipped})
+        on conflict on constraint data_lake_external_id_provider_updated_at_key
+        do nothing
     </insert>
 
     <insert id="markAsNormalized">

--- a/src/main/resources/db/mappers/NormalizedObservationsMapper.xml
+++ b/src/main/resources/db/mappers/NormalizedObservationsMapper.xml
@@ -111,6 +111,37 @@
         select count(*) from normalized_observations where not recombined;
     </select>
 
+    <select id="buildShakemapPolygons" resultType="string">
+        select buildShakemapPolygons(#{json}::jsonb)::text
+    </select>
+
+    <select id="buildPgaMask" resultType="string">
+        select ST_AsGeoJSON(
+                   CASE
+                       WHEN ST_XMax(g) - ST_XMin(g) > 180 THEN ST_ShiftLongitude(g)
+                       ELSE g
+                   END
+               )
+        from (
+            select buildPgaMask(#{json}::jsonb) as g
+        ) s
+    </select>
+
+    <select id="buildCentroidBuffer" resultType="string">
+        select ST_AsGeoJSON(
+                   CASE
+                       WHEN ST_XMax(g) - ST_XMin(g) > 180 THEN ST_ShiftLongitude(g)
+                       ELSE g
+                   END, 6, 4
+               )
+        from (
+            select ST_Buffer(
+                       ST_SetSRID(ST_MakePoint(#{lon}, #{lat}), 4326)::geography,
+                       100000
+                   )::geometry as g
+        ) s
+    </select>
+
     <resultMap id="normalizedObservationsDtoMap" type="io.kontur.eventapi.entity.NormalizedObservation">
         <result property="observationId" column="observation_id"/>
         <result property="externalEventId" column="external_event_id"/>

--- a/src/test/java/io/kontur/eventapi/config/WorkerSchedulerTest.java
+++ b/src/test/java/io/kontur/eventapi/config/WorkerSchedulerTest.java
@@ -28,6 +28,8 @@ import io.kontur.eventapi.staticdata.job.StaticImportJob;
 import io.kontur.eventapi.tornadojapanma.job.HistoricalTornadoJapanMaImportJob;
 import io.kontur.eventapi.tornadojapanma.job.TornadoJapanMaImportJob;
 import io.kontur.eventapi.uhc.job.HumanitarianCrisisImportJob;
+import io.kontur.eventapi.usgs.earthquake.job.UsgsEarthquakeImportJob;
+import io.kontur.eventapi.usgs.earthquake.job.UsgsEarthquakeNormalizationJob;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -62,6 +64,8 @@ class WorkerSchedulerTest {
     private final FirmsEventCombinationJob firmsEventCombinationJob = mock(FirmsEventCombinationJob.class);
     private final CalFireSearchJob calFireSearchJob = mock(CalFireSearchJob.class);
     private final NifcImportJob nifcImportJob = mock(NifcImportJob.class);
+    private final UsgsEarthquakeImportJob usgsEarthquakeImportJob = mock(UsgsEarthquakeImportJob.class);
+    private final UsgsEarthquakeNormalizationJob usgsEarthquakeNormalizationJob = mock(UsgsEarthquakeNormalizationJob.class);
     private final InciWebImportJob inciWebImportJob = mock(InciWebImportJob.class);
     private final HumanitarianCrisisImportJob humanitarianCrisisImportJob = mock(HumanitarianCrisisImportJob.class);
     private final NhcAtImportJob nhcAtImportJob = mock(NhcAtImportJob.class);
@@ -75,8 +79,8 @@ class WorkerSchedulerTest {
             eventCombinationJob, firmsEventCombinationJob, feedCompositionJob, firmsImportModisJob, firmsImportNoaaJob,
             firmsImportSuomiJob, emDatImportJob, staticImportJob, stormsNoaaImportJob, tornadoJapanMaImportJob,
             historicalTornadoJapanMaImportJob, pdcMapSrvSearchJobs, enrichmentJob, calFireSearchJob,
-            nifcImportJob, inciWebImportJob, humanitarianCrisisImportJob, nhcAtImportJob, nhcCpImportJob, nhcEpImportJob,
-            metricsJob, reEnrichmentJob, eventExpirationJob);
+            nifcImportJob, usgsEarthquakeImportJob, usgsEarthquakeNormalizationJob, inciWebImportJob, humanitarianCrisisImportJob, nhcAtImportJob,
+            nhcCpImportJob, nhcEpImportJob, metricsJob, reEnrichmentJob, eventExpirationJob);
 
     @AfterEach
     public void resetMocks() {
@@ -95,6 +99,8 @@ class WorkerSchedulerTest {
         Mockito.reset(historicalTornadoJapanMaImportJob);
         Mockito.reset(pdcMapSrvSearchJobs);
         Mockito.reset(calFireSearchJob);
+        Mockito.reset(usgsEarthquakeImportJob);
+        Mockito.reset(usgsEarthquakeNormalizationJob);
         Mockito.reset(inciWebImportJob);
         Mockito.reset(reEnrichmentJob);
         Mockito.reset(eventExpirationJob);
@@ -322,6 +328,38 @@ class WorkerSchedulerTest {
         scheduler.startCalFireSearchJob();
 
         verify(calFireSearchJob, never()).run();
+    }
+
+    @Test
+    public void startUsgsEarthquakeImportJob() {
+        ReflectionTestUtils.setField(scheduler, "usgsEarthquakeImportEnabled", "true");
+        scheduler.startUsgsEarthquakeImport();
+
+        verify(usgsEarthquakeImportJob, times(1)).run();
+    }
+
+    @Test
+    public void startUsgsEarthquakeNormalizationJob() {
+        ReflectionTestUtils.setField(scheduler, "normalizationEnabled", "true");
+        scheduler.startUsgsEarthquakeNormalization();
+
+        verify(usgsEarthquakeNormalizationJob, times(1)).run();
+    }
+
+    @Test
+    public void skipUsgsEarthquakeImportJob() {
+        ReflectionTestUtils.setField(scheduler, "usgsEarthquakeImportEnabled", "false");
+        scheduler.startUsgsEarthquakeImport();
+
+        verify(usgsEarthquakeImportJob, never()).run();
+    }
+
+    @Test
+    public void skipUsgsEarthquakeNormalizationJob() {
+        ReflectionTestUtils.setField(scheduler, "normalizationEnabled", "false");
+        scheduler.startUsgsEarthquakeNormalization();
+
+        verify(usgsEarthquakeNormalizationJob, never()).run();
     }
 
     @Test

--- a/src/test/java/io/kontur/eventapi/usgs/earthquake/job/UsgsEarthquakeImportJobTest.java
+++ b/src/test/java/io/kontur/eventapi/usgs/earthquake/job/UsgsEarthquakeImportJobTest.java
@@ -1,0 +1,74 @@
+package io.kontur.eventapi.usgs.earthquake.job;
+
+import io.kontur.eventapi.dao.DataLakeDao;
+import io.kontur.eventapi.entity.DataLake;
+import io.kontur.eventapi.usgs.earthquake.client.UsgsEarthquakeClient;
+import io.kontur.eventapi.usgs.earthquake.converter.UsgsEarthquakeDataLakeConverter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.wololo.geojson.Feature;
+import org.wololo.geojson.FeatureCollection;
+import org.wololo.geojson.Point;
+
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UsgsEarthquakeImportJobTest {
+
+    @Mock
+    private UsgsEarthquakeClient client;
+    @Mock
+    private DataLakeDao dataLakeDao;
+    @Mock
+    private UsgsEarthquakeDataLakeConverter converter;
+
+    @AfterEach
+    void resetMocks() {
+        reset(client);
+        reset(dataLakeDao);
+        reset(converter);
+    }
+
+    @Test
+    void execute() {
+        Feature feature = new Feature("id1", new Point(new double[]{0,0}), Map.of("updated", "123"));
+        FeatureCollection fc = new FeatureCollection(new Feature[]{feature});
+        when(client.getEarthquakes()).thenReturn(fc.toString());
+        when(dataLakeDao.isNewEvent(anyString(), anyString(), anyString())).thenReturn(true);
+        when(converter.convert(anyString(), any(), anyString())).thenReturn(new DataLake());
+        doNothing().when(dataLakeDao).storeDataLakes(anyList());
+
+        UsgsEarthquakeImportJob job = new UsgsEarthquakeImportJob(new SimpleMeterRegistry(), client,
+                dataLakeDao, converter);
+        job.run();
+
+        verify(client, times(1)).getEarthquakes();
+        verify(dataLakeDao, times(1)).isNewEvent(anyString(), anyString(), anyString());
+        verify(converter, times(1)).convert(anyString(), any(), anyString());
+        verify(dataLakeDao, times(1)).storeDataLakes(anyList());
+    }
+
+    @Test
+    void skipExistingEvent() {
+        Feature feature = new Feature("id1", new Point(new double[]{0,0}), Map.of("updated", "123"));
+        FeatureCollection fc = new FeatureCollection(new Feature[]{feature});
+        when(client.getEarthquakes()).thenReturn(fc.toString());
+        when(dataLakeDao.isNewEvent(anyString(), anyString(), anyString())).thenReturn(false);
+
+        UsgsEarthquakeImportJob job = new UsgsEarthquakeImportJob(new SimpleMeterRegistry(), client,
+                dataLakeDao, converter);
+        job.run();
+
+        verify(client, times(1)).getEarthquakes();
+        verify(dataLakeDao, times(1)).isNewEvent(anyString(), anyString(), anyString());
+        verify(converter, never()).convert(anyString(), any(), anyString());
+        verify(dataLakeDao, never()).storeDataLakes(anyList());
+    }
+}

--- a/src/test/java/io/kontur/eventapi/usgs/earthquake/normalization/UsgsEarthquakeNormalizerTest.java
+++ b/src/test/java/io/kontur/eventapi/usgs/earthquake/normalization/UsgsEarthquakeNormalizerTest.java
@@ -1,0 +1,136 @@
+package io.kontur.eventapi.usgs.earthquake.normalization;
+
+import io.kontur.eventapi.entity.DataLake;
+import io.kontur.eventapi.entity.EventType;
+import io.kontur.eventapi.entity.NormalizedObservation;
+import io.kontur.eventapi.entity.Severity;
+import io.kontur.eventapi.util.DateTimeUtil;
+import org.junit.jupiter.api.Test;
+import io.kontur.eventapi.dao.ShakemapDao;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.UUID;
+import org.wololo.geojson.Feature;
+
+import static io.kontur.eventapi.TestUtil.readFile;
+import static io.kontur.eventapi.usgs.earthquake.converter.UsgsEarthquakeDataLakeConverter.USGS_EARTHQUAKE_PROVIDER;
+import static org.junit.jupiter.api.Assertions.*;
+
+class UsgsEarthquakeNormalizerTest {
+
+    private final ShakemapDao shakemapDao = mock(ShakemapDao.class);
+    private final UsgsEarthquakeNormalizer normalizer = new UsgsEarthquakeNormalizer(shakemapDao);
+
+    @Test
+    void testNormalize() throws IOException {
+        when(shakemapDao.buildCentroidBuffer(anyDouble(), anyDouble())).thenReturn("{\"type\":\"Polygon\"}");
+        DataLake dl = createDataLake("/usgs/sample.json");
+        NormalizedObservation obs = normalizer.normalize(dl);
+
+        assertEquals(dl.getObservationId(), obs.getObservationId());
+        assertEquals(dl.getProvider(), obs.getProvider());
+        assertEquals("nc75206757", obs.getExternalEventId());
+        assertEquals(Severity.SEVERE, obs.getEventSeverity());
+        assertEquals(EventType.EARTHQUAKE, obs.getType());
+        assertEquals("M 7.6 - 2 km E of Aromas, CA", obs.getName());
+        assertNull(obs.getProperName());
+        assertEquals("2 km E of Aromas, CA", obs.getDescription());
+        assertEquals("CA", obs.getRegion());
+        String descr = "On 7/7/2025 4:43:17 PM, an earthquake occurred 2 km E of Aromas, CA. The earthquake had Magnitude 7.6M, Depth:0.45km.";
+        assertEquals(descr, obs.getEpisodeDescription());
+        assertEquals(dl.getUpdatedAt(), obs.getEndedAt());
+        assertEquals(dl.getLoadedAt(), obs.getLoadedAt());
+        assertTrue(obs.getUrls().contains("https://earthquake.usgs.gov/earthquakes/eventpage/nc75206757"));
+        assertEquals(2, obs.getGeometries().getFeatures().length);
+        Feature circle = obs.getGeometries().getFeatures()[1];
+        assertEquals("Polygon", circle.getGeometry().getType());
+    }
+
+    @Test
+    void testNormalizeWithShakemap() throws Exception {
+        when(shakemapDao.buildShakemapPolygons(any())).thenReturn(
+                "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[1,1]},\"properties\":{\"value\":2.5}}]}");
+        when(shakemapDao.buildCentroidBuffer(anyDouble(), anyDouble())).thenReturn("{\"type\":\"Polygon\"}");
+
+        DataLake dl = createDataLake("/usgs/sample.json");
+        NormalizedObservation obs = normalizer.normalize(dl);
+
+        verify(shakemapDao).buildShakemapPolygons(any());
+        assertEquals(3, obs.getGeometries().getFeatures().length);
+
+        Feature polygon = obs.getGeometries().getFeatures()[0];
+        Map<String, Object> props = polygon.getProperties();
+        assertEquals("Poly_SMPInt_2.5", props.get("Class"));
+        assertEquals(dl.getExternalId(), props.get("eventid"));
+        assertEquals("EQ", props.get("eventtype"));
+        assertEquals("Intensity 2.5", props.get("polygonlabel"));
+        assertEquals(Severity.SEVERE, obs.getEventSeverity());
+    }
+
+    @Test
+    void testNormalizeWithNullShakeMapFeatures() throws Exception {
+        when(shakemapDao.buildShakemapPolygons(any())).thenReturn("{\"type\":\"FeatureCollection\"}");
+        when(shakemapDao.buildCentroidBuffer(anyDouble(), anyDouble())).thenReturn("{\"type\":\"Polygon\"}");
+
+        DataLake dl = createDataLake("/usgs/sample.json");
+        NormalizedObservation obs = normalizer.normalize(dl);
+
+        verify(shakemapDao).buildShakemapPolygons(any());
+        assertEquals(2, obs.getGeometries().getFeatures().length);
+    }
+
+    @Test
+    void testNormalizeWithPgaMask() throws Exception {
+        when(shakemapDao.buildPgaMask(any())).thenReturn("{\"type\":\"Polygon\"}");
+        when(shakemapDao.buildCentroidBuffer(anyDouble(), anyDouble())).thenReturn("{\"type\":\"Polygon\"}");
+
+        DataLake dl = createDataLake("/usgs/sample.json");
+        NormalizedObservation obs = normalizer.normalize(dl);
+
+        verify(shakemapDao).buildPgaMask(any());
+        assertEquals(Map.of("type", "Polygon"), obs.getSeverityData().get("pga40Mask"));
+        assertEquals(2, obs.getGeometries().getFeatures().length);
+
+        Object cov = obs.getSeverityData().get("coverage_pga_highres");
+        assertTrue(cov instanceof Map);
+        assertEquals("Coverage", ((Map<?, ?>) cov).get("type"));
+        assertEquals(Severity.SEVERE, obs.getEventSeverity());
+    }
+
+    @Test
+    void testNormalizeWithNaNMaxPga() throws Exception {
+        when(shakemapDao.buildCentroidBuffer(anyDouble(), anyDouble())).thenReturn("{\"type\":\"Polygon\"}");
+
+        DataLake dl = createDataLake("/usgs/sample_nan.json");
+        NormalizedObservation obs = normalizer.normalize(dl);
+
+        verify(shakemapDao, never()).buildPgaMask(any());
+        assertFalse(obs.getSeverityData().containsKey("pga40Mask"));
+
+        Object cov = obs.getSeverityData().get("coverage_pga_highres");
+        assertTrue(cov instanceof Map);
+        assertEquals("Coverage", ((Map<?, ?>) cov).get("type"));
+    }
+
+    @Test
+    void testMagnitudeUpgrade() throws Exception {
+        when(shakemapDao.buildCentroidBuffer(anyDouble(), anyDouble())).thenReturn("{\"type\":\"Polygon\"}");
+
+        DataLake dl = createDataLake("/usgs/sample.json");
+        NormalizedObservation obs = normalizer.normalize(dl);
+
+        assertEquals(Severity.SEVERE, obs.getEventSeverity());
+    }
+
+    private DataLake createDataLake(String file) throws IOException {
+        String data = readFile(this, file);
+        DataLake dl = new DataLake(UUID.randomUUID(), "nc75206757",
+                DateTimeUtil.getDateTimeFromMilli(1751906694946L), OffsetDateTime.now());
+        dl.setData(data);
+        dl.setProvider(USGS_EARTHQUAKE_PROVIDER);
+        return dl;
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -41,6 +41,9 @@ nifc:
 inciweb:
   host: 'https://inciweb.nwcg.gov'
 
+usgs:
+  host: 'https://earthquake.usgs.gov'
+
 nhc:
   host: 'https://www.nhc.noaa.gov'
 
@@ -101,6 +104,10 @@ scheduler:
     fixedDelay: 999999
   nifcImport:
     enable: false
+    initialDelay: 999999
+    fixedDelay: 999999
+  usgsEarthquakeImport:
+    enable: true
     initialDelay: 999999
     fixedDelay: 999999
   inciwebImport:

--- a/src/test/resources/usgs/sample.json
+++ b/src/test/resources/usgs/sample.json
@@ -1,0 +1,35 @@
+{
+  "type": "Feature",
+  "properties": {
+    "mag": 7.6,
+    "place": "2 km E of Aromas, CA",
+    "time": 1751906597590,
+    "updated": 1751906694946,
+    "url": "https://earthquake.usgs.gov/earthquakes/eventpage/nc75206757",
+    "detail": "https://earthquake.usgs.gov/earthquakes/feed/v1.0/detail/nc75206757.geojson",
+    "alert": "green",
+    "status": "automatic",
+    "tsunami": 0,
+    "sig": 317,
+    "net": "nc",
+    "code": "75206757",
+    "types": ",origin,phase-data,",
+    "type": "earthquake",
+    "title": "M 7.6 - 2 km E of Aromas, CA"
+  },
+  "shakemap": [
+    {
+      "properties": {
+        "maxpga": "0.5"
+      },
+      "coverage_pga_high_res": {"type": "Coverage"},
+      "cont_pga_highres": {"type": "FeatureCollection"},
+      "cont_mmi": {"type": "FeatureCollection"}
+    }
+  ],
+  "geometry": {
+    "type": "Point",
+    "coordinates": [-121.6175, 36.895168, 0.45]
+  },
+  "id": "nc75206757"
+}

--- a/src/test/resources/usgs/sample_nan.json
+++ b/src/test/resources/usgs/sample_nan.json
@@ -1,0 +1,35 @@
+{
+  "type": "Feature",
+  "properties": {
+    "mag": 7.6,
+    "place": "2 km E of Aromas, CA",
+    "time": 1751906597590,
+    "updated": 1751906694946,
+    "url": "https://earthquake.usgs.gov/earthquakes/eventpage/nc75206757",
+    "detail": "https://earthquake.usgs.gov/earthquakes/feed/v1.0/detail/nc75206757.geojson",
+    "alert": "green",
+    "status": "automatic",
+    "tsunami": 0,
+    "sig": 317,
+    "net": "nc",
+    "code": "75206757",
+    "types": ",origin,phase-data,",
+    "type": "earthquake",
+    "title": "M 7.6 - 2 km E of Aromas, CA"
+  },
+  "shakemap": [
+    {
+      "properties": {
+        "maxpga": "nan"
+      },
+      "coverage_pga_high_res": {"type": "Coverage"},
+      "cont_pga_highres": {"type": "FeatureCollection"},
+      "cont_mmi": {"type": "FeatureCollection"}
+    }
+  ],
+  "geometry": {
+    "type": "Point",
+    "coordinates": [-121.6175, 36.895168, 0.45]
+  },
+  "id": "nc75206757"
+}


### PR DESCRIPTION
This reverts commit bda7a2922cfaa13499d3353a3ad4d084785d7ffc, reversing changes made to 552d53d7ae59473bff7148b59c4fec7b16f54d7b.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated support for importing and normalizing USGS earthquake data, including scheduled import and processing jobs.
  * Enhanced earthquake event processing with ShakeMap polygon and PGA mask generation, and enriched event severity and geometry data.
  * USGS earthquake events are now included in supported feed sources and database event combination logic.

* **Documentation**
  * Added comprehensive documentation for event combination, schema changes, and USGS earthquake feed processing.

* **Configuration**
  * Added USGS service endpoints and scheduler settings to all environment configuration files.

* **Database**
  * Introduced new SQL functions for ShakeMap polygon and PGA mask generation, and updated feeds to include USGS earthquakes.

* **Bug Fixes**
  * Improved conflict handling in data lake inserts to prevent errors on duplicate entries.

* **Tests**
  * Added extensive unit tests for USGS earthquake import, normalization, and scheduler integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->