### PR TITLE
fix(nifc): address review comments

### DIFF
--- a/src/main/java/io/kontur/eventapi/pdc/episodecomposition/BasePdcEpisodeCombinator.java
+++ b/src/main/java/io/kontur/eventapi/pdc/episodecomposition/BasePdcEpisodeCombinator.java
@@ -2,7 +2,6 @@ package io.kontur.eventapi.pdc.episodecomposition;
 
 import static com.google.common.collect.Iterators.getLast;
 import static io.kontur.eventapi.pdc.converter.PdcDataLakeConverter.*;
-import static io.kontur.eventapi.util.GeometryUtil.isEqualGeometries;
 import static java.util.Collections.emptyList;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.partitioningBy;
@@ -17,7 +16,8 @@ import io.kontur.eventapi.entity.FeedData;
 import io.kontur.eventapi.entity.FeedEpisode;
 import io.kontur.eventapi.entity.NormalizedObservation;
 import io.kontur.eventapi.episodecomposition.EpisodeCombinator;
-import org.bouncycastle.util.Arrays;
+import io.kontur.eventapi.util.EpisodeEqualityUtil;
+import org.apache.commons.lang3.ArrayUtils;
 import org.wololo.geojson.Feature;
 import org.wololo.geojson.FeatureCollection;
 
@@ -106,7 +106,7 @@ public abstract class BasePdcEpisodeCombinator extends EpisodeCombinator {
                 .sorted(comparing(FeedEpisode::getStartedAt).thenComparing(FeedEpisode::getEndedAt))
                 .forEachOrdered(episode -> {
                     FeedEpisode lastEpisode = getLast(episodesWithoutDuplicates.iterator(), null);
-                    if (lastEpisode == null || !sameEpisodes(lastEpisode, episode)) {
+                    if (lastEpisode == null || !EpisodeEqualityUtil.areSame(lastEpisode, episode)) {
                         episodesWithoutDuplicates.add(episode);
                     } else {
                         lastEpisode.setEndedAt(episode.getEndedAt());
@@ -119,18 +119,6 @@ public abstract class BasePdcEpisodeCombinator extends EpisodeCombinator {
         return episodesWithoutDuplicates;
     }
 
-    private boolean sameEpisodes(FeedEpisode episode1, FeedEpisode episode2) {
-        FeatureCollection geom1 = episode1.getGeometries();
-        FeatureCollection geom2 = episode2.getGeometries();
-        boolean geometriesEqual = (geom1 == null && geom2 == null)
-                || (geom1 != null && geom2 != null && isEqualGeometries(geom1, geom2));
-
-        return equalsIgnoreCase(episode1.getName(), episode2.getName())
-                && Objects.equals(episode1.getLoss(), episode2.getLoss())
-                && episode1.getSeverity() == episode2.getSeverity()
-                && equalsIgnoreCase(episode1.getLocation(), episode2.getLocation())
-                && geometriesEqual;
-    }
 
     private void addExposuresToEpisodes(List<FeedEpisode> episodes, Set<NormalizedObservation> exposureObservations) {
         for (int i = 0; i < episodes.size(); i++) {
@@ -175,7 +163,7 @@ public abstract class BasePdcEpisodeCombinator extends EpisodeCombinator {
         episodeObservations.stream()
                 .filter(obs -> HP_SRV_SEARCH_PROVIDER.equalsIgnoreCase(obs.getProvider())
                         || (List.of(PDC_SQS_PROVIDER, PDC_SQS_NASA_PROVIDER).contains(obs.getProvider())
-                        && obs.getGeometries() != null && !Arrays.isNullOrEmpty(obs.getGeometries().getFeatures())
+                        && obs.getGeometries() != null && !ArrayUtils.isEmpty(obs.getGeometries().getFeatures())
                         && obs.getGeometries().getFeatures()[0].getGeometry() != null
                         && "Point".equalsIgnoreCase(obs.getGeometries().getFeatures()[0].getGeometry().getType())))
                 .max(comparing(NormalizedObservation::getSourceUpdatedAt))
@@ -184,7 +172,7 @@ public abstract class BasePdcEpisodeCombinator extends EpisodeCombinator {
         episodeObservations.stream()
                 .filter(obs -> HP_SRV_MAG_PROVIDER.equalsIgnoreCase(obs.getProvider())
                         || (List.of(PDC_SQS_PROVIDER, PDC_SQS_NASA_PROVIDER).contains(obs.getProvider())
-                        && obs.getGeometries() != null && !Arrays.isNullOrEmpty(obs.getGeometries().getFeatures())
+                        && obs.getGeometries() != null && !ArrayUtils.isEmpty(obs.getGeometries().getFeatures())
                         && obs.getGeometries().getFeatures()[0].getGeometry() != null
                         && ("Polygon".equalsIgnoreCase(obs.getGeometries().getFeatures()[0].getGeometry().getType())
                         || "MultiPolygon".equalsIgnoreCase(obs.getGeometries().getFeatures()[0].getGeometry().getType()))))

--- a/src/main/java/io/kontur/eventapi/util/EpisodeEqualityUtil.java
+++ b/src/main/java/io/kontur/eventapi/util/EpisodeEqualityUtil.java
@@ -1,0 +1,40 @@
+package io.kontur.eventapi.util;
+
+import io.kontur.eventapi.entity.FeedEpisode;
+import org.apache.commons.lang3.StringUtils;
+import org.wololo.geojson.FeatureCollection;
+
+import java.util.Objects;
+
+/**
+ * Utility methods for comparing {@link FeedEpisode} instances.
+ * This encapsulates equality rules so all feeds use the same criteria
+ * when deciding whether two episodes represent the same event.
+ */
+public final class EpisodeEqualityUtil {
+
+    private EpisodeEqualityUtil() {
+    }
+
+    /**
+     * Compare two episodes to determine if they should be treated as the same.
+     * The comparison checks name, location and geometry case-insensitively,
+     * severity equality and loss equality, mirroring PDC/NIFC combinator logic.
+     *
+     * @param episode1 first episode
+     * @param episode2 the second episode
+     * @return {@code true} if episodes are considered the same
+     */
+    public static boolean areSame(FeedEpisode episode1, FeedEpisode episode2) {
+        FeatureCollection geom1 = episode1.getGeometries();
+        FeatureCollection geom2 = episode2.getGeometries();
+        boolean geometriesEqual = (geom1 == null && geom2 == null)
+                || (geom1 != null && geom2 != null && GeometryUtil.isEqualGeometries(geom1, geom2));
+
+        return StringUtils.equalsIgnoreCase(episode1.getName(), episode2.getName())
+                && Objects.equals(episode1.getLoss(), episode2.getLoss())
+                && Objects.equals(episode1.getSeverity(), episode2.getSeverity())
+                && StringUtils.equalsIgnoreCase(episode1.getLocation(), episode2.getLocation())
+                && geometriesEqual;
+    }
+}


### PR DESCRIPTION
## Summary
- ensure NIFC episodes carry valid timestamps before merging
- unify episode comparison via shared `EpisodeEqualityUtil`
- make geometry equality null-safe and order-insensitive

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_68b2efdda1348326a58909ab2be1a76a