### PR TITLE
feat(metrics): report total queue sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 #### Added
 
+- Report total queue sizes for ingestion steps.
+
 #### Changed
 - Implement flood-specific severity calculation for `storms.noaa` events.
 - Do not override event type for `storms.noaa` events in feed composition.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,10 @@
+# Metrics
+
+Queue size metrics expose current queue lengths for enabled providers.
+They also expose total queue sizes that include disabled providers.
+
+- `enrichment.queueSize` and `enrichment.totalQueueSize`
+- `enrichmentSkipped.queueSize` and `enrichmentSkipped.totalQueueSize`
+- `feedComposition.queueSize` and `feedComposition.totalQueueSize`
+- `eventCombination.queueSize` and `eventCombination.totalQueueSize`
+- `normalization.queueSize` and `normalization.totalQueueSize`

--- a/src/main/java/io/kontur/eventapi/dao/DataLakeDao.java
+++ b/src/main/java/io/kontur/eventapi/dao/DataLakeDao.java
@@ -87,4 +87,11 @@ public class DataLakeDao {
         return mapper.getNotNormalizedObservationsCount();
     }
 
+    public Integer getNotNormalizedObservationsCountForProviders(List<String> providers) {
+        if (providers == null || providers.isEmpty()) {
+            return 0;
+        }
+        return mapper.getNotNormalizedObservationsCountForProviders(providers);
+    }
+
 }

--- a/src/main/java/io/kontur/eventapi/dao/FeedDao.java
+++ b/src/main/java/io/kontur/eventapi/dao/FeedDao.java
@@ -87,6 +87,14 @@ public class FeedDao {
         return mapper.getEnrichmentSkippedEventsCount();
     }
 
+    public Integer getNotEnrichedEventsCountForFeedsWithEnrichment() {
+        return mapper.getNotEnrichedEventsCountForFeedsWithEnrichment();
+    }
+
+    public Integer getEnrichmentSkippedEventsCountForFeedsWithEnrichment() {
+        return mapper.getEnrichmentSkippedEventsCountForFeedsWithEnrichment();
+    }
+
     public void createFeed(UUID feedId, String alias, String name, List<String> providers) {
         mapper.createFeed(feedId, alias, name, providers);
     }

--- a/src/main/java/io/kontur/eventapi/dao/KonturEventsDao.java
+++ b/src/main/java/io/kontur/eventapi/dao/KonturEventsDao.java
@@ -58,4 +58,11 @@ public class KonturEventsDao {
     public Integer getNotComposedEventsCount() {
         return mapper.getNotComposedEventsCount();
     }
+
+    public Integer getNotComposedEventsCountForFeeds(List<String> aliases) {
+        if (aliases == null || aliases.isEmpty()) {
+            return 0;
+        }
+        return mapper.getNotComposedEventsCountForFeeds(aliases);
+    }
 }

--- a/src/main/java/io/kontur/eventapi/dao/NormalizedObservationsDao.java
+++ b/src/main/java/io/kontur/eventapi/dao/NormalizedObservationsDao.java
@@ -68,4 +68,11 @@ public class NormalizedObservationsDao {
     public Integer getNotRecombinedObservationsCount() {
         return mapper.getNotRecombinedObservationsCount();
     }
+
+    public Integer getNotRecombinedObservationsCountForProviders(List<String> providers) {
+        if (providers == null || providers.isEmpty()) {
+            return 0;
+        }
+        return mapper.getNotRecombinedObservationsCountForProviders(providers);
+    }
 }

--- a/src/main/java/io/kontur/eventapi/dao/mapper/DataLakeMapper.java
+++ b/src/main/java/io/kontur/eventapi/dao/mapper/DataLakeMapper.java
@@ -47,4 +47,6 @@ public interface DataLakeMapper {
                         @Param("updatedAt") String updatedAt);
 
     Integer getNotNormalizedObservationsCount();
+
+    Integer getNotNormalizedObservationsCountForProviders(@Param("providers") List<String> providers);
 }

--- a/src/main/java/io/kontur/eventapi/dao/mapper/FeedMapper.java
+++ b/src/main/java/io/kontur/eventapi/dao/mapper/FeedMapper.java
@@ -73,6 +73,10 @@ public interface FeedMapper {
 
     Integer getEnrichmentSkippedEventsCount();
 
+    Integer getNotEnrichedEventsCountForFeedsWithEnrichment();
+
+    Integer getEnrichmentSkippedEventsCountForFeedsWithEnrichment();
+
     void createFeed(@Param("feedId") UUID feedId, @Param("alias") String alias, @Param("name") String name, @Param("providers") List<String> providers);
 
     void autoExpireEvents();

--- a/src/main/java/io/kontur/eventapi/dao/mapper/KonturEventsMapper.java
+++ b/src/main/java/io/kontur/eventapi/dao/mapper/KonturEventsMapper.java
@@ -26,4 +26,6 @@ public interface KonturEventsMapper {
     Set<UUID> getEventsForRolloutEpisodes(@Param("feedId") UUID feedId);
 
     Integer getNotComposedEventsCount();
+
+    Integer getNotComposedEventsCountForFeeds(@Param("aliases") List<String> aliases);
 }

--- a/src/main/java/io/kontur/eventapi/dao/mapper/NormalizedObservationsMapper.java
+++ b/src/main/java/io/kontur/eventapi/dao/mapper/NormalizedObservationsMapper.java
@@ -61,6 +61,8 @@ public interface NormalizedObservationsMapper {
 
     Integer getNotRecombinedObservationsCount();
 
+    Integer getNotRecombinedObservationsCountForProviders(@Param("providers") List<String> providers);
+
     String buildShakemapPolygons(@Param("json") String json);
 
     String buildPgaMask(@Param("json") String json);

--- a/src/main/java/io/kontur/eventapi/metrics/collector/QueueSizeMetricsCollector.java
+++ b/src/main/java/io/kontur/eventapi/metrics/collector/QueueSizeMetricsCollector.java
@@ -18,32 +18,62 @@ public class QueueSizeMetricsCollector implements MetricCollector {
     private final AtomicInteger eventCombinationQueueSize;
     private final AtomicInteger normalizationQueueSize;
 
+    private final AtomicInteger enrichmentSkippedQueueSizeTotal;
+    private final AtomicInteger enrichmentQueueSizeTotal;
+    private final AtomicInteger feedCompositionQueueSizeTotal;
+    private final AtomicInteger eventCombinationQueueSizeTotal;
+    private final AtomicInteger normalizationQueueSizeTotal;
+
     private final FeedDao feedDao;
     private final KonturEventsDao konturEventsDao;
     private final NormalizedObservationsDao normalizedObservationsDao;
     private final DataLakeDao dataLakeDao;
 
+    private final String[] feedAliases;
+    private final String[] eventCombinationProviders;
+    private final String[] normalizationProviders;
+
     public QueueSizeMetricsCollector(AtomicInteger enrichmentSkippedQueueSizeGauge, AtomicInteger enrichmentQueueSizeGauge,
                                      AtomicInteger feedCompositionQueueSizeGauge, AtomicInteger eventCombinationQueueSizeGauge,
-                                     AtomicInteger normalizationQueueSizeGauge, FeedDao feedDao, KonturEventsDao konturEventsDao,
-                                     NormalizedObservationsDao normalizedObservationsDao, DataLakeDao dataLakeDao) {
+                                     AtomicInteger normalizationQueueSizeGauge,
+                                     AtomicInteger enrichmentSkippedQueueSizeTotalGauge, AtomicInteger enrichmentQueueSizeTotalGauge,
+                                     AtomicInteger feedCompositionQueueSizeTotalGauge, AtomicInteger eventCombinationQueueSizeTotalGauge,
+                                     AtomicInteger normalizationQueueSizeTotalGauge, FeedDao feedDao, KonturEventsDao konturEventsDao,
+                                     NormalizedObservationsDao normalizedObservationsDao, DataLakeDao dataLakeDao,
+                                     @org.springframework.beans.factory.annotation.Value("${scheduler.feedComposition.alias}") String[] feedAliases,
+                                     @org.springframework.beans.factory.annotation.Value("${scheduler.eventCombination.providers}") String[] eventCombinationProviders,
+                                     @org.springframework.beans.factory.annotation.Value("${scheduler.normalization.providers}") String[] normalizationProviders) {
         this.enrichmentSkippedQueueSize = enrichmentSkippedQueueSizeGauge;
         this.enrichmentQueueSize = enrichmentQueueSizeGauge;
         this.feedCompositionQueueSize = feedCompositionQueueSizeGauge;
         this.eventCombinationQueueSize = eventCombinationQueueSizeGauge;
         this.normalizationQueueSize = normalizationQueueSizeGauge;
+        this.enrichmentSkippedQueueSizeTotal = enrichmentSkippedQueueSizeTotalGauge;
+        this.enrichmentQueueSizeTotal = enrichmentQueueSizeTotalGauge;
+        this.feedCompositionQueueSizeTotal = feedCompositionQueueSizeTotalGauge;
+        this.eventCombinationQueueSizeTotal = eventCombinationQueueSizeTotalGauge;
+        this.normalizationQueueSizeTotal = normalizationQueueSizeTotalGauge;
         this.feedDao = feedDao;
         this.konturEventsDao = konturEventsDao;
         this.normalizedObservationsDao = normalizedObservationsDao;
         this.dataLakeDao = dataLakeDao;
+        this.feedAliases = feedAliases;
+        this.eventCombinationProviders = eventCombinationProviders;
+        this.normalizationProviders = normalizationProviders;
     }
 
     @Override
     public void collect() {
-        enrichmentSkippedQueueSize.set(feedDao.getEnrichmentSkippedEventsCount());
-        enrichmentQueueSize.set(feedDao.getNotEnrichedEventsCount());
-        feedCompositionQueueSize.set(konturEventsDao.getNotComposedEventsCount());
-        eventCombinationQueueSize.set(normalizedObservationsDao.getNotRecombinedObservationsCount());
-        normalizationQueueSize.set(dataLakeDao.getNotNormalizedObservationsCount());
+        enrichmentSkippedQueueSize.set(feedDao.getEnrichmentSkippedEventsCountForFeedsWithEnrichment());
+        enrichmentQueueSize.set(feedDao.getNotEnrichedEventsCountForFeedsWithEnrichment());
+        feedCompositionQueueSize.set(konturEventsDao.getNotComposedEventsCountForFeeds(java.util.Arrays.asList(feedAliases)));
+        eventCombinationQueueSize.set(normalizedObservationsDao.getNotRecombinedObservationsCountForProviders(java.util.Arrays.asList(eventCombinationProviders)));
+        normalizationQueueSize.set(dataLakeDao.getNotNormalizedObservationsCountForProviders(java.util.Arrays.asList(normalizationProviders)));
+
+        enrichmentSkippedQueueSizeTotal.set(feedDao.getEnrichmentSkippedEventsCount());
+        enrichmentQueueSizeTotal.set(feedDao.getNotEnrichedEventsCount());
+        feedCompositionQueueSizeTotal.set(konturEventsDao.getNotComposedEventsCount());
+        eventCombinationQueueSizeTotal.set(normalizedObservationsDao.getNotRecombinedObservationsCount());
+        normalizationQueueSizeTotal.set(dataLakeDao.getNotNormalizedObservationsCount());
     }
 }

--- a/src/main/java/io/kontur/eventapi/metrics/config/MetricsConfig.java
+++ b/src/main/java/io/kontur/eventapi/metrics/config/MetricsConfig.java
@@ -35,6 +35,12 @@ public class MetricsConfig {
     private final AtomicInteger eventCombinationQueueSize;
     private final AtomicInteger normalizationQueueSize;
 
+    private final AtomicInteger enrichmentQueueSizeTotal;
+    private final AtomicInteger enrichmentSkippedQueueSizeTotal;
+    private final AtomicInteger feedCompositionQueueSizeTotal;
+    private final AtomicInteger eventCombinationQueueSizeTotal;
+    private final AtomicInteger normalizationQueueSizeTotal;
+
     private final AtomicInteger sqsQueueSize;
     private final AtomicInteger sqsDLQueueSize;
 
@@ -63,6 +69,12 @@ public class MetricsConfig {
         this.eventCombinationQueueSize = registry.gauge("eventCombination.queueSize", new AtomicInteger(0));
         this.normalizationQueueSize = registry.gauge("normalization.queueSize", new AtomicInteger(0));
 
+        this.enrichmentQueueSizeTotal = registry.gauge("enrichment.totalQueueSize", new AtomicInteger(0));
+        this.enrichmentSkippedQueueSizeTotal = registry.gauge("enrichmentSkipped.totalQueueSize", new AtomicInteger(0));
+        this.feedCompositionQueueSizeTotal = registry.gauge("feedComposition.totalQueueSize", new AtomicInteger(0));
+        this.eventCombinationQueueSizeTotal = registry.gauge("eventCombination.totalQueueSize", new AtomicInteger(0));
+        this.normalizationQueueSizeTotal = registry.gauge("normalization.totalQueueSize", new AtomicInteger(0));
+
         this.sqsQueueSize = registry.gauge("sqs.queueSize", new AtomicInteger(0));
         this.sqsDLQueueSize = registry.gauge("sqs.dl.queueSize", new AtomicInteger(0));
     }
@@ -83,8 +95,18 @@ public class MetricsConfig {
     }
 
     @Bean
+    public AtomicInteger enrichmentQueueSizeTotalGauge() {
+        return enrichmentQueueSizeTotal;
+    }
+
+    @Bean
     public AtomicInteger enrichmentSkippedQueueSizeGauge() {
         return enrichmentSkippedQueueSize;
+    }
+
+    @Bean
+    public AtomicInteger enrichmentSkippedQueueSizeTotalGauge() {
+        return enrichmentSkippedQueueSizeTotal;
     }
 
     @Bean
@@ -93,13 +115,28 @@ public class MetricsConfig {
     }
 
     @Bean
+    public AtomicInteger feedCompositionQueueSizeTotalGauge() {
+        return feedCompositionQueueSizeTotal;
+    }
+
+    @Bean
     public AtomicInteger eventCombinationQueueSizeGauge() {
         return eventCombinationQueueSize;
     }
 
     @Bean
+    public AtomicInteger eventCombinationQueueSizeTotalGauge() {
+        return eventCombinationQueueSizeTotal;
+    }
+
+    @Bean
     public AtomicInteger normalizationQueueSizeGauge() {
         return normalizationQueueSize;
+    }
+
+    @Bean
+    public AtomicInteger normalizationQueueSizeTotalGauge() {
+        return normalizationQueueSizeTotal;
     }
 
     @Bean Map<String, TableMetricsConfig> tableMetrics() {

--- a/src/main/resources/db/mappers/DataLakeMapper.xml
+++ b/src/main/resources/db/mappers/DataLakeMapper.xml
@@ -130,6 +130,16 @@
         select count(*) from data_lake where not normalized and not skipped;
     </select>
 
+    <select id="getNotNormalizedObservationsCountForProviders" resultType="java.lang.Integer">
+        select count(*) from data_lake
+        where not normalized
+          and not skipped
+          and provider in
+        <foreach item="provider" collection="providers" open="(" separator="," close=")">
+            #{provider}
+        </foreach>
+    </select>
+
     <resultMap id="dataLakeMap" type="io.kontur.eventapi.entity.DataLake">
         <result property="observationId" column="observation_id" />
         <result property="externalId" column="external_id" />

--- a/src/main/resources/db/mappers/FeedMapper.xml
+++ b/src/main/resources/db/mappers/FeedMapper.xml
@@ -97,8 +97,22 @@
         select count(*) from feed_data where not enriched;
     </select>
 
+    <select id="getNotEnrichedEventsCountForFeedsWithEnrichment" resultType="java.lang.Integer">
+        select count(*) from feed_data fd
+        join feeds f on f.feed_id = fd.feed_id
+        where not fd.enriched
+          and array_length(f.enrichment, 1) > 0;
+    </select>
+
     <select id="getEnrichmentSkippedEventsCount" resultType="java.lang.Integer">
         select count(*) from feed_data where enrichment_skipped;
+    </select>
+
+    <select id="getEnrichmentSkippedEventsCountForFeedsWithEnrichment" resultType="java.lang.Integer">
+        select count(*) from feed_data fd
+        join feeds f on f.feed_id = fd.feed_id
+        where fd.enrichment_skipped
+          and array_length(f.enrichment, 1) > 0;
     </select>
 
     <update id="addAnalytics">

--- a/src/main/resources/db/mappers/KonturEventsMapper.xml
+++ b/src/main/resources/db/mappers/KonturEventsMapper.xml
@@ -71,6 +71,16 @@
         select count(*) from feed_event_status where not actual;
     </select>
 
+    <select id="getNotComposedEventsCountForFeeds" resultType="java.lang.Integer">
+        select count(*) from feed_event_status fes
+        join feeds f on f.feed_id = fes.feed_id
+        where not actual
+          and f.alias in
+        <foreach item="alias" collection="aliases" open="(" separator="," close=")">
+            #{alias}
+        </foreach>
+    </select>
+
     <resultMap id="konturEventDtoMap" type="io.kontur.eventapi.entity.KonturEvent">
         <result property="eventId" column="event_id"/>
         <result property="observationIds" column="observation_ids" typeHandler="io.kontur.eventapi.typehandler.UUIDArrayTypeHandler"/>

--- a/src/main/resources/db/mappers/NormalizedObservationsMapper.xml
+++ b/src/main/resources/db/mappers/NormalizedObservationsMapper.xml
@@ -111,6 +111,15 @@
         select count(*) from normalized_observations where not recombined;
     </select>
 
+    <select id="getNotRecombinedObservationsCountForProviders" resultType="java.lang.Integer">
+        select count(*) from normalized_observations
+        where not recombined
+          and provider in
+        <foreach item="provider" collection="providers" open="(" separator="," close=")">
+            #{provider}
+        </foreach>
+    </select>
+
     <select id="buildShakemapPolygons" resultType="string">
         select buildShakemapPolygons(#{json}::jsonb)::text
     </select>

--- a/src/test/java/io/kontur/eventapi/metrics/collector/QueueSizeMetricsCollectorTest.java
+++ b/src/test/java/io/kontur/eventapi/metrics/collector/QueueSizeMetricsCollectorTest.java
@@ -1,0 +1,70 @@
+package io.kontur.eventapi.metrics.collector;
+
+import io.kontur.eventapi.dao.DataLakeDao;
+import io.kontur.eventapi.dao.FeedDao;
+import io.kontur.eventapi.dao.KonturEventsDao;
+import io.kontur.eventapi.dao.NormalizedObservationsDao;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class QueueSizeMetricsCollectorTest {
+
+    @Test
+    void collect_setsGaugeValuesForTotalAndEnabled() {
+        AtomicInteger enrichmentSkipped = new AtomicInteger();
+        AtomicInteger enrichment = new AtomicInteger();
+        AtomicInteger feedComposition = new AtomicInteger();
+        AtomicInteger eventCombination = new AtomicInteger();
+        AtomicInteger normalization = new AtomicInteger();
+
+        AtomicInteger enrichmentSkippedTotal = new AtomicInteger();
+        AtomicInteger enrichmentTotal = new AtomicInteger();
+        AtomicInteger feedCompositionTotal = new AtomicInteger();
+        AtomicInteger eventCombinationTotal = new AtomicInteger();
+        AtomicInteger normalizationTotal = new AtomicInteger();
+
+        FeedDao feedDao = mock(FeedDao.class);
+        KonturEventsDao konturEventsDao = mock(KonturEventsDao.class);
+        NormalizedObservationsDao normalizedObservationsDao = mock(NormalizedObservationsDao.class);
+        DataLakeDao dataLakeDao = mock(DataLakeDao.class);
+
+        QueueSizeMetricsCollector collector = new QueueSizeMetricsCollector(
+            enrichmentSkipped, enrichment, feedComposition, eventCombination, normalization,
+            enrichmentSkippedTotal, enrichmentTotal, feedCompositionTotal, eventCombinationTotal, normalizationTotal,
+            feedDao, konturEventsDao, normalizedObservationsDao, dataLakeDao,
+            new String[]{"feed1"}, new String[]{"provider1"}, new String[]{"provider2"}
+        );
+
+        when(feedDao.getEnrichmentSkippedEventsCountForFeedsWithEnrichment()).thenReturn(1);
+        when(feedDao.getNotEnrichedEventsCountForFeedsWithEnrichment()).thenReturn(2);
+        when(konturEventsDao.getNotComposedEventsCountForFeeds(anyList())).thenReturn(3);
+        when(normalizedObservationsDao.getNotRecombinedObservationsCountForProviders(anyList())).thenReturn(4);
+        when(dataLakeDao.getNotNormalizedObservationsCountForProviders(anyList())).thenReturn(5);
+
+        when(feedDao.getEnrichmentSkippedEventsCount()).thenReturn(6);
+        when(feedDao.getNotEnrichedEventsCount()).thenReturn(7);
+        when(konturEventsDao.getNotComposedEventsCount()).thenReturn(8);
+        when(normalizedObservationsDao.getNotRecombinedObservationsCount()).thenReturn(9);
+        when(dataLakeDao.getNotNormalizedObservationsCount()).thenReturn(10);
+
+        collector.collect();
+
+        assertEquals(1, enrichmentSkipped.get(), "Enrichment skipped enabled queue size mismatch");
+        assertEquals(2, enrichment.get(), "Enrichment enabled queue size mismatch");
+        assertEquals(3, feedComposition.get(), "Feed composition enabled queue size mismatch");
+        assertEquals(4, eventCombination.get(), "Event combination enabled queue size mismatch");
+        assertEquals(5, normalization.get(), "Normalization enabled queue size mismatch");
+
+        assertEquals(6, enrichmentSkippedTotal.get(), "Enrichment skipped total queue size mismatch");
+        assertEquals(7, enrichmentTotal.get(), "Enrichment total queue size mismatch");
+        assertEquals(8, feedCompositionTotal.get(), "Feed composition total queue size mismatch");
+        assertEquals(9, eventCombinationTotal.get(), "Event combination total queue size mismatch");
+        assertEquals(10, normalizationTotal.get(), "Normalization total queue size mismatch");
+    }
+}


### PR DESCRIPTION
## Summary
- report both enabled and total queue sizes for pipeline steps
- expose new metrics through `MetricsConfig`
- document available queue size metrics

## Testing
- `make precommit`


------
https://chatgpt.com/codex/tasks/task_e_68b43fbfe4c08324884c75e0284933fb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added total queue size metrics for ingestion steps (enrichment, enrichment skipped, feed composition, event combination, normalization). Existing queue size metrics reflect enabled feeds/providers; new totals include disabled ones for full visibility.
- Documentation
  - Introduced a Metrics guide detailing available metric groups and their queueSize vs totalQueueSize meanings.
- Chores
  - Updated changelog with an unreleased entry noting total queue size reporting for ingestion steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->