### PR TITLE
fix(ci): stop using outdated maven settings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,6 @@ jobs:
 
           # sanitize IMAGE_TAG for jib-compatible docker tagging
           IMAGE_TAG="$(echo "$IMAGE_TAG" | tr '/\\,' '--')"
-          wget -q https://kontur-github-runners.s3.eu-central-1.amazonaws.com/public_resources/projects/common/2022091500.tar.xz && tar -C "$HOME" -xf 2022091500.tar.xz && rm 2022091500.tar.xz
 
           echo '${{ secrets.NEXUS_DEPLOYER_PASS }}' | docker login nexus.kontur.io:8084 -u '${{ secrets.NEXUS_DEPLOYER }}' --password-stdin
           echo '${{ secrets.NEXUS_DEPLOYER_PASS }}' | docker login nexus.kontur.io:8085 -u '${{ secrets.NEXUS_DEPLOYER }}' --password-stdin


### PR DESCRIPTION
## Summary
- remove tarball download that injected internal Maven mirror

## Testing
- `make precommit`

------
https://chatgpt.com/codex/tasks/task_e_68b2d01625e48324a79bfbad2359c0bb