### PR TITLE
fix(ci): use branch slug for artifacts

### DIFF
--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -1,4 +1,4 @@
---- # Time-stamp: <2022-09-16 19:23:39>
+--- # Time-stamp: <2025-08-29 19:02:30>
 
 name: 10 Manual Deployment
 
@@ -38,8 +38,8 @@ jobs:
       - name: Extracting metadata from a cloned repository
         id: get-cloned
         run: |-
-          echo "::set-output name=SHA::$(git log -1 --format='%H')"
-          echo "::set-output name=REF::$(git symbolic-ref HEAD 2>/dev/null)"
+          echo "SHA=$(git log -1 --format='%H')" >> "$GITHUB_OUTPUT"
+          echo "REF=$(git symbolic-ref HEAD 2>/dev/null)" >> "$GITHUB_OUTPUT"
 
       - name: Download artifact(s)
         id: download-artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,8 +49,8 @@ jobs:
 
       - name: Extracting metadata from a cloned repository
         id: get-cloned
-        run: |-
-          echo "::set-output name=SHA::$(git log -1 --format='%h')"
+        run: |
+          echo "SHA=$(git log -1 --format='%h')" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/migration-helper01.yml
+++ b/.github/workflows/migration-helper01.yml
@@ -1,4 +1,4 @@
---- # Time-stamp: <2022-09-15 20:47:57>
+--- # Time-stamp: <2025-08-29 19:02:00>
 
 name: "99 Migration helper" # reusable workflow
 
@@ -17,6 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: create-CI_COMMIT_REF_SLUG
+        env:
+          REF_NAME: ${{ github.head_ref || github.ref_name }}
         run: |
-          CI_COMMIT_REF_SLUG=$(echo '${{ github.ref }}' | cut -d/ -f3- | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9_-]/-/g; s/^-*//; s/-*$//')
-          echo "::set-output name=CI_COMMIT_REF_SLUG::$CI_COMMIT_REF_SLUG"
+          CI_COMMIT_REF_SLUG=$(echo "$REF_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9_-]/-/g; s/^-*//; s/-*$//')
+          echo "CI_COMMIT_REF_SLUG=$CI_COMMIT_REF_SLUG" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- ensure migration helper uses branch name or tag for artifact slug
- switch to $GITHUB_OUTPUT in workflows to avoid deprecated set-output

## Testing
- `make precommit` *(fails: No rule to make target 'precommit')*


------
https://chatgpt.com/codex/tasks/task_e_68b1f8d4441c83249d168d749a382c73