### PR TITLE
fix(feed): stop overriding type for storms.noaa events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Changed
 - Implement flood-specific severity calculation for `storms.noaa` events.
+- Do not override event type for `storms.noaa` events in feed composition.
 
 #### Removed
 

--- a/src/main/java/io/kontur/eventapi/job/FeedCompositionJob.java
+++ b/src/main/java/io/kontur/eventapi/job/FeedCompositionJob.java
@@ -22,7 +22,6 @@ import java.util.*;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static io.kontur.eventapi.entity.Severity.UNKNOWN;
-import static io.kontur.eventapi.stormsnoaa.job.StormsNoaaImportJob.STORMS_NOAA_PROVIDER;
 import static io.kontur.eventapi.util.SeverityUtil.*;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
@@ -155,10 +154,6 @@ public class FeedCompositionJob extends AbstractJob {
                 .filter(ep -> ep.getType() != null)
                 .max(comparing(FeedEpisode::getUpdatedAt))
                 .map(FeedEpisode::getType).orElse(null));
-
-        if (eventObservations.stream().anyMatch(obs -> obs.getProvider().equals(STORMS_NOAA_PROVIDER))) {
-            feedData.setType(EventType.STORM);
-        }
 
         Map<String, Object> loss = new HashMap<>();
         episodes.stream()


### PR DESCRIPTION
## Summary
- avoid forcing STORM type when storms.noaa observations are present
- document feed composition not overriding event type for storms.noaa events

## Testing
- ⚠️ `make precommit` (no rule to make target 'precommit')
- ⚠️ `mvn -q test` (failed to resolve org.springframework.boot:spring-boot-starter-parent:pom:2.6.1)


------
https://chatgpt.com/codex/tasks/task_e_68a5e118a28c8323858238061a65e383

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stopped overriding event type for storms.noaa items during feed composition. Event type now consistently derives from the latest episode, improving accuracy and consistency across feeds.

* **Documentation**
  * Updated CHANGELOG to reflect the change from severity calculation details to preserving original event types for storms.noaa events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->