### PR TITLE
fix(stormsnoaa): correct event and episode id mapping

### DIFF
--- a/src/main/java/io/kontur/eventapi/stormsnoaa/normalization/StormsNoaaNormalizer.java
+++ b/src/main/java/io/kontur/eventapi/stormsnoaa/normalization/StormsNoaaNormalizer.java
@@ -128,8 +128,8 @@ public class StormsNoaaNormalizer extends Normalizer {
         String[] csvHeaderAndRow = dataLakeDto.getData().split("\n");
         Map<String, String> data = parseRow(csvHeaderAndRow[0], csvHeaderAndRow[1]);
 
-        normalizedObservation.setExternalEventId(parseString(data, "EPISODE_ID"));
-        normalizedObservation.setExternalEpisodeId(parseString(data, "EVENT_ID"));
+        normalizedObservation.setExternalEpisodeId(parseString(data, "EPISODE_ID"));
+        normalizedObservation.setExternalEventId(parseString(data, "EVENT_ID"));
         normalizedObservation.setDescription(parseString(data, "EPISODE_NARRATIVE"));
         normalizedObservation.setEpisodeDescription(parseString(data, "EVENT_NARRATIVE"));
         BigDecimal propertyDamage = getCost(parseString(data, "DAMAGE_PROPERTY"));

--- a/src/test/java/io/kontur/eventapi/stormsnoaa/normalization/StormsNoaaNormalizerIT.java
+++ b/src/test/java/io/kontur/eventapi/stormsnoaa/normalization/StormsNoaaNormalizerIT.java
@@ -32,7 +32,8 @@ class StormsNoaaNormalizerIT extends AbstractCleanableIntegrationTest {
     public void testIsApplicable() {
         DataLake dataLake = new DataLake();
         dataLake.setProvider("storms.noaa");
-        assertTrue(normalizer.isApplicable(dataLake));
+        assertTrue(normalizer.isApplicable(dataLake),
+                "StormsNoaaNormalizer should be applicable for provider 'storms.noaa'");
     }
 
     @Test
@@ -40,24 +41,42 @@ class StormsNoaaNormalizerIT extends AbstractCleanableIntegrationTest {
         DataLake dataLake = createTestDataLake();
         NormalizedObservation normalizedObservation = normalizer.normalize(dataLake);
 
-        assertEquals(dataLake.getObservationId(), normalizedObservation.getObservationId());
-        assertEquals(dataLake.getLoadedAt(), normalizedObservation.getLoadedAt());
-        assertEquals(dataLake.getUpdatedAt(), normalizedObservation.getSourceUpdatedAt());
-        assertEquals(dataLake.getProvider(), normalizedObservation.getProvider());
-        assertEquals(dataLake.getExternalId(), normalizedObservation.getExternalEpisodeId());
-        assertFalse(normalizedObservation.getActive());
-        assertEquals(EventType.TORNADO, normalizedObservation.getType());
-        assertNull(normalizedObservation.getExternalEventId());
-        assertNull(normalizedObservation.getEpisodeDescription());
-        assertNull(normalizedObservation.getDescription());
-        assertEquals(BigDecimal.valueOf(250000), normalizedObservation.getCost());
-        assertEquals(OffsetDateTime.parse("1950-04-28T13:20:00Z"), normalizedObservation.getStartedAt());
-        assertEquals(OffsetDateTime.parse("1950-04-29T14:45:00Z"), normalizedObservation.getEndedAt());
-        assertEquals(Severity.SEVERE, normalizedObservation.getEventSeverity());
-        assertEquals("Tornado - WASHITA, OKLAHOMA, USA", normalizedObservation.getName());
-        assertNotNull(normalizedObservation.getGeometries());
-        assertEquals(1, normalizedObservation.getGeometries().getFeatures().length);
-        assertEquals(STORMS_NOAA_TRACK_PROPERTIES, normalizedObservation.getGeometries().getFeatures()[0].getProperties());
+        assertEquals(dataLake.getObservationId(), normalizedObservation.getObservationId(),
+                "Observation ID should match the original DataLake observation ID");
+        assertEquals(dataLake.getLoadedAt(), normalizedObservation.getLoadedAt(),
+                "Loaded timestamp should be carried over from DataLake");
+        assertEquals(dataLake.getUpdatedAt(), normalizedObservation.getSourceUpdatedAt(),
+                "Source update time should come from DataLake updatedAt");
+        assertEquals(dataLake.getProvider(), normalizedObservation.getProvider(),
+                "Provider should remain unchanged after normalization");
+        assertEquals("7", normalizedObservation.getExternalEpisodeId(),
+                "Episode ID should be taken from the EPISODE_ID column");
+        assertEquals(dataLake.getExternalId(), normalizedObservation.getExternalEventId(),
+                "Event ID should match DataLake externalId sourced from EVENT_ID column");
+        assertFalse(normalizedObservation.getActive(),
+                "Newly normalized observations from Storms NOAA should be inactive by default");
+        assertEquals(EventType.TORNADO, normalizedObservation.getType(),
+                "EVENT_TYPE 'Tornado' should map to EventType.TORNADO");
+        assertNull(normalizedObservation.getEpisodeDescription(),
+                "EPISODE_NARRATIVE is empty in the CSV and should result in null");
+        assertNull(normalizedObservation.getDescription(),
+                "EVENT_NARRATIVE is empty in the CSV and should result in null");
+        assertEquals(BigDecimal.valueOf(250000), normalizedObservation.getCost(),
+                "Property damage should equal 250K parsed from DAMAGE_PROPERTY");
+        assertEquals(OffsetDateTime.parse("1950-04-28T13:20:00Z"), normalizedObservation.getStartedAt(),
+                "BEGIN_DATE_TIME should be converted to startedAt");
+        assertEquals(OffsetDateTime.parse("1950-04-29T14:45:00Z"), normalizedObservation.getEndedAt(),
+                "END_DATE_TIME should be converted to endedAt");
+        assertEquals(Severity.SEVERE, normalizedObservation.getEventSeverity(),
+                "Fujita scale F3 should translate to SEVERE severity");
+        assertEquals("Tornado - WASHITA, OKLAHOMA, USA", normalizedObservation.getName(),
+                "Name should combine event type and location");
+        assertNotNull(normalizedObservation.getGeometries(),
+                "Geometry collection should be created from provided coordinates");
+        assertEquals(1, normalizedObservation.getGeometries().getFeatures().length,
+                "Track geometry should contain exactly one feature");
+        assertEquals(STORMS_NOAA_TRACK_PROPERTIES, normalizedObservation.getGeometries().getFeatures()[0].getProperties(),
+                "Feature properties should match STORMS_NOAA_TRACK_PROPERTIES");
     }
 
     private DataLake createTestDataLake() {
@@ -68,7 +87,7 @@ class StormsNoaaNormalizerIT extends AbstractCleanableIntegrationTest {
         dataLake.setUpdatedAt(DateTimeUtil.uniqueOffsetDateTime());
         dataLake.setProvider("test-provider");
         dataLake.setData("EVENT_TYPE,EPISODE_ID,EVENT_ID,STATE,CZ_NAME,BEGIN_DATE_TIME,END_DATE_TIME,DAMAGE_PROPERTY,TOR_F_SCALE,BEGIN_LAT,BEGIN_LON,END_LAT,END_LON,EPISODE_NARRATIVE,EVENT_NARRATIVE\n" +
-                "Tornado,,10096222,OKLAHOMA,WASHITA,28-APR-50 13:20:00,29-APR-50 14:45:00,250K,F3,35.12,-99.2,35.17,-99.2,,");
+                "Tornado,7,10096222,OKLAHOMA,WASHITA,28-APR-50 13:20:00,29-APR-50 14:45:00,250K,F3,35.12,-99.2,35.17,-99.2,,");
         return dataLake;
     }
 }


### PR DESCRIPTION
## Summary
- fix StormsNoaaNormalizer to map episode and event IDs to the proper CSV fields
- ensure integration test validates Storms NOAA episode and event identifiers

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a5da01d594832395a056c8a36f6e95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected mapping of external IDs for NOAA Storms observations: Episode ID now derives from EPISODE_ID and Event ID from EVENT_ID. This fixes swapped identifiers, ensuring accurate linking, display, filtering, and integrations reliant on these IDs.

* **Tests**
  * Strengthened tests with clearer assertions and updated test data to validate the corrected EPISODE_ID mapping, improving confidence in data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->