### PR TITLE
fix(feed): gate latest version updates to highest enriched version

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -103,9 +103,10 @@ Stores event versions for each feed. Table was redesigned in version 1.15.
 | `location` | `text` |
 | `collected_geometry` | `geometry` generated from episodes |
 
-`is_latest_version` becomes `true` only after the corresponding event version is
-successfully enriched. Until then the previous enriched version remains the
-latest for API queries.
+`is_latest_version` is set to `true` only after that event version has been successfully enriched.
+Until then, the previous enriched version remains the latest for API queries.
+Once a later version becomes enriched, it is marked as the new highest enriched version and earlier versions never regain `is_latest_version = true`.
+Only the highest enriched version is considered latest for API queries.
 
 Unique key: (`event_id`, `version`, `feed_id`). Several GIST and BTREE indexes exist for geometry and timestamps. An additional
 index `feed_data_event_feed_latest_idx` on `(event_id, feed_id)` with condition `is_latest_version` speeds up retrieval of the

--- a/src/main/java/io/kontur/eventapi/dao/mapper/FeedMapper.java
+++ b/src/main/java/io/kontur/eventapi/dao/mapper/FeedMapper.java
@@ -44,6 +44,10 @@ public interface FeedMapper {
                                     @Param("feedId") UUID feedId,
                                     @Param("version") Long version);
 
+    /**
+     * Mark the given version as the latest if it is the most recent enriched one.
+     * Older versions remain unchanged when enrichments arrive out of order.
+     */
     void markEventVersionAsLatest(@Param("eventId") UUID eventId,
                                   @Param("feedId") UUID feedId,
                                   @Param("version") Long version);

--- a/src/main/resources/db/mappers/FeedMapper.xml
+++ b/src/main/resources/db/mappers/FeedMapper.xml
@@ -50,9 +50,19 @@
     </update>
 
     <update id="markEventVersionAsLatest">
-        update feed_data
-        set is_latest_version = case when version = #{version} then true else false end
-        where event_id = #{eventId} and feed_id = #{feedId};
+        with maxv as (
+            select max(version) as v
+            from feed_data
+            where event_id = #{eventId}
+              and feed_id  = #{feedId}
+              and enriched
+        )
+        update feed_data fd
+        set is_latest_version = case when fd.version = (select v from maxv) then true else false end
+        where fd.event_id = #{eventId}
+          and fd.feed_id  = #{feedId}
+          and (fd.is_latest_version is true or fd.version = (select v from maxv))
+          and #{version}  = (select v from maxv);
     </update>
 
     <select id="getLastFeedDataVersion" resultType="java.lang.Long">


### PR DESCRIPTION
## Summary
- document monotonic `is_latest_version` semantics
- only update `is_latest_version` when version is the highest enriched one
- clarify mapper documentation

## Testing
- `make precommit`

------
https://chatgpt.com/codex/tasks/task_e_68b2f9748c6c83248cf45c13dd2a4e2f