### PR TITLE
fix(episode): enforce temporal adjacency and handle null data

### DIFF
--- a/docs/Versions and timelines
+++ b/docs/Versions and timelines
@@ -35,8 +35,9 @@ Idealized workflow:
   * A job that links each Observation to an Event. Can use source provider's event id for matching (PDC, GDACS), or a heuristic (FIRMS), or be a manual operation (future). 
 * Episode rollup
   * A job that publishes a Snapshot of Event into Feed. For each feed, for each event, pulls in observations visible for the feed for the event. Checks if list of observations matches one in the last published version. If lists don't match (new observation in event, change in access restrictions, observation manually unlinked) the new version is produced and stored in output feed.
-  * While producing the new Snapshot of event, the Observations that relate to the same time are folded together into one single Episode. Data from previous Observations is generally used to fill in the gaps in newer ones.
-  * When geometry and other properties remain unchanged between consecutive observations, their time intervals are glued and a single Episode spans the whole range.
+  * While producing the new Snapshot of event, the Observations that relate to the same time are folded together into one single Episode.
+  * Data from previous Observations is generally used to fill in the gaps in newer ones.
+  * When geometry and properties such as type, severity, name, properName, description, location, loss, severityData, urls remain unchanged and observations are adjacent in time, their intervals are glued and a single Episode spans the whole range.
 
 
 

--- a/src/test/java/io/kontur/eventapi/episodecomposition/DefaultEpisodeCombinatorTest.java
+++ b/src/test/java/io/kontur/eventapi/episodecomposition/DefaultEpisodeCombinatorTest.java
@@ -21,8 +21,8 @@ class DefaultEpisodeCombinatorTest {
     void mergesEpisodesWithUnchangedGeometryAndProperties() {
         OffsetDateTime start1 = OffsetDateTime.parse("2023-08-01T00:00:00Z");
         OffsetDateTime end1 = OffsetDateTime.parse("2023-08-01T01:00:00Z");
-        OffsetDateTime start2 = OffsetDateTime.parse("2023-08-01T02:00:00Z");
-        OffsetDateTime end2 = OffsetDateTime.parse("2023-08-01T03:00:00Z");
+        OffsetDateTime start2 = end1;
+        OffsetDateTime end2 = OffsetDateTime.parse("2023-08-01T02:00:00Z");
 
         FeatureCollection geom = new FeatureCollection(new Feature[] {
             new Feature(new Point(new double[] {10d, 10d}), null)
@@ -54,5 +54,15 @@ class DefaultEpisodeCombinatorTest {
         assertEquals(end2, mergedEpisode.getEndedAt(), "Merged episode end should be latest end");
         assertTrue(mergedEpisode.getObservations().containsAll(Arrays.asList(obs1, obs2)),
             "Merged episode must include all observations");
+
+        OffsetDateTime latestUpdatedAt = ep1.getUpdatedAt().isAfter(ep2.getUpdatedAt())
+                ? ep1.getUpdatedAt() : ep2.getUpdatedAt();
+        assertEquals(latestUpdatedAt, mergedEpisode.getUpdatedAt(),
+                "Merged episode must carry latest updatedAt");
+
+        OffsetDateTime latestSourceUpdatedAt = ep1.getSourceUpdatedAt().isAfter(ep2.getSourceUpdatedAt())
+                ? ep1.getSourceUpdatedAt() : ep2.getSourceUpdatedAt();
+        assertEquals(latestSourceUpdatedAt, mergedEpisode.getSourceUpdatedAt(),
+                "Merged episode must carry latest sourceUpdatedAt");
     }
 }


### PR DESCRIPTION
## Summary
- ensure episode merging checks temporal adjacency and sorts timestamps safely
- guard loss and severityData maps against nulls and compare URLs ignoring order
- document fields required for episode merge and expand unit tests for timestamp propagation

## Testing
- `make precommit`

------
https://chatgpt.com/codex/tasks/task_e_68b36344eee48324b57fe4c59878665d