### PR TITLE
fix(nhc): reduce import delay

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -171,15 +171,15 @@ scheduler:
   nhcAtImport:
     enable: true
     initialDelay: 1000
-    fixedDelay: 1800000
+    fixedDelay: 300000 # every 5 minutes
   nhcCpImport:
     enable: true
     initialDelay: 1000
-    fixedDelay: 1800000
+    fixedDelay: 300000 # every 5 minutes
   nhcEpImport:
     enable: true
     initialDelay: 1000
-    fixedDelay: 1800000
+    fixedDelay: 300000 # every 5 minutes
   normalization:
     enable: true
     initialDelay: 1000


### PR DESCRIPTION
## Summary
- reduce NHC import job delay from 30 minutes to 5 minutes

## Testing
- `make precommit` *(fails: No rule to make target 'precommit')*
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b069363c34832397a20c989480b586

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Increased run frequency of scheduled NHC data imports (AT, CP, EP) from every 30 minutes to every 5 minutes, resulting in faster data refresh, more up-to-date information, and reduced latency between source changes and user availability. No other schedules affected; no user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->