### PR TITLE
feat(logging): add episode diagnostics for oversized jsonb

### DIFF
--- a/src/main/java/io/kontur/eventapi/job/FeedCompositionJob.java
+++ b/src/main/java/io/kontur/eventapi/job/FeedCompositionJob.java
@@ -11,7 +11,6 @@ import io.micrometer.core.annotation.Counted;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.MeterRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.nio.charset.StandardCharsets;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.locationtech.jts.geom.Geometry;
 import org.wololo.geojson.Feature;
@@ -44,6 +43,14 @@ public class FeedCompositionJob extends AbstractJob {
     private static final Logger LOG = LoggerFactory.getLogger(FeedCompositionJob.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final GeoJSONReader GEOJSON_READER = new GeoJSONReader();
+
+    static ObjectMapper getMapper() {
+        return MAPPER;
+    }
+
+    static GeoJSONReader getGeoJsonReader() {
+        return GEOJSON_READER;
+    }
     @Value("${scheduler.feedComposition.alias}")
     private String[] alias;
 
@@ -169,9 +176,9 @@ public class FeedCompositionJob extends AbstractJob {
             return "{}";
         }
         try {
-            String json = MAPPER.writeValueAsString(fc);
-            String hash = DigestUtils.md5Hex(json);
-            int bytes = json.getBytes(StandardCharsets.UTF_8).length;
+            byte[] jsonBytes = MAPPER.writeValueAsBytes(fc);
+            String hash = DigestUtils.md5Hex(jsonBytes);
+            int bytes = jsonBytes.length;
             double areaKm2 = 0d;
             double lengthKm = 0d;
             for (Feature feature : fc.getFeatures()) {

--- a/src/main/java/io/kontur/eventapi/util/GeometryUtil.java
+++ b/src/main/java/io/kontur/eventapi/util/GeometryUtil.java
@@ -51,10 +51,23 @@ public class GeometryUtil {
         return areaInMeters / 1_000_000;
     }
 
+    /**
+     * Calculate geodesic length of the provided geometry in kilometers.
+     * Returns {@code 0.0} when geometry is {@code null}, empty or has no segments.
+     *
+     * @param geometry geometry to measure
+     * @return length in kilometers
+     */
     public static double calculateLengthKm(Geometry geometry) {
+        if (geometry == null || geometry.getNumGeometries() == 0) {
+            return 0d;
+        }
         double lengthInMeters = 0d;
         for (int i = 0; i < geometry.getNumGeometries(); i++) {
             var coords = geometry.getGeometryN(i).getCoordinates();
+            if (coords == null || coords.length < 2) {
+                continue;
+            }
             for (int j = 1; j < coords.length; j++) {
                 lengthInMeters += Geodesic.WGS84.Inverse(
                         coords[j - 1].y, coords[j - 1].x,

--- a/src/main/java/io/kontur/eventapi/util/GeometryUtil.java
+++ b/src/main/java/io/kontur/eventapi/util/GeometryUtil.java
@@ -51,6 +51,20 @@ public class GeometryUtil {
         return areaInMeters / 1_000_000;
     }
 
+    public static double calculateLengthKm(Geometry geometry) {
+        double lengthInMeters = 0d;
+        for (int i = 0; i < geometry.getNumGeometries(); i++) {
+            var coords = geometry.getGeometryN(i).getCoordinates();
+            for (int j = 1; j < coords.length; j++) {
+                lengthInMeters += Geodesic.WGS84.Inverse(
+                        coords[j - 1].y, coords[j - 1].x,
+                        coords[j].y, coords[j].x
+                ).s12;
+            }
+        }
+        return lengthInMeters / 1_000d;
+    }
+
     public static FeatureCollection convertGeometryToFeatureCollection(org.wololo.geojson.Geometry geometry, Map<String, Object> properties) {
         Feature feature = new Feature(geometry, properties);
         return new FeatureCollection(new Feature[] {feature});

--- a/src/test/java/io/kontur/eventapi/job/FeedCompositionJobTest.java
+++ b/src/test/java/io/kontur/eventapi/job/FeedCompositionJobTest.java
@@ -1,0 +1,54 @@
+package io.kontur.eventapi.job;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.kontur.eventapi.entity.FeedEpisode;
+import io.kontur.eventapi.util.GeometryUtil;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.junit.jupiter.api.Test;
+import org.wololo.geojson.FeatureCollection;
+import org.wololo.geojson.GeoJSONFactory;
+import org.wololo.jts2geojson.GeoJSONReader;
+
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FeedCompositionJobTest {
+
+    @Test
+    void buildEpisodesDebugInfoIncludesGeometryData() throws Exception {
+        FeedEpisode episode = new FeedEpisode();
+        episode.setStartedAt(OffsetDateTime.parse("2020-01-01T00:00Z"));
+        episode.setEndedAt(OffsetDateTime.parse("2020-01-02T00:00Z"));
+        UUID obsId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        episode.addObservation(obsId);
+        String fcString = "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[0,0],[0,1],[1,1],[1,0],[0,0]]]},\"properties\":{}}]}";
+        FeatureCollection fc = (FeatureCollection) GeoJSONFactory.create(fcString);
+        episode.setGeometries(fc);
+
+        String info = FeedCompositionJob.buildEpisodesDebugInfo(Collections.singletonList(episode));
+
+        ObjectMapper mapper = new ObjectMapper();
+        String json = mapper.writeValueAsString(fc);
+        String hash = DigestUtils.md5Hex(json);
+        int bytes = json.getBytes(StandardCharsets.UTF_8).length;
+        double area = GeometryUtil.calculateAreaKm2(new GeoJSONReader().read(fc.getFeatures()[0].getGeometry()));
+
+        assertTrue(info.contains("start=2020-01-01T00:00Z"),
+                "Start time missing in debug info: " + info);
+        assertTrue(info.contains("end=2020-01-02T00:00Z"),
+                "End time missing in debug info: " + info);
+        assertTrue(info.contains(obsId.toString()),
+                "Observation ID missing in debug info: " + info);
+        assertTrue(info.contains(hash),
+                "Geometry hash missing in debug info: " + info);
+        assertTrue(info.contains("bytes=" + bytes),
+                "Geometry byte length missing in debug info: " + info);
+        assertTrue(info.contains("areaKm2=" + String.format(Locale.ROOT, "%.2f", area)),
+                "Geometry area missing in debug info: " + info);
+    }
+}

--- a/src/test/java/io/kontur/eventapi/job/FeedCompositionJobTest.java
+++ b/src/test/java/io/kontur/eventapi/job/FeedCompositionJobTest.java
@@ -1,15 +1,11 @@
 package io.kontur.eventapi.job;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kontur.eventapi.entity.FeedEpisode;
 import io.kontur.eventapi.util.GeometryUtil;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.jupiter.api.Test;
 import org.wololo.geojson.FeatureCollection;
 import org.wololo.geojson.GeoJSONFactory;
-import org.wololo.jts2geojson.GeoJSONReader;
-
-import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.Locale;
@@ -44,7 +40,8 @@ class FeedCompositionJobTest {
 
         String info = FeedCompositionJob.buildEpisodesDebugInfo(Collections.singletonList(episode));
 
-        double length = GeometryUtil.calculateLengthKm(new GeoJSONReader().read(fc.getFeatures()[0].getGeometry()));
+        double length = GeometryUtil.calculateLengthKm(
+                FeedCompositionJob.getGeoJsonReader().read(fc.getFeatures()[0].getGeometry()));
         assertTrue(info.contains("lengthKm=" + String.format(Locale.ROOT, "%.2f", length)),
                 "Geometry length missing in debug info: " + info);
     }
@@ -62,12 +59,11 @@ class FeedCompositionJobTest {
 
         String info = FeedCompositionJob.buildEpisodesDebugInfo(Collections.singletonList(episode));
 
-        ObjectMapper mapper = new ObjectMapper();
-        String json = mapper.writeValueAsString(fc);
-        byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
+        byte[] bytes = FeedCompositionJob.getMapper().writeValueAsBytes(fc);
         String hash = DigestUtils.md5Hex(bytes);
         int length = bytes.length;
-        double area = GeometryUtil.calculateAreaKm2(new GeoJSONReader().read(fc.getFeatures()[0].getGeometry()));
+        double area = GeometryUtil.calculateAreaKm2(
+                FeedCompositionJob.getGeoJsonReader().read(fc.getFeatures()[0].getGeometry()));
 
         assertTrue(info.contains("start=2020-01-01T00:00Z"),
                 "Start time missing in debug info: " + info);
@@ -96,8 +92,11 @@ class FeedCompositionJobTest {
 
         String info = FeedCompositionJob.buildEpisodesDebugInfo(Collections.singletonList(episode));
 
-        double length = GeometryUtil.calculateLengthKm(new GeoJSONReader().read(fc.getFeatures()[0].getGeometry()));
+        double length = GeometryUtil.calculateLengthKm(
+                FeedCompositionJob.getGeoJsonReader().read(fc.getFeatures()[0].getGeometry()));
 
+        assertTrue(info.contains(obsId.toString()),
+                "Observation ID missing in debug info: " + info);
         assertTrue(info.contains("lengthKm=" + String.format(Locale.ROOT, "%.2f", length)),
                 "Geometry length missing in debug info: " + info);
     }


### PR DESCRIPTION
## Summary
- log episode start/end, associated observations, and geometry metrics when JSONB payloads exceed size limit
- add test for episode debug information

## Testing
- `make precommit`
- `TEST_MODE=1 PYTHONPATH=. make -B -j all`


------
https://chatgpt.com/codex/tasks/task_e_68b342bd4a4c832492f7bb27934d82ee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Enhanced oversized-data diagnostics with richer per-episode geometry summaries (hash, byte size, area/length), improved logging context (time ranges, provider and observation identifiers) and safer handling when geometries or episodes are missing.

- Tests
  - Added unit tests validating episode diagnostic output across scenarios (empty/null geometries, polygons/lines/multilines), including timestamps, identifiers, hashes, sizes and computed area/length.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->