### PR TITLE
fix(gdacs): remove all drought alert levels

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,1 +1,0 @@
-- Maven tests fail to resolve parent POM from kontur nexus due to network restrictions in the CI environment. Consider configuring offline dependencies or a mirror.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,0 +1,1 @@
+- Maven tests fail to resolve parent POM from kontur nexus due to network restrictions in the CI environment. Consider configuring offline dependencies or a mirror.

--- a/src/main/java/io/kontur/eventapi/gdacs/normalization/GdacsAlertNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/gdacs/normalization/GdacsAlertNormalizer.java
@@ -4,6 +4,7 @@ import io.kontur.eventapi.entity.DataLake;
 import io.kontur.eventapi.entity.NormalizedObservation;
 import io.kontur.eventapi.gdacs.converter.GdacsAlertXmlParser;
 import io.kontur.eventapi.gdacs.dto.ParsedAlert;
+import io.kontur.eventapi.gdacs.util.GdacsDescriptionCleaner;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -59,8 +60,9 @@ public class GdacsAlertNormalizer extends GdacsNormalizer {
 
         normalizedObservation.setName(parsedAlert.getHeadLine());
         normalizedObservation.setProperName(parsedAlert.getEventName().trim());
-        normalizedObservation.setDescription(parsedAlert.getDescription());
-        normalizedObservation.setEpisodeDescription(parsedAlert.getDescription());
+        String cleanedDescription = GdacsDescriptionCleaner.clean(parsedAlert.getDescription());
+        normalizedObservation.setDescription(cleanedDescription);
+        normalizedObservation.setEpisodeDescription(cleanedDescription);
         normalizedObservation.setType(defineType(parsedAlert.getEvent()));
         normalizedObservation.setEventSeverity(defineSeverity(parsedAlert.getSeverity()));
         normalizedObservation.setExternalEventId(composeExternalEventId(parsedAlert.getEventType(), parsedAlert.getEventId()));

--- a/src/main/java/io/kontur/eventapi/gdacs/util/GdacsDescriptionCleaner.java
+++ b/src/main/java/io/kontur/eventapi/gdacs/util/GdacsDescriptionCleaner.java
@@ -25,13 +25,17 @@ public class GdacsDescriptionCleaner {
 
         result = DATE_PREFIX.matcher(result).replaceFirst("");
         result = PERIOD_RANGE_PREFIX.matcher(result).replaceFirst("");
+        // drop leftover indefinite article after removing date range
+        result = result.replaceFirst("(?i)^a\\s+", "");
 
         if (FOREST_FIRE_SENTENCE.matcher(result).matches()) {
             return "";
         }
 
         result = result.replace("(vulnerability [unknown])", "");
-        result = result.replaceAll("Estimated population affected by category 1 \\(120 km/h\\) wind speeds or higher is 0\\s*(\\(0 in tropical storm\\))?\\.?", "");
+        result = result.replaceAll(
+                "Estimated population affected by category 1 \\(120 km/h\\) wind speeds or higher is 0(?:\\s*\\(0 in tropical storm\\))?\\s*\\.(?:\\s*$)",
+                "");
         result = result.replaceAll("The flood caused 0 deaths and 0 displaced \\.", "");
         result = result.replaceAll("The flood caused 0 deaths and (\\d+) displaced", "The flood caused $1 displaced");
         result = result.replaceAll("The flood caused (\\d+) deaths and 0 displaced", "The flood caused $1 deaths");

--- a/src/main/java/io/kontur/eventapi/gdacs/util/GdacsDescriptionCleaner.java
+++ b/src/main/java/io/kontur/eventapi/gdacs/util/GdacsDescriptionCleaner.java
@@ -1,0 +1,44 @@
+package io.kontur.eventapi.gdacs.util;
+
+import org.apache.commons.lang3.RegExUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.regex.Pattern;
+
+public class GdacsDescriptionCleaner {
+
+    private static final Pattern DATE_PREFIX = Pattern.compile("^(On \\d{1,2}/\\d{1,2}/\\d{4}( \\d{1,2}:\\d{2}(?::\\d{2})? (?:AM|PM))?,?[^.]*\\.\\s*)");
+    private static final Pattern PERIOD_RANGE_PREFIX = Pattern.compile("^From \\d{1,2}/\\d{1,2}/\\d{4} to \\d{1,2}/\\d{1,2}/\\d{4},\\s*");
+    private static final Pattern FOREST_FIRE_SENTENCE = Pattern.compile("^On \\d{1,2}/\\d{1,2}/\\d{4}, a forest fire started.*?\\.\\s*$");
+
+    private GdacsDescriptionCleaner() {
+    }
+
+    public static String clean(String description) {
+        if (description == null) {
+            return null;
+        }
+        String result = description.trim();
+
+        // Remove drought alert statements regardless of specified level
+        result = result.replaceAll("^The\\s+Drought alert level is [^.]*\\.\\s*", "");
+
+        result = DATE_PREFIX.matcher(result).replaceFirst("");
+        result = PERIOD_RANGE_PREFIX.matcher(result).replaceFirst("");
+
+        if (FOREST_FIRE_SENTENCE.matcher(result).matches()) {
+            return "";
+        }
+
+        result = result.replaceAll("\\(vulnerability \\[unknown\\])", "");
+        result = result.replaceAll("Estimated population affected by category 1 \(120 km/h\) wind speeds or higher is 0\\s*(\\(0 in tropical storm\\))?\\.?", "");
+        result = result.replaceAll("The flood caused 0 deaths and 0 displaced \\.", "");
+        result = result.replaceAll("The flood caused 0 deaths and (\\d+) displaced", "The flood caused $1 displaced");
+        result = result.replaceAll("The flood caused (\\d+) deaths and 0 displaced", "The flood caused $1 deaths");
+        result = result.replaceAll("potentially affecting No people affected[^.]*\\.", "");
+
+        result = StringUtils.normalizeSpace(result);
+        result = RegExUtils.replacePattern(result, " \\.", ".");
+        return result.trim();
+    }
+}

--- a/src/main/java/io/kontur/eventapi/gdacs/util/GdacsDescriptionCleaner.java
+++ b/src/main/java/io/kontur/eventapi/gdacs/util/GdacsDescriptionCleaner.java
@@ -31,7 +31,7 @@ public class GdacsDescriptionCleaner {
         }
 
         result = result.replaceAll("\\(vulnerability \\[unknown\\])", "");
-        result = result.replaceAll("Estimated population affected by category 1 \(120 km/h\) wind speeds or higher is 0\\s*(\\(0 in tropical storm\\))?\\.?", "");
+        result = result.replaceAll("Estimated population affected by category 1 \\(120 km/h\\) wind speeds or higher is 0\\s*(\\(0 in tropical storm\\))?\\.?", "");
         result = result.replaceAll("The flood caused 0 deaths and 0 displaced \\.", "");
         result = result.replaceAll("The flood caused 0 deaths and (\\d+) displaced", "The flood caused $1 displaced");
         result = result.replaceAll("The flood caused (\\d+) deaths and 0 displaced", "The flood caused $1 deaths");

--- a/src/main/java/io/kontur/eventapi/gdacs/util/GdacsDescriptionCleaner.java
+++ b/src/main/java/io/kontur/eventapi/gdacs/util/GdacsDescriptionCleaner.java
@@ -30,7 +30,7 @@ public class GdacsDescriptionCleaner {
             return "";
         }
 
-        result = result.replaceAll("\\(vulnerability \\[unknown\\])", "");
+        result = result.replace("(vulnerability [unknown])", "");
         result = result.replaceAll("Estimated population affected by category 1 \\(120 km/h\\) wind speeds or higher is 0\\s*(\\(0 in tropical storm\\))?\\.?", "");
         result = result.replaceAll("The flood caused 0 deaths and 0 displaced \\.", "");
         result = result.replaceAll("The flood caused 0 deaths and (\\d+) displaced", "The flood caused $1 displaced");

--- a/src/test/java/io/kontur/eventapi/gdacs/normalization/GdacsNormalizerIT.java
+++ b/src/test/java/io/kontur/eventapi/gdacs/normalization/GdacsNormalizerIT.java
@@ -88,7 +88,7 @@ public class GdacsNormalizerIT extends AbstractIntegrationTest {
     public void normalizeGdacsAlert() {
         var observation = gdacsAlertNormalizer.normalize(dataLakeAlert);
 
-        String description = "On 10/12/2020 7:03:07 AM, an earthquake occurred in Mexico potentially affecting About 13000 people within 100km. The earthquake had Magnitude 4.9M, Depth:28.99km.";
+        String description = "The earthquake had Magnitude 4.9M, Depth:28.99km.";
         String name = "Green earthquake alert (Magnitude 4.9M, Depth:28.99km) in Mexico 12/10/2020 07:03 UTC, About 13000 people within 100km.";
 
         var fromDate = OffsetDateTime.of(
@@ -113,8 +113,10 @@ public class GdacsNormalizerIT extends AbstractIntegrationTest {
         assertEquals(Severity.MINOR, observation.getEventSeverity());
 
         assertEquals(name, observation.getName());
-        assertEquals(description, observation.getDescription());
-        assertEquals(description, observation.getEpisodeDescription());
+        assertEquals(description, observation.getDescription(),
+                "Description should be cleaned of dates and locations if irrelevant");
+        assertEquals(description, observation.getEpisodeDescription(),
+                "Episode description should match cleaned description");
         assertEquals(fromDate, observation.getStartedAt());
         assertEquals(toDate, observation.getEndedAt());
 

--- a/src/test/java/io/kontur/eventapi/gdacs/util/GdacsDescriptionCleanerRunner.java
+++ b/src/test/java/io/kontur/eventapi/gdacs/util/GdacsDescriptionCleanerRunner.java
@@ -1,0 +1,18 @@
+package io.kontur.eventapi.gdacs.util;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class GdacsDescriptionCleanerRunner {
+    public static void main(String[] args) throws IOException {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(System.in))) {
+            String line;
+            System.out.println("before\tafter");
+            while ((line = br.readLine()) != null) {
+                String cleaned = GdacsDescriptionCleaner.clean(line);
+                System.out.println(line + "\t" + cleaned);
+            }
+        }
+    }
+}

--- a/src/test/java/io/kontur/eventapi/gdacs/util/GdacsDescriptionCleanerTest.java
+++ b/src/test/java/io/kontur/eventapi/gdacs/util/GdacsDescriptionCleanerTest.java
@@ -1,0 +1,160 @@
+package io.kontur.eventapi.gdacs.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GdacsDescriptionCleanerTest {
+
+    @Test
+    void testCleanDroughtAlert() {
+        String src = "The  Drought alert level is Green.";
+        String expected = "";
+        assertEquals(expected, GdacsDescriptionCleaner.clean(src),
+                "Should remove drought alert line entirely");
+    }
+
+    @Test
+    void testCleanFloodDescription() {
+        String src = "On 16/05/2025, a flood started in China, lasting until 30/07/2025 (last update). The flood caused 49 deaths and 550342 displaced .";
+        String expected = "The flood caused 49 deaths and 550342 displaced.";
+        assertEquals(expected, GdacsDescriptionCleaner.clean(src),
+                "Flood description should strip dates and keep stats");
+    }
+
+    @Test
+    void testCleanCyclone() {
+        String src = "From 10/06/2025 to 14/06/2025, a Tropical Storm (maximum wind speed of 120 km/h) WUTIP-25 was active in NWPacific. The cyclone affects these countries: China, Viet Nam (vulnerability Medium). Estimated population affected by category 1 (120 km/h) wind speeds or higher is 0.968 million .";
+        String expected = "Tropical Storm (maximum wind speed of 120 km/h) WUTIP-25 was active in NWPacific. The cyclone affects these countries: China, Viet Nam (vulnerability Medium). Estimated population affected by category 1 (120 km/h) wind speeds or higher is 0.968 million.";
+        assertEquals(expected, GdacsDescriptionCleaner.clean(src),
+                "Cyclone description should keep useful info and drop date range");
+    }
+
+    @Test
+    void testZeroLossFlood() {
+        String src = "On 01/06/2025, a flood started in Indonesia, lasting until 08/06/2025 (last update). The flood caused 0 deaths and 0 displaced .";
+        String expected = "";
+        assertEquals(expected, GdacsDescriptionCleaner.clean(src),
+                "Flood with no impact should result in empty description");
+    }
+
+    @Test
+    void testVulnerabilityUnknown() {
+        String src = "From 12/07/2025 to 14/07/2025, a Tropical Depression (maximum wind speed of 56 km/h) SEVEN-25 was active in NWPacific. The cyclone affects these countries: Japan (vulnerability [unknown]). Estimated population affected by category 1 (120 km/h) wind speeds or higher is 0  (0 in tropical storm).";
+        String expected = "Tropical Depression (maximum wind speed of 56 km/h) SEVEN-25 was active in NWPacific. The cyclone affects these countries: Japan.";
+        assertEquals(expected, GdacsDescriptionCleaner.clean(src),
+                "Should drop unknown vulnerability and zero population");
+    }
+
+    @Test
+    void testEarthquakeNoPeople() {
+        String src = "On 7/31/2025 1:01:09 PM, an earthquake occurred in [unknown] potentially affecting No people affected in 100km. The earthquake had Magnitude 5M, Depth:10km.";
+        String expected = "The earthquake had Magnitude 5M, Depth:10km.";
+        assertEquals(expected, GdacsDescriptionCleaner.clean(src),
+                "Earthquake description should remove useless prefix");
+    }
+
+    @Test
+    void testCycloneZeroPopulation() {
+        String src = "From 11/07/2025 to 14/07/2025, a Tropical Storm (maximum wind speed of 93 km/h) NARI-25 was active in NWPacific. The cyclone affects these countries: Japan, Russian Federation (vulnerability Low). Estimated population affected by category 1 (120 km/h) wind speeds or higher is 0  (0 in tropical storm).";
+        String expected = "Tropical Storm (maximum wind speed of 93 km/h) NARI-25 was active in NWPacific. The cyclone affects these countries: Japan, Russian Federation (vulnerability Low).";
+        assertEquals(expected, GdacsDescriptionCleaner.clean(src),
+                "Cyclone with zero affected population should drop that part");
+    }
+
+    @Test
+    void testFloodZeroDisplaced() {
+        String src = "On 16/06/2025, a flood started in India, lasting until 26/06/2025 (last update). The flood caused 13 deaths and 0 displaced .";
+        String expected = "The flood caused 13 deaths.";
+        assertEquals(expected, GdacsDescriptionCleaner.clean(src),
+                "Flood description should omit zero displaced numbers");
+    }
+
+    @Test
+    void testForestFireRemoval() {
+        String src = "On 21/07/2025, a forest fire started in Australia,  until 26/07/2025.";
+        String expected = "";
+        assertEquals(expected, GdacsDescriptionCleaner.clean(src),
+                "Forest fire description with no details should be dropped");
+    }
+
+    @Test
+    void testFloodDisplacedOnly() {
+        String src = "On 06/06/2025, a flood started in Philippines, lasting until 09/06/2025 (last update). The flood caused 0 deaths and 1799 displaced .";
+        String expected = "The flood caused 1799 displaced.";
+        assertEquals(expected, GdacsDescriptionCleaner.clean(src),
+                "Flood description should keep displaced count only");
+    }
+
+    @Test
+    void testDroughtOrange() {
+        String src = "The Drought alert level is Orange.";
+        String expected = "";
+        assertEquals(expected, GdacsDescriptionCleaner.clean(src),
+                "Orange drought alert lines should be removed");
+    }
+
+    @Test
+    void testFloodStatsPreserved() {
+        String src = "On 14/07/2025, a flood started in Pakistan, lasting until 17/07/2025 (last update). The flood caused 196 deaths and 176 displaced .";
+        String expected = "The flood caused 196 deaths and 176 displaced.";
+        assertEquals(expected, GdacsDescriptionCleaner.clean(src),
+                "Flood stats should be kept when not zero");
+    }
+
+    @Test
+    void testFloodOnlyDeaths() {
+        String src = "On 27/06/2025, a flood started in Afghanistan, lasting until 07/07/2025 (last update). The flood caused 8 deaths and 0 displaced .";
+        String expected = "The flood caused 8 deaths.";
+        assertEquals(expected, GdacsDescriptionCleaner.clean(src),
+                "Flood description should keep deaths count only");
+    }
+
+    @Test
+    void testFloodAllZero() {
+        String src = "On 30/06/2025, a flood started in Algeria, lasting until 02/07/2025 (last update). The flood caused 0 deaths and 0 displaced .";
+        String expected = "";
+        assertEquals(expected, GdacsDescriptionCleaner.clean(src),
+                "Zero impact flood should yield empty description");
+    }
+
+    @Test
+    void testDepressionUnknown() {
+        String src = "From 25/06/2025 to 26/06/2025, a Tropical Depression (maximum wind speed of 46 km/h) THREE-25 was active in NWPacific. The cyclone affects these countries: China (vulnerability [unknown]). Estimated population affected by category 1 (120 km/h) wind speeds or higher is 0 (0 in tropical storm).";
+        String expected = "Tropical Depression (maximum wind speed of 46 km/h) THREE-25 was active in NWPacific. The cyclone affects these countries: China.";
+        assertEquals(expected, GdacsDescriptionCleaner.clean(src),
+                "Unknown vulnerability and zero population should be removed");
+    }
+
+    @Test
+    void testEarthquakeWithPopulation() {
+        String src = "On 7/21/2025 9:54:00 AM, an earthquake occurred in Taiwan potentially affecting 650 thousand in MMI VI. The earthquake had Magnitude 5.6M, Depth:10 km.";
+        String expected = "The earthquake had Magnitude 5.6M, Depth:10 km.";
+        assertEquals(expected, GdacsDescriptionCleaner.clean(src),
+                "Earthquake prefix with population should be removed");
+    }
+
+    @Test
+    void testEarthquakeNoPeople2() {
+        String src = "On 6/28/2025 8:32:21 AM, an earthquake occurred in [unknown] potentially affecting No people affected in 100 km. The earthquake had Magnitude 6.6M, Depth:10 km.";
+        String expected = "The earthquake had Magnitude 6.6M, Depth:10 km.";
+        assertEquals(expected, GdacsDescriptionCleaner.clean(src),
+                "Earthquake description should drop useless population part");
+    }
+
+    @Test
+    void testForestFireShort() {
+        String src = "On 22/06/2025, a forest fire started in Greece, until 25/06/2025.";
+        String expected = "";
+        assertEquals(expected, GdacsDescriptionCleaner.clean(src),
+                "Short forest fire records should be removed");
+    }
+
+    @Test
+    void testVolcanoPreserved() {
+        String src = "Volcano Fuego is emitting ash clouds according to the regional VAAC. The aviation alert level is Green.";
+        String expected = "Volcano Fuego is emitting ash clouds according to the regional VAAC. The aviation alert level is Green.";
+        assertEquals(expected, GdacsDescriptionCleaner.clean(src),
+                "Volcano messages should be left untouched");
+    }
+}


### PR DESCRIPTION
## Summary
- handle any drought alert level line when cleaning GDACS descriptions
- record failing Maven build in docs/todo

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_688bd53b3f288326ae6c8cda0876c475

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic cleaning and normalization of event alert descriptions for clearer, concise display.

* **Bug Fixes**
  * Removed irrelevant or redundant details (dates, zero-impact stats, etc.) from disaster descriptions to improve readability.

* **Tests**
  * Added comprehensive unit tests and a small runner to validate cleaning across disaster types and edge cases.

* **Documentation**
  * Noted CI Maven parent POM resolution issue and suggested offline/mirror dependency configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->