### PR TITLE
build(maven): drop systemd service wrapper dependency

### DIFF
--- a/assembly.xml
+++ b/assembly.xml
@@ -23,13 +23,6 @@
             <fileMode>0640</fileMode>
         </fileSet>
         <fileSet>
-            <directory>${project.build.directory}/unpacked</directory>
-            <useDefaultExcludes>true</useDefaultExcludes>
-            <outputDirectory>./</outputDirectory>
-            <filtered>true</filtered>
-            <fileMode>0750</fileMode>
-        </fileSet>
-        <fileSet>
             <directory>${project.basedir}</directory>
             <useDefaultExcludes>true</useDefaultExcludes>
             <includes>

--- a/pom.xml
+++ b/pom.xml
@@ -358,45 +358,6 @@
 					</archive>
 				</configuration>
 			</plugin>
-			<!-- Copy dependencies for runnable app archive packaging -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-dependency-plugin</artifactId>
-                                <version>3.8.1</version>
-				<executions>
-					<execution>
-						<phase>post-integration-test</phase>
-						<goals>
-							<goal>copy-dependencies</goal>
-						</goals>
-						<configuration>
-							<outputDirectory>${project.build.directory}/lib</outputDirectory>
-							<includeScope>runtime</includeScope>
-						</configuration>
-					</execution>
-					<execution>
-						<id>unpack</id>
-						<phase>package</phase>
-						<goals>
-							<goal>unpack</goal>
-						</goals>
-						<configuration>
-							<artifactItems>
-								<artifactItem>
-									<groupId>io.kontur.common</groupId>
-									<artifactId>systemd-service-wrapper</artifactId>
-									<version>1.0.8</version>
-									<type>jar</type>
-									<overWrite>false</overWrite>
-									<outputDirectory>${project.build.directory}/unpacked</outputDirectory>
-									<includes>**/*.sh</includes>
-									<excludes>**/*.xml</excludes>
-								</artifactItem>
-							</artifactItems>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 			<!-- Config assembly for runnable app archive packaging -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary
- remove outdated maven-dependency-plugin configuration that unpacked non-existent systemd-service-wrapper jar
- clean up assembly descriptor from unused unpack directory

## Testing
- `mvn -q package` *(fails: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:2.7.18 (absent): Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.7.18 from/to central-only (https://repo.maven.apache.org/maven2): Network is unreachable and 'parent.relativePath' points at no local POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b1dd6bdf148324b2991f9152133bc2