### PR TITLE
fix(deps): align feign micrometer with spring cloud

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
                 <spring-cloud.version>2021.0.9</spring-cloud.version>
 		<spring-cloud-aws-messaging.version>2.2.6.RELEASE</spring-cloud-aws-messaging.version>
                 <springdoc-openapi-ui.version>1.8.0</springdoc-openapi-ui.version>
-                <feign-micrometer.version>13.6</feign-micrometer.version>
+                <feign-micrometer.version>11.10</feign-micrometer.version>
                 <mybatis-spring-boot-starter.version>2.3.2</mybatis-spring-boot-starter.version>
                 <liquibase-core.version>4.32.0</liquibase-core.version>
                 <jts2geojson.version>0.18.1</jts2geojson.version>


### PR DESCRIPTION
## Summary
- pin feign-micrometer to 11.10 to match Spring Cloud's Feign version and prevent NoClassDefFoundError

## Testing
- `make precommit`

------
https://chatgpt.com/codex/tasks/task_e_68bd6ae391c8832491e7d3bdf95c1506

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a third-party library version used for metrics/monitoring integration. No functional changes are expected for end-users, and existing behavior should remain consistent.
  * This change affects build-time dependencies only and does not introduce new features or UI updates.
  * If you notice any unexpected behavior after the update, please report it so we can investigate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->