### PR TITLE
fix(ci): use correct artifact download action version

### DIFF
--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Download artifact(s)
         id: download-artifact
-        uses: konturio/action-download-artifact@v8
+        uses: konturio/action-download-artifact@v2
         with:
           workflow: main.yml
           workflow_conclusion: success


### PR DESCRIPTION
## Summary
- use supported konturio/action-download-artifact v2 in deployment workflow

## Testing
- `mvn -B test` *(fails: Could not transfer artifact: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f341341483248c73ea5c089d27e7