### PR TITLE
fix(deps): align MyBatis starter with Spring Boot 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<spring-cloud-aws-messaging.version>2.2.6.RELEASE</spring-cloud-aws-messaging.version>
                 <springdoc-openapi-ui.version>1.8.0</springdoc-openapi-ui.version>
                 <feign-micrometer.version>13.6</feign-micrometer.version>
-                <mybatis-spring-boot-starter.version>3.0.4</mybatis-spring-boot-starter.version>
+                <mybatis-spring-boot-starter.version>2.3.2</mybatis-spring-boot-starter.version>
                 <liquibase-core.version>4.32.0</liquibase-core.version>
                 <jts2geojson.version>0.18.1</jts2geojson.version>
                 <geographiclib-java.version>2.0</geographiclib-java.version>


### PR DESCRIPTION
## Summary
- use mybatis-spring-boot-starter 2.3.2 to match Spring Boot 2 and remove dependency on `AotDetector`

## Testing
- `mvn test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.7.18... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d6bb613c8324bd3e4447cca6e0b8