### PR TITLE
ci(workflows): avoid nexus auth for external builds

### DIFF
--- a/.github/workflows/deploy_stage.yml
+++ b/.github/workflows/deploy_stage.yml
@@ -76,9 +76,6 @@ jobs:
           TAG: ${{ github.ref_name }}.${{ steps.get_cloned.outputs.sha }}.${{ github.run_attempt }}
         run: |
           set -e
-
-          wget -q https://kontur-github-runners.s3.eu-central-1.amazonaws.com/public_resources/projects/common/2022091500.tar.xz && tar -C "$HOME" -xf 2022091500.tar.xz && rm 2022091500.tar.xz
-
           echo '${{ secrets.NEXUS_DEPLOYER_PASS }}' | docker login nexus.kontur.io:8084 -u '${{ secrets.NEXUS_DEPLOYER }}' --password-stdin
           echo '${{ secrets.NEXUS_DEPLOYER_PASS }}' | docker login nexus.kontur.io:8085 -u '${{ secrets.NEXUS_DEPLOYER }}' --password-stdin
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,10 +70,13 @@ jobs:
           # sanitize IMAGE_TAG for jib-compatible docker tagging
           IMAGE_TAG="$(echo "$IMAGE_TAG" | tr '/\\,' '--')"
 
-          echo '${{ secrets.NEXUS_DEPLOYER_PASS }}' | docker login nexus.kontur.io:8084 -u '${{ secrets.NEXUS_DEPLOYER }}' --password-stdin
-          echo '${{ secrets.NEXUS_DEPLOYER_PASS }}' | docker login nexus.kontur.io:8085 -u '${{ secrets.NEXUS_DEPLOYER }}' --password-stdin
-
-          IMAGE_TAG="$IMAGE_TAG" mvn -T 1C $MAVEN_CLI_OPTS clean install jib:build -U -Prelease
+          if [ -n "$NEXUS_DEPLOYER" ] && [ -n "$NEXUS_DEPLOYER_PASS" ]; then
+            echo "$NEXUS_DEPLOYER_PASS" | docker login nexus.kontur.io:8084 -u "$NEXUS_DEPLOYER" --password-stdin
+            echo "$NEXUS_DEPLOYER_PASS" | docker login nexus.kontur.io:8085 -u "$NEXUS_DEPLOYER" --password-stdin
+            IMAGE_TAG="$IMAGE_TAG" mvn -T 1C $MAVEN_CLI_OPTS clean install jib:build -U -Prelease
+          else
+            mvn -T 1C $MAVEN_CLI_OPTS clean install -U -Prelease
+          fi
           echo "<h3>Docker image tag</h3> $IMAGE_TAG <br><br>" >> $GITHUB_STEP_SUMMARY
           mv -v target/*.zip .
 


### PR DESCRIPTION
## Summary
- skip Nexus docker login when secrets aren't provided
- drop internal Maven mirror to allow building master with public repos

## Testing
- `make precommit`

------
https://chatgpt.com/codex/tasks/task_e_68b2d919f2a88324b456b56741ea808c