### PR TITLE
feat(feed): merge unchanged observations into single episode

### DIFF
--- a/docs/Versions and timelines
+++ b/docs/Versions and timelines
@@ -35,8 +35,9 @@ Idealized workflow:
   * A job that links each Observation to an Event. Can use source provider's event id for matching (PDC, GDACS), or a heuristic (FIRMS), or be a manual operation (future). 
 * Episode rollup
   * A job that publishes a Snapshot of Event into Feed. For each feed, for each event, pulls in observations visible for the feed for the event. Checks if list of observations matches one in the last published version. If lists don't match (new observation in event, change in access restrictions, observation manually unlinked) the new version is produced and stored in output feed.
-  * While producing the new Snapshot of event, the Observations that relate to the same time are folded together into one single Episode. Data from previous Observations is generally used to fill in the gaps in newer ones.
-  * When geometry and other properties remain unchanged between consecutive observations, their time intervals are glued and a single Episode spans the whole range.
+  * While producing the new Snapshot of event, the Observations that relate to the same time are folded together into one single Episode.
+  * Data from previous Observations is generally used to fill in the gaps in newer ones.
+  * When geometry and properties such as type, severity, name, properName, description, location, loss, severityData, urls remain unchanged and observations are adjacent in time, their intervals are glued and a single Episode spans the whole range.
 
 
 

--- a/docs/Versions and timelines
+++ b/docs/Versions and timelines
@@ -34,8 +34,9 @@ Idealized workflow:
 * Event recombination
   * A job that links each Observation to an Event. Can use source provider's event id for matching (PDC, GDACS), or a heuristic (FIRMS), or be a manual operation (future). 
 * Episode rollup
-  * A job that publishes a Snapshot of Event into Feed. For each feed, for each event, pulls in observations visible for the feed for the event. Checks if list of observations matches one in the last published version. If lists don't match (new observation in event, change in access restrictions, observation manually unlinked) the new version is produced and stored in output feed. 
+  * A job that publishes a Snapshot of Event into Feed. For each feed, for each event, pulls in observations visible for the feed for the event. Checks if list of observations matches one in the last published version. If lists don't match (new observation in event, change in access restrictions, observation manually unlinked) the new version is produced and stored in output feed.
   * While producing the new Snapshot of event, the Observations that relate to the same time are folded together into one single Episode. Data from previous Observations is generally used to fill in the gaps in newer ones.
+  * When geometry and other properties remain unchanged between consecutive observations, their time intervals are glued and a single Episode spans the whole range.
 
 
 

--- a/src/main/java/io/kontur/eventapi/episodecomposition/WildfireEpisodeCombinator.java
+++ b/src/main/java/io/kontur/eventapi/episodecomposition/WildfireEpisodeCombinator.java
@@ -11,7 +11,10 @@ public abstract class WildfireEpisodeCombinator extends EpisodeCombinator {
 
     @Override
     public List<FeedEpisode> postProcessEpisodes(List<FeedEpisode> episodes) {
-        if (episodes.size() < 2) return episodes;
+        episodes = super.postProcessEpisodes(episodes);
+        if (episodes.size() < 2) {
+            return episodes;
+        }
 
         episodes.sort(comparing(FeedEpisode::getStartedAt).thenComparing(FeedEpisode::getEndedAt));
         OffsetDateTime lastEndedAt = null;

--- a/src/main/java/io/kontur/eventapi/nhc/episodecomposition/NhcEpisodeCombinator.java
+++ b/src/main/java/io/kontur/eventapi/nhc/episodecomposition/NhcEpisodeCombinator.java
@@ -217,6 +217,7 @@ public class NhcEpisodeCombinator extends EpisodeCombinator {
 
     @Override
     public List<FeedEpisode> postProcessEpisodes(List<FeedEpisode> episodes) {
+        episodes = super.postProcessEpisodes(episodes);
         if (CollectionUtils.isEmpty(episodes)) {
             return episodes;
         }

--- a/src/test/java/io/kontur/eventapi/episodecomposition/DefaultEpisodeCombinatorTest.java
+++ b/src/test/java/io/kontur/eventapi/episodecomposition/DefaultEpisodeCombinatorTest.java
@@ -21,8 +21,8 @@ class DefaultEpisodeCombinatorTest {
     void mergesEpisodesWithUnchangedGeometryAndProperties() {
         OffsetDateTime start1 = OffsetDateTime.parse("2023-08-01T00:00:00Z");
         OffsetDateTime end1 = OffsetDateTime.parse("2023-08-01T01:00:00Z");
-        OffsetDateTime start2 = OffsetDateTime.parse("2023-08-01T02:00:00Z");
-        OffsetDateTime end2 = OffsetDateTime.parse("2023-08-01T03:00:00Z");
+        OffsetDateTime start2 = end1;
+        OffsetDateTime end2 = OffsetDateTime.parse("2023-08-01T02:00:00Z");
 
         FeatureCollection geom = new FeatureCollection(new Feature[] {
             new Feature(new Point(new double[] {10d, 10d}), null)
@@ -54,5 +54,15 @@ class DefaultEpisodeCombinatorTest {
         assertEquals(end2, mergedEpisode.getEndedAt(), "Merged episode end should be latest end");
         assertTrue(mergedEpisode.getObservations().containsAll(Arrays.asList(obs1, obs2)),
             "Merged episode must include all observations");
+
+        OffsetDateTime latestUpdatedAt = ep1.getUpdatedAt().isAfter(ep2.getUpdatedAt())
+                ? ep1.getUpdatedAt() : ep2.getUpdatedAt();
+        assertEquals(latestUpdatedAt, mergedEpisode.getUpdatedAt(),
+                "Merged episode must carry latest updatedAt");
+
+        OffsetDateTime latestSourceUpdatedAt = ep1.getSourceUpdatedAt().isAfter(ep2.getSourceUpdatedAt())
+                ? ep1.getSourceUpdatedAt() : ep2.getSourceUpdatedAt();
+        assertEquals(latestSourceUpdatedAt, mergedEpisode.getSourceUpdatedAt(),
+                "Merged episode must carry latest sourceUpdatedAt");
     }
 }

--- a/src/test/java/io/kontur/eventapi/episodecomposition/DefaultEpisodeCombinatorTest.java
+++ b/src/test/java/io/kontur/eventapi/episodecomposition/DefaultEpisodeCombinatorTest.java
@@ -1,0 +1,58 @@
+package io.kontur.eventapi.episodecomposition;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.kontur.eventapi.entity.FeedEpisode;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.wololo.geojson.Feature;
+import org.wololo.geojson.FeatureCollection;
+import org.wololo.geojson.Point;
+
+class DefaultEpisodeCombinatorTest {
+
+    private final DefaultEpisodeCombinator combinator = new DefaultEpisodeCombinator();
+
+    @Test
+    void mergesEpisodesWithUnchangedGeometryAndProperties() {
+        OffsetDateTime start1 = OffsetDateTime.parse("2023-08-01T00:00:00Z");
+        OffsetDateTime end1 = OffsetDateTime.parse("2023-08-01T01:00:00Z");
+        OffsetDateTime start2 = OffsetDateTime.parse("2023-08-01T02:00:00Z");
+        OffsetDateTime end2 = OffsetDateTime.parse("2023-08-01T03:00:00Z");
+
+        FeatureCollection geom = new FeatureCollection(new Feature[] {
+            new Feature(new Point(new double[] {10d, 10d}), null)
+        });
+
+        FeedEpisode ep1 = new FeedEpisode();
+        ep1.setStartedAt(start1);
+        ep1.setEndedAt(end1);
+        ep1.setUpdatedAt(start1);
+        ep1.setSourceUpdatedAt(start1);
+        ep1.setGeometries(geom);
+        UUID obs1 = UUID.randomUUID();
+        ep1.addObservation(obs1);
+
+        FeedEpisode ep2 = new FeedEpisode();
+        ep2.setStartedAt(start2);
+        ep2.setEndedAt(end2);
+        ep2.setUpdatedAt(start2);
+        ep2.setSourceUpdatedAt(start2);
+        ep2.setGeometries(geom);
+        UUID obs2 = UUID.randomUUID();
+        ep2.addObservation(obs2);
+
+        List<FeedEpisode> merged = combinator.postProcessEpisodes(Arrays.asList(ep1, ep2));
+
+        assertEquals(1, merged.size(), "Episodes with same geometry must merge into one");
+        FeedEpisode mergedEpisode = merged.get(0);
+        assertEquals(start1, mergedEpisode.getStartedAt(), "Merged episode start should be earliest start");
+        assertEquals(end2, mergedEpisode.getEndedAt(), "Merged episode end should be latest end");
+        assertTrue(mergedEpisode.getObservations().containsAll(Arrays.asList(obs1, obs2)),
+            "Merged episode must include all observations");
+    }
+}

--- a/src/test/java/io/kontur/eventapi/firms/event/FirmsEventAndEpisodeCombinationsJobIT.java
+++ b/src/test/java/io/kontur/eventapi/firms/event/FirmsEventAndEpisodeCombinationsJobIT.java
@@ -190,7 +190,7 @@ public class FirmsEventAndEpisodeCombinationsJobIT extends AbstractCleanableInte
 
         assertEquals(5, episodes.get(2).getObservations().size(), "Episode 3 should contain five observations");
         assertEquals(parse("2020-11-02T22:50Z"), episodes.get(2).getSourceUpdatedAt(), "Episode 3 source update mismatch");
-        assertEquals(parse("2020-11-02T14:50Z"), episodes.get(2).getStartedAt(), "Episode 3 start time mismatch");
+        assertEquals(parse("2020-11-02T22:50Z"), episodes.get(2).getStartedAt(), "Episode 3 start time mismatch");
         assertEquals(parse("2020-11-03T22:50Z"), episodes.get(2).getEndedAt(), "Episode 3 end time mismatch");
         assertEquals(Severity.MINOR, episodes.get(2).getSeverity(), "Episode 3 severity mismatch");
 

--- a/src/test/java/io/kontur/eventapi/firms/event/FirmsEventAndEpisodeCombinationsJobIT.java
+++ b/src/test/java/io/kontur/eventapi/firms/event/FirmsEventAndEpisodeCombinationsJobIT.java
@@ -185,7 +185,7 @@ public class FirmsEventAndEpisodeCombinationsJobIT extends AbstractCleanableInte
                 "Episode 2 should contain four observations after second feed composition run");
         assertEquals(parse("2020-11-02T14:50Z"), episodes.get(1).getSourceUpdatedAt(), "Episode 2 source update mismatch");
         assertEquals(parse("2020-11-02T12:50Z"), episodes.get(1).getStartedAt(), "Episode 2 start time mismatch");
-        assertEquals(parse("2020-11-02T14:50Z"), episodes.get(1).getEndedAt(), "Episode 2 end time mismatch");
+        assertEquals(parse("2020-11-02T22:50Z"), episodes.get(1).getEndedAt(), "Episode 2 end time mismatch");
         assertEquals(Severity.MINOR, episodes.get(1).getSeverity(), "Episode 2 severity mismatch");
 
         assertEquals(5, episodes.get(2).getObservations().size(), "Episode 3 should contain five observations");

--- a/src/test/java/io/kontur/eventapi/firms/event/FirmsEventAndEpisodeCombinationsJobIT.java
+++ b/src/test/java/io/kontur/eventapi/firms/event/FirmsEventAndEpisodeCombinationsJobIT.java
@@ -183,7 +183,7 @@ public class FirmsEventAndEpisodeCombinationsJobIT extends AbstractCleanableInte
 
         assertEquals(4, episodes.get(1).getObservations().size(),
                 "Episode 2 should contain four observations after second feed composition run");
-        assertEquals(parse("2020-11-02T12:50Z"), episodes.get(1).getSourceUpdatedAt(), "Episode 2 source update mismatch");
+        assertEquals(parse("2020-11-02T14:50Z"), episodes.get(1).getSourceUpdatedAt(), "Episode 2 source update mismatch");
         assertEquals(parse("2020-11-02T12:50Z"), episodes.get(1).getStartedAt(), "Episode 2 start time mismatch");
         assertEquals(parse("2020-11-02T14:50Z"), episodes.get(1).getEndedAt(), "Episode 2 end time mismatch");
         assertEquals(Severity.MINOR, episodes.get(1).getSeverity(), "Episode 2 severity mismatch");

--- a/src/test/java/io/kontur/eventapi/firms/event/FirmsEventAndEpisodeCombinationsJobIT.java
+++ b/src/test/java/io/kontur/eventapi/firms/event/FirmsEventAndEpisodeCombinationsJobIT.java
@@ -181,7 +181,8 @@ public class FirmsEventAndEpisodeCombinationsJobIT extends AbstractCleanableInte
         assertEquals(parse("2020-11-02T12:50Z"), episodes.get(0).getEndedAt(), "Episode 1 end time mismatch");
         assertEquals(Severity.MINOR, episodes.get(0).getSeverity(), "Episode 1 severity mismatch");
 
-        assertEquals(3, episodes.get(1).getObservations().size(), "Episode 2 should contain three observations");
+        assertEquals(4, episodes.get(1).getObservations().size(),
+                "Episode 2 should contain four observations after second feed composition run");
         assertEquals(parse("2020-11-02T12:50Z"), episodes.get(1).getSourceUpdatedAt(), "Episode 2 source update mismatch");
         assertEquals(parse("2020-11-02T12:50Z"), episodes.get(1).getStartedAt(), "Episode 2 start time mismatch");
         assertEquals(parse("2020-11-02T14:50Z"), episodes.get(1).getEndedAt(), "Episode 2 end time mismatch");

--- a/src/test/java/io/kontur/eventapi/firms/event/FirmsEventAndEpisodeCombinationsJobIT.java
+++ b/src/test/java/io/kontur/eventapi/firms/event/FirmsEventAndEpisodeCombinationsJobIT.java
@@ -189,7 +189,7 @@ public class FirmsEventAndEpisodeCombinationsJobIT extends AbstractCleanableInte
         assertEquals(Severity.MINOR, episodes.get(1).getSeverity(), "Episode 2 severity mismatch");
 
         assertEquals(5, episodes.get(2).getObservations().size(), "Episode 3 should contain five observations");
-        assertEquals(parse("2020-11-02T14:50Z"), episodes.get(2).getSourceUpdatedAt(), "Episode 3 source update mismatch");
+        assertEquals(parse("2020-11-02T22:50Z"), episodes.get(2).getSourceUpdatedAt(), "Episode 3 source update mismatch");
         assertEquals(parse("2020-11-02T14:50Z"), episodes.get(2).getStartedAt(), "Episode 3 start time mismatch");
         assertEquals(parse("2020-11-03T22:50Z"), episodes.get(2).getEndedAt(), "Episode 3 end time mismatch");
         assertEquals(Severity.MINOR, episodes.get(2).getSeverity(), "Episode 3 severity mismatch");

--- a/src/test/java/io/kontur/eventapi/firms/event/FirmsEventAndEpisodeCombinationsJobIT.java
+++ b/src/test/java/io/kontur/eventapi/firms/event/FirmsEventAndEpisodeCombinationsJobIT.java
@@ -154,53 +154,47 @@ public class FirmsEventAndEpisodeCombinationsJobIT extends AbstractCleanableInte
         //THEN
         List<TestEventDto> firmsUpdated = searchFeedData();
 
-        assertEquals(3, firmsUpdated.size());
+        assertEquals(3, firmsUpdated.size(), "Expected three events after second feed composition run");
 
-        assertEquals(1, firmsUpdated.get(0).getObservations().size());
-        assertEquals(1, firmsUpdated.get(0).getEpisodes().size());
-        assertEquals(1, firmsUpdated.get(0).getVersion());
+        assertEquals(1, firmsUpdated.get(0).getObservations().size(), "First event should have one observation");
+        assertEquals(1, firmsUpdated.get(0).getEpisodes().size(), "First event should have one episode");
+        assertEquals(1, firmsUpdated.get(0).getVersion(), "First event version mismatch");
 
-        assertEquals(2, firmsUpdated.get(1).getObservations().size());
-        assertEquals(2, firmsUpdated.get(1).getEpisodes().size());
-        assertEquals(2, firmsUpdated.get(1).getVersion());
+        assertEquals(2, firmsUpdated.get(1).getObservations().size(), "Second event should have two observations");
+        assertEquals(2, firmsUpdated.get(1).getEpisodes().size(), "Second event should have two episodes");
+        assertEquals(2, firmsUpdated.get(1).getVersion(), "Second event version mismatch");
 
         TestEventDto someFedData = firmsUpdated.get(2);
-        assertEquals(5, someFedData.getObservations().size());
-        assertEquals(parse("2020-11-02T11:50Z"),someFedData.getStartedAt());
-        assertEquals(parse("2020-11-03T22:50Z"),someFedData.getEndedAt());
-        assertEquals(2, someFedData.getVersion());
+        assertEquals(5, someFedData.getObservations().size(), "Third event should contain five observations");
+        assertEquals(parse("2020-11-02T11:50Z"), someFedData.getStartedAt(), "Unexpected start time for third event");
+        assertEquals(parse("2020-11-03T22:50Z"), someFedData.getEndedAt(), "Unexpected end time for third event");
+        assertEquals(2, someFedData.getVersion(), "Third event version mismatch");
 
         List<TestEpisodeDto> episodes = someFedData.getEpisodes();
-        assertEquals(4, episodes.size());
+        assertEquals(3, episodes.size(), "Expected three episodes in third event");
 
         episodes.sort(Comparator.comparing(TestEpisodeDto::getSourceUpdatedAt));
 
-        assertEquals(2, episodes.get(0).getObservations().size());
-        assertEquals(parse("2020-11-02T11:50Z"), episodes.get(0).getSourceUpdatedAt());
-        assertEquals(parse("2020-11-02T11:50Z"), episodes.get(0).getStartedAt());
-        assertEquals(parse("2020-11-02T12:50Z"), episodes.get(0).getEndedAt());
-        assertEquals(Severity.MINOR, episodes.get(0).getSeverity());
+        assertEquals(2, episodes.get(0).getObservations().size(), "Episode 1 should contain two observations");
+        assertEquals(parse("2020-11-02T11:50Z"), episodes.get(0).getSourceUpdatedAt(), "Episode 1 source update mismatch");
+        assertEquals(parse("2020-11-02T11:50Z"), episodes.get(0).getStartedAt(), "Episode 1 start time mismatch");
+        assertEquals(parse("2020-11-02T12:50Z"), episodes.get(0).getEndedAt(), "Episode 1 end time mismatch");
+        assertEquals(Severity.MINOR, episodes.get(0).getSeverity(), "Episode 1 severity mismatch");
 
-        assertEquals(3, episodes.get(1).getObservations().size());
-        assertEquals(parse("2020-11-02T12:50Z"), episodes.get(1).getSourceUpdatedAt());
-        assertEquals(parse("2020-11-02T12:50Z"), episodes.get(1).getStartedAt());
-        assertEquals(parse("2020-11-02T14:50Z"), episodes.get(1).getEndedAt());
-        assertEquals(Severity.MINOR, episodes.get(1).getSeverity());
+        assertEquals(3, episodes.get(1).getObservations().size(), "Episode 2 should contain three observations");
+        assertEquals(parse("2020-11-02T12:50Z"), episodes.get(1).getSourceUpdatedAt(), "Episode 2 source update mismatch");
+        assertEquals(parse("2020-11-02T12:50Z"), episodes.get(1).getStartedAt(), "Episode 2 start time mismatch");
+        assertEquals(parse("2020-11-02T14:50Z"), episodes.get(1).getEndedAt(), "Episode 2 end time mismatch");
+        assertEquals(Severity.MINOR, episodes.get(1).getSeverity(), "Episode 2 severity mismatch");
 
-        assertEquals(4, episodes.get(2).getObservations().size());
-        assertEquals(parse("2020-11-02T14:50Z"), episodes.get(2).getSourceUpdatedAt());
-        assertEquals(parse("2020-11-02T14:50Z"), episodes.get(2).getStartedAt());
-        assertEquals(parse("2020-11-02T22:50Z"), episodes.get(2).getEndedAt());
-        assertEquals(Severity.MINOR, episodes.get(2).getSeverity());
-
-        assertEquals(5, episodes.get(3).getObservations().size());
-        assertEquals(parse("2020-11-02T22:50Z"), episodes.get(3).getSourceUpdatedAt());
-        assertEquals(parse("2020-11-02T22:50Z"), episodes.get(3).getStartedAt());
-        assertEquals(parse("2020-11-03T22:50Z"), episodes.get(3).getEndedAt());
-        assertEquals(Severity.MINOR, episodes.get(3).getSeverity());
+        assertEquals(5, episodes.get(2).getObservations().size(), "Episode 3 should contain five observations");
+        assertEquals(parse("2020-11-02T14:50Z"), episodes.get(2).getSourceUpdatedAt(), "Episode 3 source update mismatch");
+        assertEquals(parse("2020-11-02T14:50Z"), episodes.get(2).getStartedAt(), "Episode 3 start time mismatch");
+        assertEquals(parse("2020-11-03T22:50Z"), episodes.get(2).getEndedAt(), "Episode 3 end time mismatch");
+        assertEquals(Severity.MINOR, episodes.get(2).getSeverity(), "Episode 3 severity mismatch");
 
         List<KonturEvent> newEventsForRolloutEpisodes = readEvents(konturEventsDao.getEventsForRolloutEpisodes(firmsFeed.getFeedId()));
-        assertTrue(newEventsForRolloutEpisodes.isEmpty());
+        assertTrue(newEventsForRolloutEpisodes.isEmpty(), "No events should remain for rollout after feed composition");
 
         //WHEN new data available for modis - 1 observations within 1 km to existing observations
         when(firmsClient.getModisData()).thenReturn(readCsv("firms.modis-c6-update-2.csv"));

--- a/src/test/java/io/kontur/eventapi/usgs/earthquake/event/UsgsEarthquakeEventCombinationJobTest.java
+++ b/src/test/java/io/kontur/eventapi/usgs/earthquake/event/UsgsEarthquakeEventCombinationJobTest.java
@@ -61,6 +61,6 @@ public class UsgsEarthquakeEventCombinationJobTest {
         job.run();
 
         assertEquals(2, events.get("eq1").getObservationIds().size(),
-                "Merged earthquake event should contain two observations");
+                "Merged earthquake event should contain two observations sharing external ID 'eq1'");
     }
 }

--- a/src/test/java/io/kontur/eventapi/usgs/earthquake/event/UsgsEarthquakeEventCombinationJobTest.java
+++ b/src/test/java/io/kontur/eventapi/usgs/earthquake/event/UsgsEarthquakeEventCombinationJobTest.java
@@ -1,0 +1,66 @@
+package io.kontur.eventapi.usgs.earthquake.event;
+
+import io.kontur.eventapi.dao.KonturEventsDao;
+import io.kontur.eventapi.dao.NormalizedObservationsDao;
+import io.kontur.eventapi.entity.KonturEvent;
+import io.kontur.eventapi.entity.NormalizedObservation;
+import io.kontur.eventapi.eventcombination.DefaultEventCombinator;
+import io.kontur.eventapi.job.EventCombinationJob;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class UsgsEarthquakeEventCombinationJobTest {
+
+    @Test
+    void mergeSameEarthquakeUpdates() {
+        NormalizedObservationsDao observationsDao = Mockito.mock(NormalizedObservationsDao.class);
+        KonturEventsDao eventsDao = Mockito.mock(KonturEventsDao.class);
+
+        UUID firstId = UUID.randomUUID();
+        UUID secondId = UUID.randomUUID();
+        NormalizedObservation first = new NormalizedObservation();
+        first.setObservationId(firstId);
+        first.setExternalEventId("eq1");
+        first.setProvider("usgs.earthquake");
+        NormalizedObservation second = new NormalizedObservation();
+        second.setObservationId(secondId);
+        second.setExternalEventId("eq1");
+        second.setProvider("usgs.earthquake");
+
+        Mockito.when(observationsDao.getObservationsNotLinkedToEvent(Mockito.anyList()))
+                .thenReturn(List.of(first, second));
+
+        Map<String, KonturEvent> events = new HashMap<>();
+        Mockito.when(eventsDao.getEventByExternalId(Mockito.anyString()))
+                .thenAnswer(inv -> Optional.ofNullable(events.get(inv.getArgument(0))));
+        Mockito.doAnswer(inv -> {
+            UUID eventId = inv.getArgument(0);
+            NormalizedObservation obs = inv.getArgument(1);
+            events.computeIfAbsent(obs.getExternalEventId(), id -> new KonturEvent(eventId))
+                  .addObservations(obs.getObservationId());
+            return null;
+        }).when(eventsDao).appendObservationIntoEvent(Mockito.any(UUID.class), Mockito.any(NormalizedObservation.class));
+
+        EventCombinationJob job = new EventCombinationJob(
+                observationsDao,
+                eventsDao,
+                List.of(new DefaultEventCombinator(eventsDao)),
+                new SimpleMeterRegistry());
+
+        ReflectionTestUtils.setField(job, "sequentialProviders", new String[]{"usgs.earthquake"});
+
+        job.run();
+
+        assertEquals(2, events.get("eq1").getObservationIds().size(),
+                "Merged earthquake event should contain two observations");
+    }
+}


### PR DESCRIPTION
## Summary
- merge consecutive observations into a single episode when geometry and other properties remain unchanged
- ensure wildfire and NHC combinators reuse base post-processing
- document the merging rule and cover it with a unit test

## Testing
- `make precommit`

------
https://chatgpt.com/codex/tasks/task_e_68b35db34ef0832495c4a28c2ca88d9f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Episodes with identical geometry and properties are now automatically merged when time-adjacent, consolidating observations, timestamps, URLs and metadata; merging can consider a time tolerance.
  - Wildfire and NHC episode flows now benefit from the shared post-processing merge behavior.

- Documentation
  - Expanded “Idealized workflow” episode rollup: folding observations, filling gaps from prior data, and gluing adjacent intervals.

- Tests
  - Added/updated tests validating contiguous-episode merging and updated end/start/updated timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->